### PR TITLE
Remove running locally Various small tweaks for Documentation#64

### DIFF
--- a/docs/developer-guide/running-substreams.md
+++ b/docs/developer-guide/running-substreams.md
@@ -14,12 +14,6 @@ substreams run -e mainnet.eth.streamingfast.io:443 \
    --stop-block +1
 ```
 
-Another option is to run Substreams against a locally deployed Firehose. _Note, Firehose needs to be installed and set up on the target system._
-
-```bash
-substreams run -p -e localhost:9000 substreams.yaml block_to_transfers --start-block 12370550 --stop-block +1
-```
-
 ### Explanation
 
 #### Substreams Run


### PR DESCRIPTION
Updates for change request from Matt.

In https://substreams.streamingfast.io/developer-guide/running-substreams, let's remove the content about running locally, not important in this section.