### PR TITLE
Updates per task: Various small tweaks for Documentation#64

### DIFF
--- a/docs/concept-and-fundamentals/modules/outputs.md
+++ b/docs/concept-and-fundamentals/modules/outputs.md
@@ -6,15 +6,15 @@ description: StreamingFast Substreams module outputs
 
 ### Data Outputs
 
-A `map` module can define one output. The output is the protobuf data type the module will produce.
+Substreams `map` modules currently only support a single output. The output must be a protobuf that has been populated with data acquired inside the `map` module. If the module intends to provide a basic output type of a single value, such as a String or bool, a protobuf is still required. The single value needs to be wrapped in a protobuf for use as the output value from a `map` module.
 
 {% hint style="info" %}
-_**Note:**  `store` modules **cannot** define an output._
+_**Note:** `store` modules **cannot** define an output._
 {% endhint %}
 
-An output object has an attribute `type` that defines the type of the output for the `map` module. The output definition is found in the manifest for the Substreams implementation.
+An output object has a `type` attribute defining the type of the output for the `map` module. The output definition is located in the Substreams manifest, within the module definition.
 
 ```yaml
 output:
-    type: proto:eth.erc721.v1.Transfers
+  type: proto:eth.erc721.v1.Transfers
 ```


### PR DESCRIPTION
Addressing the following change request:

Augment https://substreams.streamingfast.io/concept-and-fundamentals/modules/outputs to discuss the fact that only 1 output is possible today and it must be of a proto type (no literal like String or bool, if a single value is required, wrap in a Proto message)