### PR TITLE
Updated Readme by removing the link

### DIFF
--- a/docs/developers-guide/modules/README.md
+++ b/docs/developers-guide/modules/README.md
@@ -77,6 +77,4 @@ Notable facts and use cases for working `store` modules include:
 * `store` modules are used to implement the Dynamic Data Sources pattern from Subgraphs, keeping track of contracts created to filter the next block with that information.
 * Downstream of the Substreams output, do not use `store` modules to query anything from them. Instead, use a sink to shape the data for proper querying.
 
-### Additional information
 
-Learn more about [modules in the Developer's guide](./).


### PR DESCRIPTION
There is no need to have an "Additional Information"  section in the "https://substreams.streamingfast.io/developers-guide/modules" page because the link added to this section itself leads to this "https://substreams.streamingfast.io/developers-guide/modules" or the same page. Need to remove it for now or we need to link it with other sources if we have one.