### PR TITLE
remove distinction between execOutput and storeSnapshots SaveInterval

### DIFF
--- a/orchestrator/multisquasher.go
+++ b/orchestrator/multisquasher.go
@@ -56,7 +56,7 @@ func NewMultiSquasher(
 				return nil, fmt.Errorf("store %q not found", storeModuleName)
 			}
 
-			storeSquasher, err := buildStoreSquasher(ctx, runtimeConfig.StoreSnapshotsSaveInterval, storeConfig, logger, storageState, upToBlock, onStoreCompletedUntilBlock)
+			storeSquasher, err := buildStoreSquasher(ctx, runtimeConfig.CacheSaveInterval, storeConfig, logger, storageState, upToBlock, onStoreCompletedUntilBlock)
 			if err != nil {
 				return nil, err
 			}

--- a/orchestrator/parallelprocessor.go
+++ b/orchestrator/parallelprocessor.go
@@ -43,7 +43,7 @@ func BuildParallelProcessor(
 		if requestedModule.GetKindStore() != nil {
 			panic("logic error: should not get a store as outputModule on tier 1")
 		}
-		firstRange := block.NewBoundedRange(requestedModule.InitialBlock, runtimeConfig.ExecOutputSaveInterval, reqDetails.RequestStartBlockNum, reqDetails.LinearHandoffBlockNum)
+		firstRange := block.NewBoundedRange(requestedModule.InitialBlock, runtimeConfig.CacheSaveInterval, reqDetails.RequestStartBlockNum, reqDetails.LinearHandoffBlockNum)
 		requestedModuleCache := execoutStorage.NewFile(requestedModule.Name, firstRange)
 		execOutputReader = execout.NewLinearReader(
 			reqDetails.RequestStartBlockNum,
@@ -51,7 +51,7 @@ func BuildParallelProcessor(
 			requestedModule,
 			requestedModuleCache,
 			respFunc,
-			runtimeConfig.ExecOutputSaveInterval,
+			runtimeConfig.CacheSaveInterval,
 		)
 	}
 
@@ -71,15 +71,14 @@ func BuildParallelProcessor(
 	storeLinearHandoffBlockNum := reqDetails.LinearHandoffBlockNum
 	if stopAtHandoff {
 		// we don't need to bring the stores up to handoff block if we stop there
-		storeLinearHandoffBlockNum = lowBoundary(reqDetails.LinearHandoffBlockNum, runtimeConfig.StoreSnapshotsSaveInterval)
+		storeLinearHandoffBlockNum = lowBoundary(reqDetails.LinearHandoffBlockNum, runtimeConfig.CacheSaveInterval)
 	}
 
 	modulesStateMap, err := storage.BuildModuleStorageStateMap( // ok, I will cut stores up to 800 not 842
 		ctx,
 		storeConfigs,
-		runtimeConfig.StoreSnapshotsSaveInterval,
+		runtimeConfig.CacheSaveInterval,
 		execoutStorage,
-		runtimeConfig.ExecOutputSaveInterval,
 		reqDetails.RequestStartBlockNum,
 		reqDetails.LinearHandoffBlockNum,
 		storeLinearHandoffBlockNum,

--- a/service/config/runtimeconfig.go
+++ b/service/config/runtimeconfig.go
@@ -6,10 +6,10 @@ import (
 )
 
 type RuntimeConfig struct {
-	StoreSnapshotsSaveInterval uint64
-	ExecOutputSaveInterval     uint64
-	SubrequestsSplitSize       uint64 // in multiple of the SaveIntervals above
-	ParallelSubrequests        uint64 // how many sub-jobs to launch for a given user
+	CacheSaveInterval uint64
+
+	SubrequestsSplitSize uint64 // in multiple of the SaveIntervals above
+	ParallelSubrequests  uint64 // how many sub-jobs to launch for a given user
 	// derives substores `states/`, for `store` modules snapshots (full and partial)
 	// and `outputs/` for execution output of both `map` and `store` module kinds
 	BaseObjectStore  dstore.Store
@@ -18,19 +18,17 @@ type RuntimeConfig struct {
 }
 
 func NewRuntimeConfig(
-	storeSnapshotsSaveInterval uint64,
-	execOutputSaveInterval uint64,
+	cacheSaveInterval uint64,
 	subrequestsSplitSize uint64,
 	parallelSubrequests uint64,
 	baseObjectStore dstore.Store,
 	workerFactory work.WorkerFactory,
 ) RuntimeConfig {
 	return RuntimeConfig{
-		StoreSnapshotsSaveInterval: storeSnapshotsSaveInterval,
-		ExecOutputSaveInterval:     execOutputSaveInterval,
-		SubrequestsSplitSize:       subrequestsSplitSize,
-		ParallelSubrequests:        parallelSubrequests,
-		BaseObjectStore:            baseObjectStore,
-		WorkerFactory:              workerFactory,
+		CacheSaveInterval:    cacheSaveInterval,
+		SubrequestsSplitSize: subrequestsSplitSize,
+		ParallelSubrequests:  parallelSubrequests,
+		BaseObjectStore:      baseObjectStore,
+		WorkerFactory:        workerFactory,
 	}
 }

--- a/service/options.go
+++ b/service/options.go
@@ -25,15 +25,9 @@ func WithPartialMode() Option {
 	}
 }
 
-func WithStoresSaveInterval(block uint64) Option {
+func WithCacheSaveInterval(block uint64) Option {
 	return func(s *Service) {
-		s.runtimeConfig.StoreSnapshotsSaveInterval = block
-	}
-}
-
-func WithOutCacheSaveInterval(block uint64) Option {
-	return func(s *Service) {
-		s.runtimeConfig.ExecOutputSaveInterval = block
+		s.runtimeConfig.CacheSaveInterval = block
 	}
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -69,7 +69,6 @@ func New(
 
 	runtimeConfig := config.NewRuntimeConfig(
 		1000, // overridden by Options
-		1000, // overridden by Options
 		subrequestSplitSize,
 		parallelSubRequests,
 		stateStore,
@@ -161,8 +160,7 @@ func (s *Service) Blocks(request *pbsubstreams.Request, streamSrv pbsubstreams.S
 	s.runtimeConfig.BaseObjectStore.SetMeter(tracking.GetBytesMeter(ctx))
 
 	runtimeConfig := config.NewRuntimeConfig(
-		s.runtimeConfig.StoreSnapshotsSaveInterval,
-		s.runtimeConfig.ExecOutputSaveInterval,
+		s.runtimeConfig.CacheSaveInterval,
 		s.runtimeConfig.SubrequestsSplitSize,
 		s.runtimeConfig.ParallelSubrequests,
 		s.runtimeConfig.BaseObjectStore,
@@ -235,7 +233,7 @@ func (s *Service) blocks(ctx context.Context, runtimeConfig config.RuntimeConfig
 
 	wasmRuntime := wasm.NewRuntime(s.wasmExtensions)
 
-	execOutputConfigs, err := execout.NewConfigs(runtimeConfig.BaseObjectStore, outputGraph.AllModules(), outputGraph.ModuleHashes(), runtimeConfig.ExecOutputSaveInterval, logger)
+	execOutputConfigs, err := execout.NewConfigs(runtimeConfig.BaseObjectStore, outputGraph.AllModules(), outputGraph.ModuleHashes(), runtimeConfig.CacheSaveInterval, logger)
 	if err != nil {
 		return fmt.Errorf("new config map: %w", err)
 	}
@@ -244,7 +242,7 @@ func (s *Service) blocks(ctx context.Context, runtimeConfig config.RuntimeConfig
 	if err != nil {
 		return fmt.Errorf("configuring stores: %w", err)
 	}
-	stores := pipeline.NewStores(storeConfigs, runtimeConfig.StoreSnapshotsSaveInterval, requestDetails.RequestStartBlockNum, request.StopBlockNum, isSubRequest)
+	stores := pipeline.NewStores(storeConfigs, runtimeConfig.CacheSaveInterval, requestDetails.RequestStartBlockNum, request.StopBlockNum, isSubRequest)
 
 	// TODO(abourget): why would this start at the LinearHandoffBlockNum ?
 	//  * in direct mode, this would mean we start writing files after the handoff,

--- a/storage/build.go
+++ b/storage/build.go
@@ -13,12 +13,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func BuildModuleStorageStateMap(ctx context.Context, storeConfigMap store.ConfigMap, storeSnapshotsSaveInterval uint64, mapConfigs *execout.Configs, execOutputSaveInterval, requestStartBlock, linearHandoffBlock, storeLinearHandoffBlock uint64) (ModuleStorageStateMap, error) {
+func BuildModuleStorageStateMap(ctx context.Context, storeConfigMap store.ConfigMap, cacheSaveInterval uint64, mapConfigs *execout.Configs, requestStartBlock, linearHandoffBlock, storeLinearHandoffBlock uint64) (ModuleStorageStateMap, error) {
 	out := make(ModuleStorageStateMap)
-	if err := buildStoresStorageState(ctx, storeConfigMap, storeSnapshotsSaveInterval, storeLinearHandoffBlock, out); err != nil {
+	if err := buildStoresStorageState(ctx, storeConfigMap, cacheSaveInterval, storeLinearHandoffBlock, out); err != nil {
 		return nil, err
 	}
-	if err := buildMappersStorageState(ctx, mapConfigs, execOutputSaveInterval, requestStartBlock, linearHandoffBlock, out); err != nil {
+	if err := buildMappersStorageState(ctx, mapConfigs, cacheSaveInterval, requestStartBlock, linearHandoffBlock, out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/test/runnable_test.go
+++ b/test/runnable_test.go
@@ -212,7 +212,6 @@ func processRequest(
 	}
 	runtimeConfig := config.NewRuntimeConfig(
 		10,
-		10,
 		subrequestsSplitSize,
 		parallelSubrequests,
 		baseStoreStore,


### PR DESCRIPTION


they must be aligned into the new CacheSaveInterval. This is to prevent a tier2 trying to start at block 300 if the stores only exist at 200 or 400. Too much complexity added in generating the outputs on tier2 in production mode.