### PR TITLE
Pass substreams endpoint to `service serve`

### DIFF
--- a/cmd/substreams/service-serve.go
+++ b/cmd/substreams/service-serve.go
@@ -52,6 +52,7 @@ func serveE(cmd *cobra.Command, args []string) error {
 	listenAddr := sflags.MustGetString(cmd, "listen-addr")
 	corsHostRegexAllow := sflags.MustGetString(cmd, "cors-host-regex-allow")
 	dataDir := sflags.MustGetString(cmd, "data-dir")
+	endpoint := sflags.MustGetString(cmd, "endpoint")
 
 	var cors *regexp.Regexp
 	if corsHostRegexAllow != "" {
@@ -72,7 +73,7 @@ func serveE(cmd *cobra.Command, args []string) error {
 	var err error
 	switch engineType {
 	case "docker":
-		engine, err = docker.NewEngine(dataDir, token)
+		engine, err = docker.NewEngine(dataDir, token, endpoint)
 		if err != nil {
 			return err
 		}

--- a/cmd/substreams/service-serve.go
+++ b/cmd/substreams/service-serve.go
@@ -21,6 +21,7 @@ import (
 func init() {
 	serviceCmd.AddCommand(serveCmd)
 
+	serveCmd.Flags().StringP("endpoint", "e", "", "Substreams endpoint to connect to")
 	serveCmd.Flags().String("data-dir", "./sink-data", "Store data to this folder")
 	serveCmd.Flags().String("listen-addr", "localhost:8000", "Listen for GRPC connections on this address")
 	serveCmd.Flags().String("cors-host-regex-allow", "^localhost", "Regex to allow CORS origin requests from, defaults to localhost only")

--- a/sink-server/docker/docker.go
+++ b/sink-server/docker/docker.go
@@ -29,15 +29,17 @@ import (
 )
 
 type DockerEngine struct {
-	mutex sync.Mutex
-	dir   string
-	token string
+	mutex    sync.Mutex
+	dir      string
+	endpoint string
+	token    string
 }
 
-func NewEngine(dir string, sf_token string) (*DockerEngine, error) {
+func NewEngine(dir string, sf_token string, endpoint string) (*DockerEngine, error) {
 	out := &DockerEngine{
-		dir:   dir,
-		token: sf_token,
+		dir:      dir,
+		token:    sf_token,
+		endpoint: endpoint,
 	}
 	if err := out.CheckVersion(); err != nil {
 		return nil, err

--- a/sink-server/docker/sink.go
+++ b/sink-server/docker/sink.go
@@ -86,6 +86,11 @@ func (e *DockerEngine) newSink(deploymentID string, dbService string, pkg *pbsub
 		withPostgraphile = "--postgraphile"
 	}
 
+	withEndpoint := ""
+	if e.endpoint != "" {
+		withEndpoint = "-e " + e.endpoint
+	}
+
 	startScript := []byte(fmt.Sprintf(`#!/bin/bash
 set -xeu
 
@@ -93,8 +98,8 @@ if [ ! -f /opt/subservices/data/setup-complete ]; then
     /app/substreams-sink-sql setup $DSN /opt/subservices/config/substreams.spkg %s && touch /opt/subservices/data/setup-complete
 fi
 
-/app/substreams-sink-sql run $DSN /opt/subservices/config/substreams.spkg --on-module-hash-mistmatch=warn
-`, withPostgraphile))
+/app/substreams-sink-sql run $DSN /opt/subservices/config/substreams.spkg --on-module-hash-mistmatch=warn %s
+`, withPostgraphile, withEndpoint))
 	if err := os.WriteFile(filepath.Join(configFolder, "start.sh"), startScript, 0755); err != nil {
 		fmt.Println("")
 		return conf, motd, fmt.Errorf("writing file: %w", err)


### PR DESCRIPTION
Fixes #353

Allows to use `--endpoint` flag to pass substreams endpoint to connect to.