### PR TITLE
fix run remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Then, try to run the **PancakeSwap Substreams** from our [Substreams Playground]
 ```
 cd ./pcs-rust/ && ./build.sh
 cd ../eth-token/ && ./build.sh
-cd ..
-substreams run -e bsc-dev.streamingfast.io:443 ./pcs-rust/substreams.yaml pairs,block_to_pairs,volumes,totals,db_out -s 6810706 -t 6810711
+cd ../pcs-rust
+substreams run -e bsc-dev.streamingfast.io:443 ./substreams.yaml pairs,block_to_pairs,volumes,totals,db_out -s 6810706 -t 6810711
 ```
 
 Run locally


### PR DESCRIPTION
otherwise

```
$ substreams run -e bsc-dev.streamingfast.io:443 ./pcs-rust/substreams.yaml pairs,block_to_pairs,volumes,totals,db_out -s 6810706 -t 6810711
2022-05-10T09:49:48.613+0800 (substreams) starting atomic level switcher {"listen_addr": "127.0.0.1:1065"}
Error: read manifest "./pcs-rust/substreams.yaml": reading file "./pkg/pcs_substreams_bg.wasm": open ./pkg/pcs_substreams_bg.wasm: no such file or directory
```