### PR TITLE
chore: add github workflow for buf linting & push

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,0 +1,42 @@
+name: Buf
+
+on:
+  pull_request:
+  push:
+    tags:
+      - v*
+    branches:
+      - develop
+      - release/v*
+      - feature/*
+
+jobs:
+  buf:
+    runs-on: ubuntu-20.04
+    if: "${{ !startsWith(github.event.head_commit.message, 'GitBook: [#') }}"
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Lint protos
+        # TODO: Consider enabling this after fixing or ignoring the current linting errors?
+        if: false
+        uses: bufbuild/buf-lint-action@v1
+          
+      - name: Check for breaking changes
+        if: github.event_name == 'pull_request'
+        uses: bufbuild/buf-breaking-action@v1
+        with:
+          against: 'https://github.com/${{ github.repository }}.git#branch=${{ github.base_ref }}'
+
+      - uses: bufbuild/buf-push-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          buf_token: ${{ secrets.BUF_TOKEN }}
+          draft: ${{ !startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Something like that @maoueh?

Since you guys are using github releases anyways, why don't you use the `release` trigger for your workflows to tag docker images, gitpod images & this? That would imho be a better match.

There are currently a few linting errors in `buf lint`. Do we/you care about those? Do we want to fix them?