### PR TITLE
Updates for Various small tweaks for Documentation#64

### DIFF
--- a/docs/developer-guide/creating-your-manifest.md
+++ b/docs/developer-guide/creating-your-manifest.md
@@ -97,7 +97,7 @@ The manifest defines a list of [modules](../concepts/modules.md) used in the Sub
 The modules are Rust functions containing the business logic for the implementation.
 
 {% hint style="info" %}
-**Note**: The manifest in the Substreams Template example lists two modules: `map_transfers` and `store_transfers.` The naming convention prescribed by StreamingFast for Substreams modules is to prefix the name with either `map_` or `store_` depending on the module type.
+**Note**: The manifest in the Substreams Template example lists two modules: `map_transfers` and `store_transfers.` The naming convention for Substreams modules is to prefix the name with either `map_` or `store_` depending on the module type.
 {% endhint %}
 
 ### **`map_transfers`**

--- a/docs/developer-guide/creating-your-manifest.md
+++ b/docs/developer-guide/creating-your-manifest.md
@@ -23,10 +23,11 @@ The manifest below is from the [Substreams Template example](https://github.com/
 {% endhint %}
 
 {% code title="substreams.yaml" overflow="wrap" lineNumbers="true" %}
+
 ```yaml
 specVersion: v0.1.0
 package:
-  name: "substreams_example"
+  name: 'substreams_example'
   version: v0.1.0
 
 imports:
@@ -44,7 +45,7 @@ binaries:
     file: ./target/wasm32-unknown-unknown/release/substreams_example.wasm
 
 modules:
-  - name: block_to_transfers
+  - name: map_transfers
     kind: map
     initialBlock: 12287507
     inputs:
@@ -52,15 +53,15 @@ modules:
     output:
       type: proto:eth.erc721.v1.Transfers
 
-  - name: nft_state
+  - name: store_transfers
     kind: store
     initialBlock: 12287507
     updatePolicy: add
     valueType: int64
     inputs:
-      - map: block_to_transfers
-
+      - map: map_transfers
 ```
+
 {% endcode %}
 
 View this file in the repo by visiting the following link.
@@ -96,29 +97,29 @@ The manifest defines a list of [modules](../concepts/modules.md) used in the Sub
 The modules are Rust functions containing the business logic for the implementation.
 
 {% hint style="info" %}
-**Note**: The manifest in the Substreams Template example lists two modules: `block_to_transfers` and `nft_state.`
+**Note**: The manifest in the Substreams Template example lists two modules: `map_transfers` and `store_transfers.` The naming convention prescribed by StreamingFast for Substreams modules is to prefix the name with either `map_` or `store_` depending on the module type.
 {% endhint %}
 
-### **`block_to_transfers`**
+### **`map_transfers`**
 
-The `block_to_transfers` module extracts all ERC721 transfers related to a specific smart contract address. The module receives Ethereum blocks as [`sf.ethereum.type.v2.Block`](https://github.com/streamingfast/firehose-ethereum/blob/develop/proto/sf/ethereum/type/v2/type.proto).
+The `map_transfers` module extracts all ERC721 transfers related to a specific smart contract address. The module receives Ethereum blocks as [`sf.ethereum.type.v2.Block`](https://github.com/streamingfast/firehose-ethereum/blob/develop/proto/sf/ethereum/type/v2/type.proto).
 
-The output for the `blocks_to_transfers` module is a list of ERC721 transfers. The business logic for `block_to_transfers` module is written as a Rust function.
+The output for the `map_transfers` module is a list of ERC721 transfers. The business logic for `map_transfers` module is written as a Rust function.
 
 {% hint style="info" %}
 **Note**: The `initialBlock` is set to `12287507` in the Substreams Template example because the first transfers of tokens originated from the contracts at that block.
 {% endhint %}
 
-### **`nft_state`**
+### **`store_transfers`**
 
-The `nft_state` store module receives transfers in each block extracted by the mapper. The store is a `count` of ERC721 tokens for a holder.&#x20;
+The `store_transfers` store module receives transfers in each block extracted by the mapper. The store is a `count` of ERC721 tokens for a holder.&#x20;
 
 The inputs of the module are protobuf models defined as: `proto:eth.erc721.v1.Transfers`.&#x20;
 
-The `eth.erc721.v1.Transfers` protobuf module represents a list of ERC721 transfers in a  block.&#x20;
+The `eth.erc721.v1.Transfers` protobuf module represents a list of ERC721 transfers in a block.&#x20;
 
 {% hint style="info" %}
 **Note**: The `eth.erc721.v1.Transfers` protobuf module is also used as the output for the `map` module.
 {% endhint %}
 
-The stores `valueType` is `int64` and the merge strategy is `add.`
+The store's `valueType` is `int64` and the merge strategy is `add.`

--- a/docs/developer-guide/running-substreams.md
+++ b/docs/developer-guide/running-substreams.md
@@ -9,7 +9,7 @@ After a successful build Substreams can be started with the following command, e
 ```
 substreams run -e mainnet.eth.streamingfast.io:443 \
    substreams.yaml \
-   block_to_transfers \
+   map_transfers \
    --start-block 12292922 \
    --stop-block +1
 ```
@@ -17,7 +17,7 @@ substreams run -e mainnet.eth.streamingfast.io:443 \
 Another option is to run Substreams against a locally deployed Firehose. _Note, Firehose needs to be installed and set up on the target system._
 
 ```bash
-substreams run -p -e localhost:9000 substreams.yaml block_to_transfers --start-block 12370550 --stop-block +1
+substreams run -p -e localhost:9000 substreams.yaml map_transfers --start-block 12370550 --stop-block +1
 ```
 
 ### Explanation
@@ -37,7 +37,7 @@ Inform Substreams where to find the `substreams.yaml` configuration file.
 
 #### Module
 
-The `block_to_transfers` module is defined in the manifest and it is the module that will be run by Substreams.
+The `map_transfers` module is defined in the manifest and it is the module that will be run by Substreams.
 
 #### Block Mapping
 
@@ -53,16 +53,16 @@ The following messages will be printed to the terminal for a successfully instal
 ```bash
  substreams run -e mainnet.eth.streamingfast.io:443 \
    substreams.yaml \
-   block_to_transfers \
+   map_transfers \
    --start-block 12292922 \
    --stop-block +1
 2022-05-30T10:52:27.256-0400 INFO (substreams) connecting...
 2022-05-30T10:52:27.389-0400 INFO (substreams) connected
 
 ----------- IRREVERSIBLE BLOCK #12,292,922 (12292922) ---------------
-block_to_transfers: log: NFT Contract bc4ca0eda7647a8ab7c2061c2e118a18a936f13d invoked
+map_transfers: log: NFT Contract bc4ca0eda7647a8ab7c2061c2e118a18a936f13d invoked
 [...]
-block_to_transfers: message "eth.erc721.v1.Transfers": {
+map_transfers: message "eth.erc721.v1.Transfers": {
   "transfers": [
     {
       "from": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",


### PR DESCRIPTION
Addressing updates for the task:

Throughout https://substreams.streamingfast.io/developer-guide/, there is some old module name reference mainly block_to_transfers and nft_state, they need to be changed because they are not aligned with substreams-template. All occurrences should be renamed Update also https://substreams.streamingfast.io/developer-guide/creating-your-manifest#module-definitions so that modules have either map_ and store_ prefixes, we have settled more or less for this convention. We also need to have this loose "convention" documented at various places in the documentation maybe, maybe as a "note" element. Not sure exactly where, probably where first introduction to creating a new module is made and maybe in "reference" page.