### PR TITLE
--init-config flag in substreams init

### DIFF
--- a/cmd/substreams/init.go
+++ b/cmd/substreams/init.go
@@ -54,15 +54,31 @@ var initCmd = &cobra.Command{
 
 var etherscanAPIKey = "YourApiKeyToken"
 
+type ConfigContract struct {
+	Address    string `json:"address"`
+	ShortName  string `json:"short_name"`
+	StartBlock string `json:"start_block"`
+	ABIPath    string `json:"abi_path"`
+}
+
+type InitConfig struct {
+	ProjectName string           `json:"project_name"`
+	Protocol    string           `json:"protocol"`
+	Chain       string           `json:"chain"`
+	Contracts   []ConfigContract `json:"contracts"`
+}
+
 func init() {
 	if x := os.Getenv("ETHERSCAN_API_KEY"); x != "" {
 		etherscanAPIKey = x
 	}
+	initCmd.Flags().Bool("init-config", false, "Load init config from substreams-init.json")
 	rootCmd.AddCommand(initCmd)
 }
 
 func runSubstreamsInitE(cmd *cobra.Command, args []string) error {
 	relativeWorkingDir := "."
+
 	if len(args) == 1 {
 		relativeWorkingDir = args[0]
 	}
@@ -71,25 +87,51 @@ func runSubstreamsInitE(cmd *cobra.Command, args []string) error {
 		relativeWorkingDir = devInitSourceDirectory
 	}
 
+	var initConfig InitConfig
+
+	initConfigFlag := mustGetBool(cmd, "init-config")
+
+	if initConfigFlag {
+		initConfig = loadInitConfig(relativeWorkingDir)
+	}
+
 	absoluteWorkingDir, err := filepath.Abs(relativeWorkingDir)
 	if err != nil {
 		return fmt.Errorf("getting absolute path of %q: %w", relativeWorkingDir, err)
 	}
 
-	projectName, moduleName, err := promptProjectName(absoluteWorkingDir)
-	if err != nil {
-		return fmt.Errorf("running project name prompt: %w", err)
-	}
+	var protocol codegen.Protocol
+	var chainSelected codegen.EthereumChain
+	var projectName string
+	var moduleName string
 
-	absoluteProjectDir := filepath.Join(absoluteWorkingDir, projectName)
+	if initConfigFlag {
+		projectName = initConfig.ProjectName
+		moduleName = projectNameToModuleName(initConfig.ProjectName)
+		protocol, err = codegen.ParseProtocol(initConfig.Protocol)
 
-	protocol, err := promptProtocol()
-	if err != nil {
-		return fmt.Errorf("running protocol prompt: %w", err)
-	}
+		if err != nil {
+			return fmt.Errorf("loading protocol from config: %w", err)
+		}
+		chainSelected, err = codegen.ParseEthereumChain(initConfig.Chain)
 
-	switch protocol {
-	case codegen.ProtocolEthereum:
+		if err != nil {
+			return fmt.Errorf("loading chain from config: %w", err)
+		}
+	} else {
+
+		projectName, moduleName, err = promptProjectName(absoluteWorkingDir)
+
+		if err != nil {
+			return fmt.Errorf("running project name prompt: %w", err)
+		}
+
+		protocol, err = promptProtocol()
+
+		if err != nil {
+			return fmt.Errorf("running protocol prompt: %w", err)
+		}
+
 		chainSelected, err := promptEthereumChain()
 		if err != nil {
 			return fmt.Errorf("running chain prompt: %w", err)
@@ -102,23 +144,38 @@ func runSubstreamsInitE(cmd *cobra.Command, args []string) error {
 			fmt.Println()
 			return errInitUnsupportedChain
 		}
+	}
 
-		chain := templates.EthereumChainsByID[chainSelected.String()]
-		if chain == nil {
-			return fmt.Errorf("unknown chain: %s", chainSelected.String())
-		}
+	absoluteProjectDir := filepath.Join(absoluteWorkingDir, projectName)
+	chain := templates.EthereumChainsByID[chainSelected.String()]
 
-		ethereumContracts, err := promptEthereumVerifiedContracts(eth.MustNewAddress(chain.DefaultContractAddress), chain.DefaultContractName)
-		if err != nil {
-			return fmt.Errorf("running contract prompt: %w", err)
-		}
+	if chain == nil {
+		return fmt.Errorf("unknown chain: %s", chainSelected.String())
+	}
 
-		if len(ethereumContracts) != 1 {
-			// more than one contract to track, need to set the short names of the contracts
-			fmt.Printf("Tracking %d contracts, let's define a short name for each contract\n", len(ethereumContracts))
-			ethereumContracts, err = promptEthereumContractShortNames(ethereumContracts)
+	switch protocol {
+	case codegen.ProtocolEthereum:
+
+		var ethereumContracts []*templates.EthereumContract
+
+		if initConfigFlag {
+			ethereumContracts = parseContractsFromConfig(initConfig.Contracts)
+
+			fmt.Printf("%+v\n", ethereumContracts)
+
+		} else {
+			ethereumContracts, err := promptEthereumVerifiedContracts(eth.MustNewAddress(chain.DefaultContractAddress), chain.DefaultContractName)
 			if err != nil {
-				return fmt.Errorf("running short name contract prompt: %w", err)
+				return fmt.Errorf("running contract prompt: %w", err)
+			}
+
+			if len(ethereumContracts) != 1 {
+				// more than one contract to track, need to set the short names of the contracts
+				fmt.Printf("Tracking %d contracts, let's define a short name for each contract\n", len(ethereumContracts))
+				ethereumContracts, err = promptEthereumContractShortNames(ethereumContracts)
+				if err != nil {
+					return fmt.Errorf("running short name contract prompt: %w", err)
+				}
 			}
 		}
 
@@ -627,53 +684,66 @@ func getContractABI(ctx context.Context, address eth.Address, endpoint string) (
 
 func getAndSetContractABIs(ctx context.Context, contracts []*templates.EthereumContract, chain *templates.EthereumChain) ([]*templates.EthereumContract, error) {
 	for _, contract := range contracts {
-		abi, abiContent, wait, err := getContractABI(ctx, contract.GetAddress(), chain.ApiEndpoint)
-		if err != nil {
-			return nil, err
-		}
 
-		<-wait.C
-		implementationAddress, wait, err := getProxyContractImplementation(ctx, contract.GetAddress(), chain.ApiEndpoint)
-		if err != nil {
-			return nil, err
-		}
-		<-wait.C
+		localAbi := contract.GetAbiContent()
+		var abiContent string
+		var abi *eth.ABI
+		var err error
 
-		if implementationAddress != nil {
-			implementationABI, implementationABIContent, wait, err := getContractABI(ctx, *implementationAddress, chain.ApiEndpoint)
+		if localAbi != "" {
+			abi, abiContent, err = getLocalContractABI(ctx, localAbi)
 			if err != nil {
 				return nil, err
 			}
-			for k, v := range implementationABI.LogEventsMap {
-				abi.LogEventsMap[k] = append(abi.LogEventsMap[k], v...)
-			}
 
-			for k, v := range implementationABI.LogEventsByNameMap {
-				abi.LogEventsByNameMap[k] = append(abi.LogEventsByNameMap[k], v...)
-			}
-
-			abiAsArray := []map[string]interface{}{}
-			if err := json.Unmarshal([]byte(abiContent), &abiAsArray); err != nil {
-				return nil, fmt.Errorf("unmarshalling abiContent as array: %w", err)
-			}
-
-			implementationABIAsArray := []map[string]interface{}{}
-			if err := json.Unmarshal([]byte(implementationABIContent), &implementationABIAsArray); err != nil {
-				return nil, fmt.Errorf("unmarshalling implementationABIContent as array: %w", err)
-			}
-
-			abiAsArray = append(abiAsArray, implementationABIAsArray...)
-
-			content, err := json.Marshal(abiAsArray)
+		} else {
+			abi, abiContent, wait, err := getContractABI(ctx, contract.GetAddress(), chain.ApiEndpoint)
 			if err != nil {
-				return nil, fmt.Errorf("re-marshalling ABI")
+				return nil, err
 			}
-			abiContent = string(content)
 
-			fmt.Printf("Fetched contract ABI for Implementation %s of Proxy %s\n", *implementationAddress, contract.GetAddress())
 			<-wait.C
-		}
+			implementationAddress, wait, err := getProxyContractImplementation(ctx, contract.GetAddress(), chain.ApiEndpoint)
+			if err != nil {
+				return nil, err
+			}
+			<-wait.C
 
+			if implementationAddress != nil {
+				implementationABI, implementationABIContent, wait, err := getContractABI(ctx, *implementationAddress, chain.ApiEndpoint)
+				if err != nil {
+					return nil, err
+				}
+				for k, v := range implementationABI.LogEventsMap {
+					abi.LogEventsMap[k] = append(abi.LogEventsMap[k], v...)
+				}
+
+				for k, v := range implementationABI.LogEventsByNameMap {
+					abi.LogEventsByNameMap[k] = append(abi.LogEventsByNameMap[k], v...)
+				}
+
+				abiAsArray := []map[string]interface{}{}
+				if err := json.Unmarshal([]byte(abiContent), &abiAsArray); err != nil {
+					return nil, fmt.Errorf("unmarshalling abiContent as array: %w", err)
+				}
+
+				implementationABIAsArray := []map[string]interface{}{}
+				if err := json.Unmarshal([]byte(implementationABIContent), &implementationABIAsArray); err != nil {
+					return nil, fmt.Errorf("unmarshalling implementationABIContent as array: %w", err)
+				}
+
+				abiAsArray = append(abiAsArray, implementationABIAsArray...)
+
+				content, err := json.Marshal(abiAsArray)
+				if err != nil {
+					return nil, fmt.Errorf("re-marshalling ABI")
+				}
+				abiContent = string(content)
+
+				fmt.Printf("Fetched contract ABI for Implementation %s of Proxy %s\n", *implementationAddress, contract.GetAddress())
+				<-wait.C
+			}
+		}
 		//fmt.Println("this is the complete abiContent after merge", abiContent)
 		contract.SetAbiContent(abiContent)
 		contract.SetAbi(abi)
@@ -729,4 +799,70 @@ func getContractCreationBlock(ctx context.Context, contracts []*templates.Ethere
 		fmt.Printf("Fetched initial block %d for %s (lowest %d)\n", blockNum, contract.GetAddress(), lowestStartBlock)
 	}
 	return lowestStartBlock, nil
+}
+
+func loadInitConfig(relativeWorkingDir string) InitConfig {
+	file, err := os.Open(filepath.Join(relativeWorkingDir, "substreams-init.json"))
+	if err != nil {
+		panic(fmt.Errorf("error opening file: %w", err))
+	}
+	defer file.Close()
+	fmt.Println("Config file found!")
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		panic(fmt.Errorf("error reading file: %w", err))
+
+	}
+
+	var initConfig InitConfig
+
+	err = json.Unmarshal(data, &initConfig)
+	if err != nil {
+		panic(fmt.Errorf("error unmarshalling JSON: %w", err))
+	}
+
+	return initConfig
+}
+
+func parseContractsFromConfig(contracts []ConfigContract) []*templates.EthereumContract {
+
+	var ethereumContracts []*templates.EthereumContract
+
+	for _, contract := range contracts {
+
+		ethereumContracts = append(ethereumContracts, templates.NewEthereumContract(contract.ShortName, eth.MustNewAddress(contract.Address), nil, nil, contract.ABIPath))
+	}
+
+	return ethereumContracts
+}
+
+func getLocalContractABI(ctx context.Context, abiLocation string) (*eth.ABI, string, error) {
+
+	absAbi, err := filepath.Abs(abiLocation)
+
+	if err != nil {
+		return nil, "", fmt.Errorf("getting absolute path of %q: %w", abiLocation, err)
+
+	}
+
+	file, err := os.Open(absAbi)
+
+	if err != nil {
+		panic(fmt.Errorf("error opening file: %w", err))
+	}
+	defer file.Close()
+
+	abiContent, err := io.ReadAll(file)
+	if err != nil {
+		panic(fmt.Errorf("error reading file: %w", err))
+
+	}
+
+	ethABI, err := eth.ParseABIFromBytes(abiContent)
+	if err != nil {
+		return nil, "", fmt.Errorf("parsing abi %q: %w", abiContent, err)
+	}
+
+	return ethABI, string(abiContent), nil
 }

--- a/cmd/substreams/init.go
+++ b/cmd/substreams/init.go
@@ -161,10 +161,8 @@ func runSubstreamsInitE(cmd *cobra.Command, args []string) error {
 		if initConfigFlag {
 			ethereumContracts = parseContractsFromConfig(initConfig.Contracts)
 
-			fmt.Printf("%+v\n", ethereumContracts)
-
 		} else {
-			ethereumContracts, err := promptEthereumVerifiedContracts(eth.MustNewAddress(chain.DefaultContractAddress), chain.DefaultContractName)
+			ethereumContracts, err = promptEthereumVerifiedContracts(eth.MustNewAddress(chain.DefaultContractAddress), chain.DefaultContractName)
 			if err != nil {
 				return fmt.Errorf("running contract prompt: %w", err)
 			}
@@ -697,20 +695,26 @@ func getAndSetContractABIs(ctx context.Context, contracts []*templates.EthereumC
 			}
 
 		} else {
-			abi, abiContent, wait, err := getContractABI(ctx, contract.GetAddress(), chain.ApiEndpoint)
+
+			var wait *time.Timer
+			var implementationAddress *eth.Address
+			var implementationABI *eth.ABI
+			var implementationABIContent string
+
+			abi, abiContent, wait, err = getContractABI(ctx, contract.GetAddress(), chain.ApiEndpoint)
 			if err != nil {
 				return nil, err
 			}
 
 			<-wait.C
-			implementationAddress, wait, err := getProxyContractImplementation(ctx, contract.GetAddress(), chain.ApiEndpoint)
+			implementationAddress, wait, err = getProxyContractImplementation(ctx, contract.GetAddress(), chain.ApiEndpoint)
 			if err != nil {
 				return nil, err
 			}
 			<-wait.C
 
 			if implementationAddress != nil {
-				implementationABI, implementationABIContent, wait, err := getContractABI(ctx, *implementationAddress, chain.ApiEndpoint)
+				implementationABI, implementationABIContent, wait, err = getContractABI(ctx, *implementationAddress, chain.ApiEndpoint)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/substreams/init.go
+++ b/cmd/substreams/init.go
@@ -132,7 +132,7 @@ func runSubstreamsInitE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("running protocol prompt: %w", err)
 		}
 
-		chainSelected, err := promptEthereumChain()
+		chainSelected, err = promptEthereumChain()
 		if err != nil {
 			return fmt.Errorf("running chain prompt: %w", err)
 		}

--- a/codegen/ethereum_chain_enum.go
+++ b/codegen/ethereum_chain_enum.go
@@ -18,6 +18,8 @@ const (
 	EthereumChainBNB
 	// EthereumChainPolygon is a EthereumChain of type Polygon.
 	EthereumChainPolygon
+	// EthereumChainPolygon is a EthereumChain of type Polygon.
+	EthereumChainArbitrum	
 	// EthereumChainGoerli is a EthereumChain of type Goerli.
 	EthereumChainGoerli
 	// EthereumChainMumbai is a EthereumChain of type Mumbai.
@@ -28,15 +30,16 @@ const (
 
 var ErrInvalidEthereumChain = fmt.Errorf("not a valid EthereumChain, try [%s]", strings.Join(_EthereumChainNames, ", "))
 
-const _EthereumChainName = "MainnetBNBPolygonGoerliMumbaiOther"
+const _EthereumChainName = "MainnetBNBPolygonArbitrumGoerliMumbaiOther"
 
 var _EthereumChainNames = []string{
 	_EthereumChainName[0:7],
 	_EthereumChainName[7:10],
 	_EthereumChainName[10:17],
-	_EthereumChainName[17:23],
-	_EthereumChainName[23:29],
-	_EthereumChainName[29:34],
+	_EthereumChainName[17:25],
+	_EthereumChainName[25:31],
+	_EthereumChainName[31:36],
+	_EthereumChainName[36:41],
 }
 
 // EthereumChainNames returns a list of possible string values of EthereumChain.
@@ -50,9 +53,10 @@ var _EthereumChainMap = map[EthereumChain]string{
 	EthereumChainMainnet: _EthereumChainName[0:7],
 	EthereumChainBNB:     _EthereumChainName[7:10],
 	EthereumChainPolygon: _EthereumChainName[10:17],
-	EthereumChainGoerli:  _EthereumChainName[17:23],
-	EthereumChainMumbai:  _EthereumChainName[23:29],
-	EthereumChainOther:   _EthereumChainName[29:34],
+	EthereumChainArbitrum: _EthereumChainName[17:25],
+	EthereumChainGoerli:  _EthereumChainName[25:31],
+	EthereumChainMumbai:  _EthereumChainName[31:36],
+	EthereumChainOther:   _EthereumChainName[36:41],
 }
 
 // String implements the Stringer interface.
@@ -77,12 +81,14 @@ var _EthereumChainValue = map[string]EthereumChain{
 	strings.ToLower(_EthereumChainName[7:10]):  EthereumChainBNB,
 	_EthereumChainName[10:17]:                  EthereumChainPolygon,
 	strings.ToLower(_EthereumChainName[10:17]): EthereumChainPolygon,
-	_EthereumChainName[17:23]:                  EthereumChainGoerli,
-	strings.ToLower(_EthereumChainName[17:23]): EthereumChainGoerli,
-	_EthereumChainName[23:29]:                  EthereumChainMumbai,
-	strings.ToLower(_EthereumChainName[23:29]): EthereumChainMumbai,
-	_EthereumChainName[29:34]:                  EthereumChainOther,
-	strings.ToLower(_EthereumChainName[29:34]): EthereumChainOther,
+	_EthereumChainName[17:25]:                  EthereumChainArbitrum,
+	strings.ToLower(_EthereumChainName[17:25]): EthereumChainArbitrum,
+	_EthereumChainName[25:31]:                  EthereumChainGoerli,
+	strings.ToLower(_EthereumChainName[25:31]): EthereumChainGoerli,
+	_EthereumChainName[31:36]:                  EthereumChainMumbai,
+	strings.ToLower(_EthereumChainName[31:36]): EthereumChainMumbai,
+	_EthereumChainName[36:41]:                  EthereumChainOther,
+	strings.ToLower(_EthereumChainName[36:41]): EthereumChainOther,
 }
 
 // ParseEthereumChain attempts to convert a string to a EthereumChain.

--- a/codegen/templates/ethereum_chain.go
+++ b/codegen/templates/ethereum_chain.go
@@ -39,6 +39,15 @@ var EthereumChainsByID = map[string]*EthereumChain{
 		FirehoseEndpoint:       "polygon.streamingfast.io:443",
 		Network:                "polygon",
 	},
+	"Arbitrum": {
+		DisplayName:            "Arbitrum",
+		ExplorerLink:           "https://arbiscan.io",
+		ApiEndpoint:            "https://api.arbiscan.io",
+		DefaultContractAddress: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+		DefaultContractName:    "WETH Token",
+		FirehoseEndpoint:       "arb-one.streamingfast.io:443",
+		Network:                "arbitrum",
+	},
 	"Goerli": {
 		DisplayName:            "Goerli Testnet",
 		ExplorerLink:           "https://goerli.etherscan.io",

--- a/codegen/templates/ethereum_project.go
+++ b/codegen/templates/ethereum_project.go
@@ -83,6 +83,10 @@ func (e *EthereumContract) SetAbiContent(abiContent string) {
 	e.abiContent = abiContent
 }
 
+func (e *EthereumContract) GetAbiContent() string {
+	return e.abiContent
+}
+
 type EthereumProject struct {
 	name                        string
 	moduleName                  string


### PR DESCRIPTION
`substreams init --init-config`

I've added an --init-config flag for use in substreams init.

This allows you to use a local config file rather than the command prompts to spin up a substreams projects.

The config should be in the root directory of wherever you're running the substreams init command from.

```
{
    "project_name" : "testing_local",
    "protocol" : "Ethereum",
    "chain" : "Mainnet",
    "contracts" : [
        {
            "address" : "0xB4Ac9F231D2469769A0a56eee5559Fd4613ed3fB",
            "short_name" : "loans_interface",
            "start_block" : "10600000",
            "abi_path" : "./abis/LoansInterface.json"
        }
    ]
}
```
The main use case here is to use local abis for non verified contracts rather than relying on the block explorer.

`contracts` can be an array to support multiple contracts.
`start_block` is currently not used as the explorer is able to handle to retrieving the start block without contract verification.
`abi_path` should point to your local abi file.

All fields should be present in the config.

I've tested this on the following scenarios:
- Single & Multiple substreams init with the init-config flag
- Single & Multiple substreams init without the init-config flag
- Proxy Contracts without the init-config flag

Some things to note:
- Its probably more preferable to use a yaml than json
- Rather than a bool flag allow a string to the location of the config file
- This needs better error handling I'm sure
- Allow dynamic use where some contracts are available on the explorer and some aren't