### PR TITLE
publish protos to bsr

### DIFF
--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - proto

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,13 @@
+version: v1
+name: buf.build/streamingfast/substreams
+
+# TODO: Install google protobufs as deps
+deps: []
+
+lint:
+  use:
+    - DEFAULT
+
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
Let's publish all protos on the buf.build BSR.

We might also want to use the buf.gen.yaml to use the remote builders to generate the prost and go code.

The external protos from google could be declared as deps. 

Just putting this here because I had to (well, for convenience) publish these to BSR for generate code for the typescript / node.js consumer example