### PR TITLE
Fix error message cutoff

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+* Fixed status bar message cutoff bug
+
 ## [1.0.0](https://github.com/streamingfast/substreams/releases/tag/v1.0.0)
 
 ### Highlights

--- a/manifest/sink.go
+++ b/manifest/sink.go
@@ -39,7 +39,7 @@ func (r *Reader) loadSinkConfig(pkg *pbsubstreams.Package, m *Manifest) error {
 
 	files, err := desc.CreateFileDescriptors(pkg.ProtoFiles)
 	if err != nil {
-		return fmt.Errorf("failed to create file descriptor: %2", err)
+		return fmt.Errorf("failed to create file descriptor: %w", err)
 	}
 
 	var found bool

--- a/tui2/pages/progress/progress.go
+++ b/tui2/pages/progress/progress.go
@@ -117,5 +117,5 @@ func (p *Progress) SetSize(w, h int) {
 	headerHeight := 7
 	p.Common.SetSize(w, h)
 	p.bars.SetSize(w, h-headerHeight)
-	p.Styles.StatusBarValue.Width(p.Common.Width - labelsMaxLen() - 2) // adjust width to force word wrap
+	p.Styles.StatusBarValue.Width(p.Common.Width - labelsMaxLen()) // adjust status bar width to force word wrap: full width - labels width
 }

--- a/tui2/pages/progress/progress.go
+++ b/tui2/pages/progress/progress.go
@@ -78,13 +78,25 @@ func (p *Progress) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return p, nil
 }
 
-func (p *Progress) View() string {
-	labels := []string{
-		"Parallel engine progress messages: ",
-		"target block: ",
-		"Data payloads received: ",
-		"Status: ",
+var labels = []string{
+	"Parallel engine progress messages: ",
+	"Target block: ",
+	"Data payloads received: ",
+	"Status: ",
+}
+
+func labelsMaxLen() int {
+	width := 0
+	for _, label := range labels {
+		if len(label) > width {
+			width = len(label)
+		}
 	}
+	return width
+}
+
+func (p *Progress) View() string {
+
 	infos := []string{
 		fmt.Sprintf("%d (%d block/sec)", p.progressUpdates, p.updatesPerSecond),
 		fmt.Sprintf("%d", p.targetBlock),
@@ -105,5 +117,5 @@ func (p *Progress) SetSize(w, h int) {
 	headerHeight := 7
 	p.Common.SetSize(w, h)
 	p.bars.SetSize(w, h-headerHeight)
-	p.Styles.StatusBarValue.Width(p.Common.Width - len("Parallel engine progress messages: ") - 2)	// adjust width to force word wrap
+	p.Styles.StatusBarValue.Width(p.Common.Width - labelsMaxLen() - 2) // adjust width to force word wrap
 }

--- a/tui2/pages/progress/progress.go
+++ b/tui2/pages/progress/progress.go
@@ -105,4 +105,5 @@ func (p *Progress) SetSize(w, h int) {
 	headerHeight := 7
 	p.Common.SetSize(w, h)
 	p.bars.SetSize(w, h-headerHeight)
+	p.Styles.StatusBarValue.Width(p.Common.Width - len("Parallel engine progress messages: ") - 2)	// adjust width to force word wrap
 }

--- a/tui2/styles/styles.go
+++ b/tui2/styles/styles.go
@@ -151,7 +151,8 @@ func DefaultStyles() *Styles {
 		Foreground(lipgloss.Color("228"))
 
 	s.StatusBarValue = lipgloss.NewStyle().
-		Padding(0, 1).
+		PaddingLeft(1).
+		PaddingRight(2).
 		Background(lipgloss.Color("235")).
 		Foreground(lipgloss.Color("243"))
 


### PR DESCRIPTION
This should fix an issue with RPC error message cutoff #193
The only way to force word wrap with this library is to set component width explicitly and it depends on the longest label length

Before:

<img width="1474" alt="image" src="https://user-images.githubusercontent.com/29608734/225146166-5c8dfe0b-2f69-4387-bc88-834923cc8289.png">


After:

<img width="1478" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/29608734/225145393-1e981a77-7066-4491-9300-39755b6857d9.png">
