### PR TITLE
Update endpoint

### DIFF
--- a/cmd/substreams/proxy.go
+++ b/cmd/substreams/proxy.go
@@ -93,7 +93,7 @@ func (cs *ConnectServer) Blocks(
 }
 
 func init() {
-	proxyCmd.Flags().StringP("substreams-endpoint", "e", "api.streamingfast.io:443", "Substreams gRPC endpoint")
+	proxyCmd.Flags().StringP("substreams-endpoint", "e", "mainnet.eth.streamingfast.io:443.io:443", "Substreams gRPC endpoint")
 	proxyCmd.Flags().String("substreams-api-token-envvar", "SUBSTREAMS_API_TOKEN", "name of variable containing Substreams Authentication token")
 	proxyCmd.Flags().String("listen-addr", "localhost:8080", "listen on this address (unencrypted)")
 	proxyCmd.Flags().BoolP("insecure", "k", false, "Skip certificate validation on GRPC connection")

--- a/cmd/substreams/run.go
+++ b/cmd/substreams/run.go
@@ -18,7 +18,7 @@ import (
 )
 
 func init() {
-	runCmd.Flags().StringP("substreams-endpoint", "e", "api.streamingfast.io:443", "Substreams gRPC endpoint")
+	runCmd.Flags().StringP("substreams-endpoint", "e", "mainnet.eth.streamingfast.io:443", "Substreams gRPC endpoint")
 	runCmd.Flags().String("substreams-api-token-envvar", "SUBSTREAMS_API_TOKEN", "name of variable containing Substreams Authentication token")
 	runCmd.Flags().Int64P("start-block", "s", -1, "Start block to stream from. Defaults to -1, which means the initialBlock of the first module you are streaming")
 	runCmd.Flags().StringP("cursor", "c", "", "Cursor to stream from. Leave blank for no cursor")


### PR DESCRIPTION
- [ ] update endpoint to `mainnet.eth.streamingfast.io:443`

`mainnet.eth` is used in all the documentation references