### PR TITLE
Feature/fuel limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,11 +24,10 @@ require (
 
 replace github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869 => github.com/streamingfast/graph v0.0.0-20220329181048-a5710712d873
 
-replace github.com/bytecodealliance/wasmtime-go/v4 => github.com/streamingfast/wasmtime-go/v4 v4.0.0-freemem
+replace github.com/bytecodealliance/wasmtime-go/v4 => github.com/streamingfast/wasmtime-go/v4 v4.0.0-freemem3
 
 require (
-	github.com/76creates/stickers v0.0.0-20230121000757-d6bf5dc8ab6b
-	github.com/aymanbagabas/go-osc52 v1.2.1
+	github.com/alecthomas/chroma v0.10.0
 	github.com/bufbuild/connect-go v1.1.0
 	github.com/bufbuild/connect-grpcreflect-go v1.0.0
 	github.com/bytecodealliance/wasmtime-go/v4 v4.0.0
@@ -36,16 +35,16 @@ require (
 	github.com/charmbracelet/bubbletea v0.23.1
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/charmbracelet/lipgloss v0.6.0
-	github.com/charmbracelet/soft-serve v0.4.5
 	github.com/dustin/go-humanize v1.0.0
 	github.com/google/uuid v1.3.0
-	github.com/lrstanley/bubblezone v0.0.0-20221222153816-e95291e2243e
 	github.com/mattn/go-isatty v0.0.16
 	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/muesli/reflow v0.3.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/rs/cors v1.8.3
+	github.com/schollz/closestmatch v2.1.0+incompatible
 	github.com/streamingfast/dauth v0.0.0-20221027185237-b209f25fa3ff
+	github.com/streamingfast/dbin v0.0.0-20210809205249-73d5eca35dc5
 	github.com/streamingfast/dmetrics v0.0.0-20221107142404-e88fe183f07d
 	github.com/streamingfast/sf-tracing v0.0.0-20221104190152-7f721cb9b60c
 	github.com/streamingfast/shutter v1.5.0
@@ -72,8 +71,8 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.6 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.32.6 // indirect
-	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.187 // indirect
+	github.com/aymanbagabas/go-osc52 v1.2.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
@@ -129,14 +128,12 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rivo/uniseg v0.4.2 // indirect
-	github.com/schollz/closestmatch v2.1.0+incompatible // indirect
 	github.com/sethvargo/go-retry v0.2.3 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/spf13/viper v1.7.0 // indirect
 	github.com/streamingfast/atm v0.0.0-20220131151839-18c87005e680 // indirect
-	github.com/streamingfast/dbin v0.0.0-20210809205249-73d5eca35dc5 // indirect
 	github.com/streamingfast/opaque v0.0.0-20210811180740-0c01d37ea308 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ cloud.google.com/go/trace v1.2.0 h1:oIaB4KahkIUOpLSAAjEJ8y2desbjY/x/RfP4O3KAtTI=
 cloud.google.com/go/trace v1.2.0/go.mod h1:Wc8y/uYyOhPy12KEnXG9XGrvfMz5F5SrYecQlbW1rwM=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.6/go.mod h1:8x999/OcIPy5ivx/wDiV7Gx4D+VUPODf0mWRGRc5kSk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/76creates/stickers v0.0.0-20230121000757-d6bf5dc8ab6b h1:FJJZQtpNygTX4SlVutmjnU7W832+uVBq+ORQJo9CGgw=
-github.com/76creates/stickers v0.0.0-20230121000757-d6bf5dc8ab6b/go.mod h1:OnGyCp42wnTwuZv2Ewh4dkvMuaiWMoH4I80yU2IJVmI=
 github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVtCdfBE21U=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-storage-blob-go v0.14.0 h1:1BCg74AmVdYwO3dlKwtFU1V0wU2PZdREkXvAmZJRUlM=
@@ -151,8 +149,6 @@ github.com/charmbracelet/glamour v0.6.0/go.mod h1:taqWV4swIMMbWALc0m7AfE9JkPSU8o
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.6.0 h1:1StyZB9vBSOyuZxQUcUwGr17JmojPNm87inij9N3wJY=
 github.com/charmbracelet/lipgloss v0.6.0/go.mod h1:tHh2wr34xcHjC2HCXIlGSG1jaDF0S0atAUvBMP6Ppuk=
-github.com/charmbracelet/soft-serve v0.4.5 h1:kir6DPoaBzT8SBnmEJZWjH1apGEF1a271JbrYG++9v8=
-github.com/charmbracelet/soft-serve v0.4.5/go.mod h1:/WfK7svyEIdGM94+1d9JSlWX9/W4FEZFjqm1r0Idh0E=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
@@ -431,8 +427,6 @@ github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffkt
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/lrstanley/bubblezone v0.0.0-20221222153816-e95291e2243e h1:XoxHx8K6ZKoMtjzWOMDuM69LCdjDDsTOtTfWGrT/fns=
-github.com/lrstanley/bubblezone v0.0.0-20221222153816-e95291e2243e/go.mod h1:v5lEwWaguF1o2MW/ucO0ZIA/IZymdBYJJ+2cMRLE7LU=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
@@ -633,8 +627,8 @@ github.com/streamingfast/sf-tracing v0.0.0-20221104190152-7f721cb9b60c h1:ihGABW
 github.com/streamingfast/sf-tracing v0.0.0-20221104190152-7f721cb9b60c/go.mod h1:Pm+uEfIOzgU97Kqwji9WRpJXqR/gKfi8myDCw8e74tU=
 github.com/streamingfast/shutter v1.5.0 h1:NpzDYzj0HVpSiDJVO/FFSL6QIK/YKOxY0gJAtyaTOgs=
 github.com/streamingfast/shutter v1.5.0/go.mod h1:B/T6efqdeMGbGwjzPS1ToXzYZI4kDzI5/u4I+7qbjY8=
-github.com/streamingfast/wasmtime-go/v4 v4.0.0-freemem h1:4K7+NCbxg5X/RqwjfemMLExSP6Zwr1MpDGwiFmXfFHs=
-github.com/streamingfast/wasmtime-go/v4 v4.0.0-freemem/go.mod h1:rOffzhrBM87FuXgj23Ss35uFDahjAauERq60QpyCzpE=
+github.com/streamingfast/wasmtime-go/v4 v4.0.0-freemem3 h1:raJHR0JWgYiSyX0vZ3leRK/TkNcn4ZUGTf+d64g48KQ=
+github.com/streamingfast/wasmtime-go/v4 v4.0.0-freemem3/go.mod h1:rOffzhrBM87FuXgj23Ss35uFDahjAauERq60QpyCzpE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -78,7 +78,7 @@ func mapTestExecutor(t *testing.T, name string) *exec.MapperModuleExecutor {
 	binary := pkg.Modules.Binaries[binaryIndex]
 	require.Greater(t, len(binary.Content), 1)
 
-	wasmModule, err := wasm.NewRuntime(nil).NewModule(
+	wasmModule, err := wasm.NewRuntime(nil, 0).NewModule(
 		context.Background(),
 		nil,
 		binary.Content,

--- a/service/config/runtimeconfig.go
+++ b/service/config/runtimeconfig.go
@@ -8,6 +8,7 @@ import (
 type RuntimeConfig struct {
 	CacheSaveInterval uint64
 
+	MaxWasmFuel          uint64 // if not 0, enable fuel consumption monitoring to stop runaway wasm module processing forever
 	SubrequestsSplitSize uint64 // in multiple of the SaveIntervals above
 	ParallelSubrequests  uint64 // how many sub-jobs to launch for a given user
 	// derives substores `states/`, for `store` modules snapshots (full and partial)
@@ -21,6 +22,7 @@ func NewRuntimeConfig(
 	cacheSaveInterval uint64,
 	subrequestsSplitSize uint64,
 	parallelSubrequests uint64,
+	MaxWasmFuel uint64,
 	baseObjectStore dstore.Store,
 	workerFactory work.WorkerFactory,
 ) RuntimeConfig {
@@ -28,6 +30,7 @@ func NewRuntimeConfig(
 		CacheSaveInterval:    cacheSaveInterval,
 		SubrequestsSplitSize: subrequestsSplitSize,
 		ParallelSubrequests:  parallelSubrequests,
+		MaxWasmFuel:          MaxWasmFuel,
 		BaseObjectStore:      baseObjectStore,
 		WorkerFactory:        workerFactory,
 	}

--- a/service/options.go
+++ b/service/options.go
@@ -36,3 +36,9 @@ func WithRequestStats() Option {
 		s.runtimeConfig.WithRequestStats = true
 	}
 }
+
+func WithMaxWasmFuelPerBlockModule(maxFuel uint64) Option {
+	return func(s *Service) {
+		s.runtimeConfig.MaxWasmFuel = maxFuel
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -71,6 +71,7 @@ func New(
 		1000, // overridden by Options
 		subrequestSplitSize,
 		parallelSubRequests,
+		0,
 		stateStore,
 		func(logger *zap.Logger) work.Worker {
 			return work.NewRemoteWorker(clientFactory, logger)
@@ -165,6 +166,7 @@ func (s *Service) Blocks(request *pbsubstreams.Request, streamSrv pbsubstreams.S
 		s.runtimeConfig.CacheSaveInterval,
 		s.runtimeConfig.SubrequestsSplitSize,
 		s.runtimeConfig.ParallelSubrequests,
+		s.runtimeConfig.MaxWasmFuel,
 		s.runtimeConfig.BaseObjectStore,
 		s.runtimeConfig.WorkerFactory,
 	)
@@ -237,7 +239,7 @@ func (s *Service) blocks(ctx context.Context, runtimeConfig config.RuntimeConfig
 		return stream.NewErrInvalidArg(err.Error())
 	}
 
-	wasmRuntime := wasm.NewRuntime(s.wasmExtensions)
+	wasmRuntime := wasm.NewRuntime(s.wasmExtensions, runtimeConfig.MaxWasmFuel)
 
 	execOutputConfigs, err := execout.NewConfigs(runtimeConfig.BaseObjectStore, outputGraph.AllModules(), outputGraph.ModuleHashes(), runtimeConfig.CacheSaveInterval, logger)
 	if err != nil {

--- a/test/runnable_test.go
+++ b/test/runnable_test.go
@@ -233,6 +233,7 @@ func processRequest(
 		10,
 		subrequestsSplitSize,
 		parallelSubrequests,
+		0,
 		baseStoreStore,
 		workerFactory,
 	)

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -36,9 +36,12 @@ func (m *Module) FreeMem() {
 }
 
 func (r *Runtime) NewModule(ctx context.Context, request *pbsubstreams.Request, wasmCode []byte, name string, entrypoint string) (*Module, error) {
-	engine := wasmtime.NewEngine()
+	cfg := wasmtime.NewConfig()
+	cfg.SetConsumeFuel(true)
+	engine := wasmtime.NewEngineWithConfig(cfg)
 	linker := wasmtime.NewLinker(engine)
 	store := wasmtime.NewStore(engine)
+
 	module, err := wasmtime.NewModule(store.Engine, wasmCode)
 	if err != nil {
 		return nil, fmt.Errorf("creating new module: %w", err)
@@ -101,6 +104,7 @@ func (m *Module) NewInstance(clock *pbsubstreams.Clock, arguments []Argument) (*
 		clock:      clock,
 		entrypoint: entrypoint,
 	}
+	m.wasmStore.AddFuel(100000000)
 
 	var args []interface{}
 	for _, input := range arguments {

--- a/wasm/runtime.go
+++ b/wasm/runtime.go
@@ -4,6 +4,7 @@ import "fmt"
 
 type Runtime struct {
 	extensions map[string]map[string]WASMExtension
+	maxFuel    uint64
 }
 
 func (r *Runtime) registerWASMExtension(namespace string, importName string, ext WASMExtension) {
@@ -29,8 +30,10 @@ func (r *Runtime) registerWASMExtension(namespace string, importName string, ext
 	r.extensions[namespace][importName] = ext
 }
 
-func NewRuntime(extensions []WASMExtensioner) *Runtime {
-	r := &Runtime{}
+func NewRuntime(extensions []WASMExtensioner, maxFuel uint64) *Runtime {
+	r := &Runtime{
+		maxFuel: maxFuel,
+	}
 	for _, ext := range extensions {
 		for ns, exts := range ext.WASMExtensions() {
 			for name, ext := range exts {


### PR DESCRIPTION
This will prevent a single wasm execution from taking "forever" (ex: an bug in wasm code)
It could evolve into request-based setting, tied in to payment, etc., but for now, allowing the server to put a hard limit is a safety protection.

In development, the consumer will receive this kind of error:
```
Error: rpc error: code = Internal desc = step new irr: handler step new: execute modules: running executor "map_ticks": execute module: execute: execute: maps wasm call: block 12369739: module "map_ticks": wasm execution failed: executing module "map_ticks": error while executing at wasm backtrace:
    0: 0xd2059 - <unknown>!num_bigint::biguint::division::div_rem_core::hc0061ad50131812f
    1: 0xd2876 - <unknown>!num_bigint::biguint::division::div_rem_ref::h9c65e3723b85af91
    2: 0xc0740 - <unknown>!substreams::scalar::BigDecimal::with_prec::h7f0c5a8f974d74ff
    3: 0xa20ca - <unknown>!substreams_uniswap_v3::math::big_decimal_exponated::hfe59b29f8ee7549d
    4: 0x5b7f7 - <unknown>!map_ticks
note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information

Caused by:
    wasm trap: all fuel consumed by WebAssembly
```

I recommend the following to leave lots of headroom on "normal" operations: `substreamsService.WithMaxWasmFuelPerBlockModule(500_000_000_000)`

There is a performance cost of the fuel instrumentation (~7%), which is only present when the feature is activated (non-zero maxWasmFuelPerBlockModule)