### PR TITLE
Adding flag to specify output-dir for pack command

### DIFF
--- a/cmd/substreams/inspect.go
+++ b/cmd/substreams/inspect.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/substreams/manifest"
@@ -37,7 +38,7 @@ func runInspect(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("processing module graph %w", err)
 	}
 
-	filename := "/tmp/package.spkg"
+	filename := filepath.Join(os.TempDir(), "package.spkg")
 
 	cnt, err := proto.Marshal(pkg)
 	if err != nil {

--- a/cmd/substreams/pack.go
+++ b/cmd/substreams/pack.go
@@ -29,10 +29,6 @@ func init() {
 	`))
 }
 
-func is_relative_path(path string) bool {
-	return path[0:1] == "."
-}
-
 func runPack(cmd *cobra.Command, args []string) error {
 	outputDir := maybeGetString(cmd, "output-dir")
 	if outputDir == "." {
@@ -42,16 +38,16 @@ func runPack(cmd *cobra.Command, args []string) error {
 	manifestPath := args[0]
 
 	if outputDir != "" {
-		if is_relative_path(outputDir) {
+		if !filepath.IsAbs(outputDir) {
 			workingDirectory, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("can't retrieve current directory information")
 			}
 			newOutputDir := filepath.Join(filepath.Dir(filepath.Join(workingDirectory, manifestPath)), outputDir)
-			fmt.Printf("Output directory specified: %s \nThis will be treated as a local path.\nFull folderpath: %s\n", outputDir, newOutputDir)
+			fmt.Printf("Output directory specified: %s \nThis will be treated as a local path.\nFull folderpath: %s\n\n", outputDir, newOutputDir)
 			outputDir = newOutputDir
 		} else {
-			fmt.Printf("Output directory treated as an absolute path.\nFull folderpath: %s\n", outputDir)
+			fmt.Printf("Output directory treated as an absolute path.\nFull folderpath: %s\n\n", outputDir)
 		}
 
 		err := os.MkdirAll(outputDir, os.ModePerm)

--- a/cmd/substreams/pack.go
+++ b/cmd/substreams/pack.go
@@ -25,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(packCmd)
 	packCmd.Flags().StringP("output-dir", "o", ".", cli.FlagDescription(`
 		Optional flag to specify output directory to output generated .spkg file. 
-		If the received argument starts with a "." it will be treated as a local path relative to the supplied manifest path.
+		If a local path is supplied it will be relative to the supplied manifest path.
 	`))
 }
 

--- a/cmd/substreams/pack.go
+++ b/cmd/substreams/pack.go
@@ -24,7 +24,7 @@ var packCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(packCmd)
-	packCmd.Flags().StringP("output-dir", "o", "src/pb", cli.FlagDescription(`
+	packCmd.Flags().StringP("output-dir", "o", ".", cli.FlagDescription(`
 		Optional flag to specify output directory to output generated .spkg file. If the received <package> argument is a local Substreams manifest file
 		(e.g. a local file ending with .yaml), the output folder will be made relative to it
 	`))
@@ -71,7 +71,7 @@ func runPack(cmd *cobra.Command, args []string) error {
 		outputFile := filepath.Join(outputDir, defaultFilename)
 		if err := ioutil.WriteFile(outputFile, cnt, 0644); err != nil {
 			fmt.Println("")
-			return fmt.Errorf("writing %q: %w", defaultFilename, err)
+			return fmt.Errorf("writing %q: %w", outputFile, err)
 		}
 	} else {
 		if err := ioutil.WriteFile(defaultFilename, cnt, 0644); err != nil {

--- a/cmd/substreams/pack.go
+++ b/cmd/substreams/pack.go
@@ -31,9 +31,6 @@ func init() {
 
 func runPack(cmd *cobra.Command, args []string) error {
 	outputDir := maybeGetString(cmd, "output-dir")
-	if outputDir == "." {
-		outputDir = ""
-	}
 
 	manifestPath := args[0]
 

--- a/cmd/substreams/protogen.go
+++ b/cmd/substreams/protogen.go
@@ -60,7 +60,7 @@ func runProtogen(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("processing module graph %w", err)
 	}
 
-	defaultFilename := "/tmp/tmp.spkg"
+	defaultFilename := filepath.Join(os.TempDir(), "tmp.spkg")
 	cnt, err := proto.Marshal(pkg)
 	if err != nil {
 		return fmt.Errorf("marshalling package: %w", err)
@@ -91,8 +91,9 @@ plugins:
 		}
 	}
 
+	filepath := filepath.Join(os.TempDir(), "tmp.spkg#format=bin")
 	cmdArgs := []string{
-		"generate", "/tmp/tmp.spkg#format=bin",
+		"generate", filepath,
 	}
 	for _, excludePath := range excludePaths {
 		cmdArgs = append(cmdArgs, "--exclude-path", excludePath)

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Endpoint's port is now validated otherwise when unspecified, it creates an infinite 'Connecting...' message that will never resolves.
 
+## [0.0.21](https://github.com/streamingfast/substreams/releases/tag/v0.0.21)
+
+### CLI
+
+* Added an optional flag to specify output-dir for pack command. Also made changes to allow for client to be run on windows OS.
+
 ## [0.0.20](https://github.com/streamingfast/substreams/releases/tag/v0.0.20)
 
 ### CLI

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -109,7 +110,8 @@ func processRequest(t *testing.T, request *pbsubstreams.Request, moduleGraph *ma
 
 	req := pipeline.NewRequestContext(ctx, request, isSubRequest)
 
-	baseStoreStore, err := dstore.NewStore("file:///tmp/test.store", "", "none", true)
+	file := fmt.Sprintf("file://%s", filepath.Join(os.TempDir(), "test.store"))
+	baseStoreStore, err := dstore.NewStore(file, "", "none", true)
 	require.NoError(t, err)
 
 	cachingEngine, err := cachev1.NewEngine(ctx, 10, baseStoreStore, zap.NewNop())
@@ -202,7 +204,8 @@ type AssertMapOutput struct {
 func runTest(t *testing.T, startBlock int64, exclusiveEndBlock uint64, moduleNames []string, newBlockGenerator NewTestBlockGenerator) (moduleOutputs []string) {
 	//_, _ = logging.ApplicationLogger("test", "test")
 
-	err := os.RemoveAll("/tmp/test.store")
+	filepath := filepath.Join(os.TempDir(), "test.store")
+	err := os.RemoveAll(filepath)
 	require.NoError(t, err)
 
 	//todo: compile substreams

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -110,8 +109,7 @@ func processRequest(t *testing.T, request *pbsubstreams.Request, moduleGraph *ma
 
 	req := pipeline.NewRequestContext(ctx, request, isSubRequest)
 
-	file := fmt.Sprintf("file://%s", filepath.Join(os.TempDir(), "test.store"))
-	baseStoreStore, err := dstore.NewStore(file, "", "none", true)
+	baseStoreStore, err := dstore.NewStore(filepath.Join(t.TempDir(), "test.store"), "", "none", true)
 	require.NoError(t, err)
 
 	cachingEngine, err := cachev1.NewEngine(ctx, 10, baseStoreStore, zap.NewNop())
@@ -203,10 +201,6 @@ type AssertMapOutput struct {
 
 func runTest(t *testing.T, startBlock int64, exclusiveEndBlock uint64, moduleNames []string, newBlockGenerator NewTestBlockGenerator) (moduleOutputs []string) {
 	//_, _ = logging.ApplicationLogger("test", "test")
-
-	filepath := filepath.Join(os.TempDir(), "test.store")
-	err := os.RemoveAll(filepath)
-	require.NoError(t, err)
 
 	//todo: compile substreams
 


### PR DESCRIPTION
Added an optional flag to specify output-dir for pack command. Also changed all occurrences of /tmp/ folder paths to use os.TempDir() instead to allow cli tool to work on windows OS.