### PR TITLE
Requesting to fixed typos in docs, Need to fixed link  on homepage of substream docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ The primary ways to use Substreams include:
 
 After installing Substreams and reviewing the Quickstart:
 
-* You can l[earn more about ](developers-guide/modules/)modules, and then [study the Developer's guide](developers-guide/overview.md).
+* You can [learn more about ](developers-guide/modules/)modules, and then [study the Developer's guide](developers-guide/overview.md).
 
 Find pre-built Substreams by using the following resources:
 


### PR DESCRIPTION
While reading through the Substreams docs at [https://substreams.streamingfast.io/], I found a small typo in "where to start section" section of docs, where the link is spelled wrong. 