### PR TITLE
Add validation for start block number vs first streamable block of the chain

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Bug fixes
+
+* If the initial block or start block is less than the first block in the chain, the substreams will now start from the
+  first block in the chain. Previously, setting the initial block to a block before the first block in the chain would
+  cause the substreams to hang.
+
 ## v1.1.12
 
 ### Highlights


### PR DESCRIPTION
Added checks in blocks method of Tier1 service to ensure that the requested start block number is equal to or greater than the first streamable block of the chain. This prevents errors caused by invalid block number requests.