### PR TITLE
dev mode output all modules (filter in cli)

### DIFF
--- a/cmd/substreams/flags.go
+++ b/cmd/substreams/flags.go
@@ -67,6 +67,13 @@ func mustGetStringArray(cmd *cobra.Command, flagName string) []string {
 	}
 	return val
 }
+func mustGetStringSlice(cmd *cobra.Command, flagName string) []string {
+	val, err := cmd.Flags().GetStringSlice(flagName)
+	if err != nil {
+		panic(fmt.Sprintf("flags: couldn't find flag %q", flagName))
+	}
+	return val
+}
 func mustGetInt64(cmd *cobra.Command, flagName string) int64 {
 	val, err := cmd.Flags().GetInt64(flagName)
 	if err != nil {

--- a/cmd/substreams/run.go
+++ b/cmd/substreams/run.go
@@ -58,9 +58,6 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	debugModulesInitialSnapshot := mustGetStringSlice(cmd, "debug-modules-initial-snapshot")
-	if debugModulesInitialSnapshot != nil && productionMode {
-		return fmt.Errorf("cannot set 'debug-modules-initial-snapshot' in 'production-mode'")
-	}
 
 	graph, err := manifest.NewModuleGraph(pkg.Modules.Modules)
 	if err != nil {

--- a/cmd/substreams/run.go
+++ b/cmd/substreams/run.go
@@ -24,15 +24,16 @@ func init() {
 	runCmd.Flags().BoolP("insecure", "k", false, "Skip certificate validation on GRPC connection")
 	runCmd.Flags().BoolP("plaintext", "p", false, "Establish GRPC connection in plaintext")
 	runCmd.Flags().StringP("output", "o", "", "Output mode. Defaults to 'ui' when in a TTY is present, and 'json' otherwise")
-	runCmd.Flags().BoolP("debug-initial-snapshots", "i", false, "Load an initial snapshot at start block, before continuing processing. Available only in development mode (production mode = false)")
-	runCmd.Flags().Bool("production-mode", false, "Enable production mode, with high-speed forward processing: limits stream to a single mapper module.")
+	runCmd.Flags().StringSlice("debug-modules-initial-snapshot", nil, "List of 'store' modules from which to print the initial data snapshot (Unavailable in Production Mode")
+	runCmd.Flags().StringSlice("debug-modules-output", nil, "List of extra modules from which to print outputs, deltas and logs (Unavailable in Production Mode)")
+	runCmd.Flags().Bool("production-mode", false, "Enable Production Mode, with high-speed parallel processing")
 	rootCmd.AddCommand(runCmd)
 }
 
 // runCmd represents the command to run substreams remotely
 var runCmd = &cobra.Command{
 	Use:          "run <manifest> <module_name>",
-	Short:        "Stream modules from a given package on a remote endpoint",
+	Short:        "Stream module outputs from a given package on a remote endpoint",
 	RunE:         runRun,
 	Args:         cobra.ExactArgs(2),
 	SilenceUsage: true,
@@ -50,12 +51,23 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("read manifest %q: %w", manifestPath, err)
 	}
 
-	outputModule := args[1]
+	productionMode := mustGetBool(cmd, "production-mode")
+	debugModulesOutput := mustGetStringSlice(cmd, "debug-modules-output")
+	if debugModulesOutput != nil && productionMode {
+		return fmt.Errorf("cannot set 'debug-modules-output' in 'production-mode'")
+	}
+
+	debugModulesInitialSnapshot := mustGetStringSlice(cmd, "debug-modules-initial-snapshot")
+	if debugModulesInitialSnapshot != nil && productionMode {
+		return fmt.Errorf("cannot set 'debug-modules-initial-snapshot' in 'production-mode'")
+	}
 
 	graph, err := manifest.NewModuleGraph(pkg.Modules.Modules)
 	if err != nil {
 		return fmt.Errorf("creating module graph: %w", err)
 	}
+
+	outputModule := args[1]
 
 	startBlock := mustGetInt64(cmd, "start-block")
 	if startBlock == -1 {
@@ -85,21 +97,26 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	req := &pbsubstreams.Request{
-		StartBlockNum:  startBlock,
-		StartCursor:    mustGetString(cmd, "cursor"),
-		StopBlockNum:   stopBlock,
-		ForkSteps:      []pbsubstreams.ForkStep{pbsubstreams.ForkStep_STEP_IRREVERSIBLE},
-		Modules:        pkg.Modules,
-		OutputModule:   outputModule,
-		OutputModules:  []string{outputModule}, //added for backwards compatibility, will be removed
-		ProductionMode: mustGetBool(cmd, "production-mode"),
+		StartBlockNum:                       startBlock,
+		StartCursor:                         mustGetString(cmd, "cursor"),
+		StopBlockNum:                        stopBlock,
+		ForkSteps:                           []pbsubstreams.ForkStep{pbsubstreams.ForkStep_STEP_IRREVERSIBLE},
+		Modules:                             pkg.Modules,
+		OutputModule:                        outputModule,
+		OutputModules:                       []string{outputModule}, //added for backwards compatibility, will be removed
+		ProductionMode:                      productionMode,
+		DebugInitialStoreSnapshotForModules: debugModulesInitialSnapshot,
 	}
 
 	if err := pbsubstreams.ValidateRequest(req, false); err != nil {
 		return fmt.Errorf("validate request: %w", err)
 	}
+	toPrint := debugModulesOutput
+	if len(toPrint) == 0 {
+		toPrint = []string{outputModule}
+	}
 
-	ui := tui.New(req, pkg, []string{outputModule})
+	ui := tui.New(req, pkg, toPrint)
 	if err := ui.Init(outputMode); err != nil {
 		return fmt.Errorf("TUI initialization: %w", err)
 	}

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -37,11 +37,11 @@ The difference between the modes are:
 
 #### Examples:
 
-(given a substreams with these dependencies: [block] --> [map_pools] --> [store_pools] --> [map_transactions])
+(given a substreams with these dependencies: [block] --> [map_pools] --> [store_pools] --> [map_transfers])
 
-* Running `substreams run substreams.yaml map_transactions -s 1000 -t +5` would only print the outputs and logs from the `map_transactions` module between blocks 1000 and 1005.
-* Running `substreams run substreams.yaml map_transactions -s 1000 -t +5 --debug-modules-output=map_pools,map_transactions,store_pools` would print the outputs of those 3 modules.
-* Running `substreams run substreams.yaml map_transactions -s 1000 -t +5 --debug-modules-initial-snapshot=store_pools`
+* Running `substreams run substreams.yaml map_transfers` will only print the outputs and logs from the `map_transfers` module. 
+* Running `substreams run substreams.yaml map_transfers --debug-modules-output=map_pools,map_transfers,store_pools` will print the outputs of those 3 modules.
+* Running `substreams run substreams.yaml map_transfers -s 1000 -t +5 --debug-modules-initial-snapshot=store_pools` will print all the entries in store_pools at block 999, then continue with outputs and logs from `map_transfers` in blocks 1000 to 1004.
 
 ### Parallel Processing
 

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -35,6 +35,14 @@ The difference between the modes are:
 - In `development` the client will receive all the logs of the executed `modules`. While in `production` mode the client will only receive the logs of the output module
 - In `development` mode you may request specific `store` snapshot that are in the execution tree 
 
+#### Examples:
+
+(given a substreams with these dependencies: [block] --> [map_pools] --> [store_pools] --> [map_transactions])
+
+* Running `substreams run substreams.yaml map_transactions -s 1000 -t +5` would only print the outputs and logs from the `map_transactions` module between blocks 1000 and 1005.
+* Running `substreams run substreams.yaml map_transactions -s 1000 -t +5 --debug-modules-output=map_pools,map_transactions,store_pools` would print the outputs of those 3 modules.
+* Running `substreams run substreams.yaml map_transactions -s 1000 -t +5 --debug-modules-initial-snapshot=store_pools`
+
 ### Parallel Processing
 
 There are 2 steps while parallel processing: back processing and forward processing. 

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -27,7 +27,7 @@ The mode impacts how the `substreams` get executed, specifically:
 
  - the time to first byte 
  - the speed at which large ranges get executed
- - the module logs sent back to the client
+ - the module logs and outputs sent back to the client
 
 The difference between the modes are:
 
@@ -60,10 +60,9 @@ Back processing will  occur in `development` and `production` mode, while the fo
 ### CLI
 
 - Added command `substreams tools analytics store-stats` to get statistic for a given store.
-
-
-
-* `--initial-snapshots` flag has been renamed to `--debug-initial-snapshots` and can only be activated in development mode (ie: when `production-mode` flag is false).
+* added `--debug-modules-output` (comma-separated module names) (unavailable in production-mode)
+* added `--debug-modules-initial-snapshots` (comma-separated module names) (unavailable in production-mode)
+* removed flag `--initial-snapshots` (bool) 
 
 ## [0.0.21](https://github.com/streamingfast/substreams/releases/tag/v0.0.21)
 

--- a/pb/sf/substreams/v1/substreams.go
+++ b/pb/sf/substreams/v1/substreams.go
@@ -52,6 +52,10 @@ func ValidateRequest(req *Request, isSubRequest bool) error {
 		return fmt.Errorf("output module: %w", err)
 	}
 
+	if req.DebugInitialStoreSnapshotForModules != nil && req.ProductionMode {
+		return fmt.Errorf("cannot set 'debug-modules-initial-snapshot' in 'production-mode'")
+	}
+
 	outputModule := req.GetOutputModuleName()
 	outputModuleFound := false
 	for _, mod := range req.Modules.Modules {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -246,7 +246,7 @@ func (p *Pipeline) execute(ctx context.Context, executor exec.ModuleExecutor, ex
 	if !hasValidOutput {
 		return nil
 	}
-	if p.isOutputModule(executor.Name()) {
+	if p.isOutputModule(executor.Name()) || !reqctx.Details(ctx).Request.GetProductionMode() {
 		p.appendModuleOutputs(moduleOutput)
 	}
 	if err := execOutput.Set(executorName, outputBytes); err != nil {

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -49,7 +49,7 @@ func TestPipeline_runExecutor(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := reqctx.WithRequest(context.Background(), &reqctx.RequestDetails{})
 			pipe := &Pipeline{
 				forkHandler: NewForkHandler(),
 				outputGraph: outputmodules.TestNew(),


### PR DESCRIPTION
fixes #82 
* server sends all module outputs and logs when in dev mode
* cli filters based on the output module or debug-modules-output
* add flag --debug-modules-output
* change (broken) flag --debug-modules-initial-snapshot to a list of modules