### PR TITLE
Add links to Substreams examples for Various small tweaks for Documen…

### DIFF
--- a/docs/developer-guide/overview.md
+++ b/docs/developer-guide/overview.md
@@ -9,7 +9,7 @@ description: StreamingFast Substreams developer guide overview
 The Substreams Developer Guide explains the process of building a Substreams implementation that tracks the ERC721 holder count for an Ethereum smart contract.
 
 {% hint style="success" %}
-**Tip**_:_ The Substreams developer guide is currently focused on an Ethereum Substreams implementation. The majority of the development tasks and workflow are agnostic to each blockchain being targeted by the developer.
+**Tip**_:_ The Substreams developer guide is currently focused on an Ethereum Substreams implementation. The majority of the development tasks and workflow are agnostic to each blockchain being targeted by the Substreams developer.
 {% endhint %}
 
 {% hint style="info" %}
@@ -17,6 +17,10 @@ The Substreams Developer Guide explains the process of building a Substreams imp
 {% endhint %}
 
 If you haven't done so already, reviewing the Substreams [fundamentals](../concept-and-fundamentals/fundamentals.md) and [modules overview](../concepts/modules.md) is helpful for getting up and running quickly.
+
+#### Substreams Examples
+
+StreamingFast and the Substreams community have provided an array of different examples to explore and learn from. Find the full list on the [examples page](https://substreams.streamingfast.io/reference-and-specs/examples) of the Substreams documentation.
 
 #### Substreams Template for Dev Guide
 

--- a/docs/getting-started/your-first-stream.md
+++ b/docs/getting-started/your-first-stream.md
@@ -39,7 +39,6 @@ The endpoint is required by Substreams to connect to for data retrieval. The dat
 
 The Substreams package being run is also passed to the `substreams` command. [https://github.com/streamingfast/substreams-template/releases/download/v0.2.0/substreams-template-v0.2.0.spkg ](https://github.com/streamingfast/substreams-template/releases/download/v0.2.0/substreams-template-v0.2.0.spkg)\
 
-
 This example points to the StreamingFast Substreams Template in the form of a `.spkg` file. In full Substreams setups, a configuration file `substreams.yaml` is generally used.
 
 #### Module
@@ -55,4 +54,6 @@ Cease block processing with `--stop-block +1.` The +1 option will request a sing
 
 ### Next steps
 
-At this point, the Substreams CLI is installed and should be functioning correctly. Simple data was sent back to the terminal to provide an idea of what is now possible. The [Developer Guide](broken-reference) provides an in-depth look at Substreams and how to target specific blockchain data.
+At this point, the Substreams CLI is installed and should be functioning correctly. Simple data was sent back to the terminal to provide an idea of the possibilities. The [Developer Guide](https://substreams.streamingfast.io/developer-guide/overview) provides an in-depth look at Substreams and how to target specific blockchain data.
+
+StreamingFast and the Substreams community have provided an assortment of examples to explore and learn from. Find them on the [examples page](https://substreams.streamingfast.io/reference-and-specs/examples) in the Substreams documentation.


### PR DESCRIPTION
Adding more links to the Substreams examples per the change request:

Make list of https://substreams.streamingfast.io/reference-and-specs/examples more discoverable by linking it, maybe in https://substreams.streamingfast.io/getting-started/your-first-stream in Next Steps and maybe somehwere in https://substreams.streamingfast.io/developer-guide/overview section?