### PR TITLE
Add support for authentication based on api keys

### DIFF
--- a/app/tier1.go
+++ b/app/tier1.go
@@ -143,6 +143,7 @@ func (a *Tier1App) Run() error {
 	subrequestsClientConfig := client.NewSubstreamsClientConfig(
 		a.config.SubrequestsEndpoint,
 		"",
+		client.None,
 		a.config.SubrequestsInsecure,
 		a.config.SubrequestsPlaintext,
 	)

--- a/client/client.go
+++ b/client/client.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
+	"google.golang.org/grpc/metadata"
 	"log"
 	"os"
 	"regexp"
@@ -22,9 +24,18 @@ import (
 	_ "google.golang.org/grpc/xds"
 )
 
+type AuthType int
+
+const (
+	None AuthType = iota
+	JWT
+	ApiKey
+)
+
 type SubstreamsClientConfig struct {
 	endpoint  string
-	jwt       string
+	authToken string
+	authType  AuthType
 	insecure  bool
 	plaintext bool
 }
@@ -41,25 +52,31 @@ func (c *SubstreamsClientConfig) PlainText() bool {
 	return c.plaintext
 }
 
-func (c *SubstreamsClientConfig) JWT() string {
-	return c.jwt
+func (c *SubstreamsClientConfig) AuthToken() string {
+	return c.authToken
+}
+
+func (c *SubstreamsClientConfig) AuthType() AuthType {
+	return c.authType
 }
 
 func (c *SubstreamsClientConfig) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	encoder.AddString("client_endpoint", c.endpoint)
 	encoder.AddBool("client_plaintext", c.plaintext)
 	encoder.AddBool("client_insecure", c.insecure)
-	encoder.AddBool("jwt_set", c.jwt != "")
+	encoder.AddBool("jwt_set", c.authToken != "" && c.authType == JWT)
+	encoder.AddBool("api_key_set", c.authToken != "" && c.authType == ApiKey)
 
 	return nil
 }
 
 type InternalClientFactory = func() (cli pbssinternal.SubstreamsClient, closeFunc func() error, callOpts []grpc.CallOption, err error)
 
-func NewSubstreamsClientConfig(endpoint string, jwt string, insecure bool, plaintext bool) *SubstreamsClientConfig {
+func NewSubstreamsClientConfig(endpoint string, authToken string, authType AuthType, insecure bool, plaintext bool) *SubstreamsClientConfig {
 	return &SubstreamsClientConfig{
 		endpoint:  endpoint,
-		jwt:       jwt,
+		authToken: authToken,
+		authType:  authType,
 		insecure:  insecure,
 		plaintext: plaintext,
 	}
@@ -92,7 +109,8 @@ func NewSubstreamsInternalClient(config *SubstreamsClientConfig) (cli pbssintern
 		return nil, nil, nil, fmt.Errorf("substreams client config not set")
 	}
 	endpoint := config.endpoint
-	jwt := config.jwt
+	authToken := config.authToken
+	authType := config.authType
 	usePlainTextConnection := config.plaintext
 	useInsecureTLSConnection := config.insecure
 
@@ -103,7 +121,7 @@ func NewSubstreamsInternalClient(config *SubstreamsClientConfig) (cli pbssintern
 	bootStrapFilename := os.Getenv("GRPC_XDS_BOOTSTRAP")
 
 	var dialOptions []grpc.DialOption
-	skipAuth := jwt == "" || usePlainTextConnection
+	skipAuth := authType == None || usePlainTextConnection
 	if bootStrapFilename != "" {
 		log.Println("Using xDS credentials...")
 		creds, err := xdscreds.NewClientCredentials(xdscreds.ClientOptions{FallbackCreds: insecure.NewCredentials()})
@@ -138,9 +156,13 @@ func NewSubstreamsInternalClient(config *SubstreamsClientConfig) (cli pbssintern
 	closeFunc = conn.Close
 
 	if !skipAuth {
-		zlog.Debug("creating oauth access", zap.String("endpoint", endpoint))
-		creds := oauth.NewOauthAccess(&oauth2.Token{AccessToken: jwt, TokenType: "Bearer"})
-		callOpts = append(callOpts, grpc.PerRPCCredentials(creds))
+		if authType == JWT {
+			zlog.Debug("creating oauth access", zap.String("endpoint", endpoint))
+			tokenSource := oauth.TokenSource{TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: authToken, TokenType: "Bearer"})}
+			callOpts = append(callOpts, grpc.PerRPCCredentials(tokenSource))
+		} else if authType == ApiKey {
+			// todo implement if necessary
+		}
 	}
 
 	zlog.Debug("creating new client", zap.String("endpoint", endpoint))
@@ -149,33 +171,34 @@ func NewSubstreamsInternalClient(config *SubstreamsClientConfig) (cli pbssintern
 	return
 }
 
-func NewSubstreamsClient(config *SubstreamsClientConfig) (cli pbsubstreamsrpc.StreamClient, closeFunc func() error, callOpts []grpc.CallOption, err error) {
+func NewSubstreamsClient(ctx context.Context, config *SubstreamsClientConfig) (ctxRes context.Context, cli pbsubstreamsrpc.StreamClient, closeFunc func() error, callOpts []grpc.CallOption, err error) {
 	if config == nil {
-		return nil, nil, nil, fmt.Errorf("substreams client config not set")
+		return nil, nil, nil, nil, fmt.Errorf("substreams client config not set")
 	}
 	endpoint := config.endpoint
-	jwt := config.jwt
+	authToken := config.authToken
+	authType := config.authType
 	usePlainTextConnection := config.plaintext
 	useInsecureTLSConnection := config.insecure
 
 	if !portSuffixRegex.MatchString(endpoint) {
-		return nil, nil, nil, fmt.Errorf("invalid endpoint %q: endpoint's suffix must be a valid port in the form ':<port>', port 443 is usually the right one to use", endpoint)
+		return nil, nil, nil, nil, fmt.Errorf("invalid endpoint %q: endpoint's suffix must be a valid port in the form ':<port>', port 443 is usually the right one to use", endpoint)
 	}
 
 	bootStrapFilename := os.Getenv("GRPC_XDS_BOOTSTRAP")
 
 	var dialOptions []grpc.DialOption
-	skipAuth := jwt == "" || usePlainTextConnection
+	skipAuth := authType == None || usePlainTextConnection
 	if bootStrapFilename != "" {
 		log.Println("Using xDS credentials...")
 		creds, err := xdscreds.NewClientCredentials(xdscreds.ClientOptions{FallbackCreds: insecure.NewCredentials()})
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to create xDS credentials: %v", err)
+			return nil, nil, nil, nil, fmt.Errorf("failed to create xDS credentials: %v", err)
 		}
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(creds))
 	} else {
 		if useInsecureTLSConnection && usePlainTextConnection {
-			return nil, nil, nil, fmt.Errorf("option --insecure and --plaintext are mutually exclusive, they cannot be both specified at the same time")
+			return nil, nil, nil, nil, fmt.Errorf("option --insecure and --plaintext are mutually exclusive, they cannot be both specified at the same time")
 		}
 		switch {
 		case usePlainTextConnection:
@@ -195,14 +218,19 @@ func NewSubstreamsClient(config *SubstreamsClientConfig) (cli pbsubstreamsrpc.St
 	zlog.Debug("getting connection", zap.String("endpoint", endpoint))
 	conn, err := dgrpc.NewExternalClient(endpoint, dialOptions...)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to create external gRPC client: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("unable to create external gRPC client: %w", err)
 	}
 	closeFunc = conn.Close
 
 	if !skipAuth {
-		zlog.Debug("creating oauth access", zap.String("endpoint", endpoint))
-		creds := oauth.NewOauthAccess(&oauth2.Token{AccessToken: jwt, TokenType: "Bearer"})
-		callOpts = append(callOpts, grpc.PerRPCCredentials(creds))
+		if authType == JWT {
+			zlog.Debug("creating oauth access", zap.String("endpoint", endpoint))
+			tokenSource := oauth.TokenSource{TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: authToken, TokenType: "Bearer"})}
+			callOpts = append(callOpts, grpc.PerRPCCredentials(tokenSource))
+		} else if authType == ApiKey {
+			zlog.Debug("creating api key access", zap.String("endpoint", endpoint))
+			ctxRes = metadata.AppendToOutgoingContext(ctx, "x-api-key", authToken)
+		}
 	}
 
 	zlog.Debug("creating new client", zap.String("endpoint", endpoint))

--- a/client/headers.go
+++ b/client/headers.go
@@ -1,0 +1,24 @@
+package client
+
+type Headers map[string]string
+
+const ApiKeyHeader = "x-api-key"
+
+func (h Headers) Append(headers map[string]string) map[string]string {
+	for key, value := range headers {
+		h[key] = value
+	}
+	return h
+}
+
+func (h Headers) ToArray() []string {
+	res := make([]string, 0, len(h)*2)
+	for key, value := range h {
+		res = append(res, key, value)
+	}
+	return res
+}
+
+func (h Headers) IsSet() bool {
+	return len(h) > 0
+}

--- a/cmd/substreams/gui.go
+++ b/cmd/substreams/gui.go
@@ -20,6 +20,7 @@ import (
 
 func init() {
 	guiCmd.Flags().String("substreams-api-token-envvar", "SUBSTREAMS_API_TOKEN", "name of variable containing Substreams Authentication token")
+	guiCmd.Flags().String("substreams-api-key-envvar", "SUBSTREAMS_API_KEY", "Name of variable containing Substreams Api Key")
 	guiCmd.Flags().StringP("substreams-endpoint", "e", "", "Substreams gRPC endpoint. If empty, will be replaced by the SUBSTREAMS_ENDPOINT_{network_name} environment variable, where `network_name` is determined from the substreams manifest. Some network names have default endpoints.")
 	guiCmd.Flags().String("network", "", "Specify the network to use for params and initialBlocks, overriding the 'network' field in the substreams package")
 	guiCmd.Flags().Bool("insecure", false, "Skip certificate validation on GRPC connection")
@@ -112,9 +113,11 @@ func runGui(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("extracting endpoint: %w", err)
 	}
 
+	authToken, authType := tools.GetAuth(cmd, "substreams-api-key-envvar", "substreams-api-token-envvar")
 	substreamsClientConfig := client.NewSubstreamsClientConfig(
 		endpoint,
-		tools.ReadAPIToken(cmd, "substreams-api-token-envvar"),
+		authToken,
+		authType,
 		mustGetBool(cmd, "insecure"),
 		mustGetBool(cmd, "plaintext"),
 	)

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Added support for authentication using api keys. The env variable can be specified with `--substreams-api-key-envvar` and defaults to `SUBSTREAMS_API_KEY`.
+
 ## v1.3.5
 
 ### Code generation

--- a/tools/cmd.go
+++ b/tools/cmd.go
@@ -16,6 +16,7 @@ package tools
 
 import (
 	"fmt"
+	"github.com/streamingfast/substreams/client"
 	"os"
 	"time"
 
@@ -96,4 +97,31 @@ func ReadAPIToken(cmd *cobra.Command, envFlagName string) string {
 	}
 
 	return os.Getenv("SF_API_TOKEN")
+}
+
+func ReadAPIKey(cmd *cobra.Command, envFlagName string) string {
+	envVar := mustGetString(cmd, envFlagName)
+	value := os.Getenv(envVar)
+	if value != "" {
+		return value
+	}
+
+	return os.Getenv("SUBSTREAMS_API_KEY")
+}
+
+func GetAuth(cmd *cobra.Command, envFlagApiKey, envFlagJwt string) (authToken string, authType client.AuthType) {
+
+	authType = client.None
+
+	if authToken = ReadAPIKey(cmd, envFlagApiKey); authToken != "" {
+		authType = client.ApiKey
+		return
+	}
+
+	if authToken = ReadAPIToken(cmd, envFlagJwt); authToken != "" {
+		authType = client.JWT
+		return
+	}
+
+	return
 }

--- a/tools/prometheus-exporter.go
+++ b/tools/prometheus-exporter.go
@@ -77,7 +77,7 @@ func runPrometheus(cmd *cobra.Command, args []string) error {
 
 	outputStreamName := moduleName
 
-	apiToken := ReadAPIToken(cmd, "substreams-api-token-envvar")
+	authToken, authType := GetAuth(cmd, "substreams-api-key-envvar", "substreams-api-token-envvar")
 	insecure := mustGetBool(cmd, "insecure")
 	plaintext := mustGetBool(cmd, "plaintext")
 	interval := mustGetDuration(cmd, "lookup_interval")
@@ -85,7 +85,8 @@ func runPrometheus(cmd *cobra.Command, args []string) error {
 	for _, endpoint := range endpoints {
 		substreamsClientConfig := client.NewSubstreamsClientConfig(
 			endpoint,
-			apiToken,
+			authToken,
+			authType,
 			insecure,
 			plaintext,
 		)
@@ -136,7 +137,7 @@ func launchSubstreamsPoller(endpoint string, substreamsClientConfig *client.Subs
 
 		ctx, cancel := context.WithTimeout(context.Background(), pollingTimeout)
 		begin := time.Now()
-		ssClient, connClose, callOpts, err := client.NewSubstreamsClient(substreamsClientConfig)
+		ctx, ssClient, connClose, callOpts, err := client.NewSubstreamsClient(ctx, substreamsClientConfig)
 		if err != nil {
 			zlog.Error("substreams client setup", zap.Error(err))
 			maybeMarkFailure(endpoint, begin, counter)

--- a/tools/prometheus-exporter.go
+++ b/tools/prometheus-exporter.go
@@ -44,6 +44,7 @@ var prometheusCmd = &cobra.Command{
 func init() {
 	prometheusCmd.Flags().String("listen-addr", ":9102", "prometheus listen address")
 	prometheusCmd.Flags().String("substreams-api-token-envvar", "SUBSTREAMS_API_TOKEN", "name of variable containing Substreams Authentication token")
+	prometheusCmd.Flags().String("substreams-api-key-envvar", "SUBSTREAMS_API_KEY", "Name of variable containing Substreams Api Key")
 	prometheusCmd.Flags().BoolP("insecure", "k", false, "Skip certificate validation on GRPC connection")
 	prometheusCmd.Flags().BoolP("plaintext", "p", false, "Establish GRPC connection in plaintext")
 	prometheusCmd.Flags().Duration("lookup_interval", time.Second*20, "endpoints will be polled at this interval")

--- a/tools/tier2call.go
+++ b/tools/tier2call.go
@@ -24,6 +24,7 @@ var tier2CallCmd = &cobra.Command{
 
 func init() {
 	tier2CallCmd.Flags().String("substreams-api-token-envvar", "SUBSTREAMS_API_TOKEN", "name of variable containing Substreams Authentication token")
+	tier2CallCmd.Flags().String("substreams-api-key-envvar", "SUBSTREAMS_API_KEY", "Name of variable containing Substreams Api Key")
 	tier2CallCmd.Flags().StringP("substreams-endpoint", "e", "mainnet.eth.streamingfast.io:443", "Substreams gRPC endpoint")
 	tier2CallCmd.Flags().Bool("insecure", false, "Skip certificate validation on GRPC connection")
 	tier2CallCmd.Flags().Bool("plaintext", false, "Establish GRPC connection in plaintext")
@@ -62,9 +63,11 @@ func tier2CallE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("apply params: %w", err)
 	}
 
+	authToken, authType := GetAuth(cmd, "substreams-api-key-envvar", "substreams-api-token-envvar")
 	clientConfig := client.NewSubstreamsClientConfig(
 		mustGetString(cmd, "substreams-endpoint"),
-		ReadAPIToken(cmd, "substreams-api-token-envvar"),
+		authToken,
+		authType,
 		mustGetBool(cmd, "insecure"),
 		mustGetBool(cmd, "plaintext"),
 	)

--- a/tools/tier2call.go
+++ b/tools/tier2call.go
@@ -71,9 +71,14 @@ func tier2CallE(cmd *cobra.Command, args []string) error {
 		mustGetBool(cmd, "insecure"),
 		mustGetBool(cmd, "plaintext"),
 	)
-	ssClient, _, callOpts, err := client.NewSubstreamsInternalClient(clientConfig)
+	ssClient, _, callOpts, headers, err := client.NewSubstreamsInternalClient(clientConfig)
 	if err != nil {
 		return fmt.Errorf("new internal client: %w", err)
+	}
+
+	// add auth header if available
+	if headers.IsSet() {
+		ctx = metadata.AppendToOutgoingContext(ctx, headers.ToArray()...)
 	}
 	//parse additional-headers flag
 	additionalHeaders := mustGetStringSlice(cmd, "header")

--- a/tui2/pages/request/request.go
+++ b/tui2/pages/request/request.go
@@ -1,7 +1,6 @@
 package request
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -262,7 +261,7 @@ func (c *Config) NewInstance() (*Instance, error) {
 		c.StartBlock = int64(sb)
 	}
 
-	ctx, ssClient, _, callOpts, err := client.NewSubstreamsClient(context.Background(), c.SubstreamsClientConfig)
+	ssClient, _, callOpts, headers, err := client.NewSubstreamsClient(c.SubstreamsClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("substreams client setup: %w", err)
 	}
@@ -278,7 +277,8 @@ func (c *Config) NewInstance() (*Instance, error) {
 		DebugInitialStoreSnapshotForModules: c.DebugModulesInitialSnapshot,
 	}
 
-	stream := streamui.New(ctx, req, ssClient, c.Headers, callOpts)
+	c.Headers = headers.Append(c.Headers)
+	stream := streamui.New(req, ssClient, c.Headers, callOpts)
 
 	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("validate request: %w", err)

--- a/tui2/pages/request/request.go
+++ b/tui2/pages/request/request.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -261,7 +262,7 @@ func (c *Config) NewInstance() (*Instance, error) {
 		c.StartBlock = int64(sb)
 	}
 
-	ssClient, _, callOpts, err := client.NewSubstreamsClient(c.SubstreamsClientConfig)
+	ctx, ssClient, _, callOpts, err := client.NewSubstreamsClient(context.Background(), c.SubstreamsClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("substreams client setup: %w", err)
 	}
@@ -277,7 +278,7 @@ func (c *Config) NewInstance() (*Instance, error) {
 		DebugInitialStoreSnapshotForModules: c.DebugModulesInitialSnapshot,
 	}
 
-	stream := streamui.New(req, ssClient, c.Headers, callOpts)
+	stream := streamui.New(ctx, req, ssClient, c.Headers, callOpts)
 
 	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("validate request: %w", err)

--- a/tui2/stream/stream.go
+++ b/tui2/stream/stream.go
@@ -44,14 +44,13 @@ type Stream struct {
 	err error
 }
 
-func New(ctx context.Context, req *pbsubstreamsrpc.Request, client pbsubstreamsrpc.StreamClient, headers map[string]string, callOpts []grpc.CallOption) *Stream {
+func New(req *pbsubstreamsrpc.Request, client pbsubstreamsrpc.StreamClient, headers map[string]string, callOpts []grpc.CallOption) *Stream {
 	return &Stream{
 		req:            req,
 		targetEndBlock: req.StopBlockNum,
 		client:         client,
 		callOpts:       callOpts,
 		headers:        headers,
-		ctx:            ctx,
 	}
 }
 
@@ -127,7 +126,7 @@ func (s *Stream) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (s *Stream) StartStream() tea.Msg {
-	streamCtx, cancel := context.WithCancel(s.ctx)
+	streamCtx, cancel := context.WithCancel(context.Background())
 	headerArray := make([]string, 0, len(s.headers)*2)
 	for k, v := range s.headers {
 		headerArray = append(headerArray, k, v)

--- a/tui2/stream/stream.go
+++ b/tui2/stream/stream.go
@@ -44,13 +44,14 @@ type Stream struct {
 	err error
 }
 
-func New(req *pbsubstreamsrpc.Request, client pbsubstreamsrpc.StreamClient, headers map[string]string, callOpts []grpc.CallOption) *Stream {
+func New(ctx context.Context, req *pbsubstreamsrpc.Request, client pbsubstreamsrpc.StreamClient, headers map[string]string, callOpts []grpc.CallOption) *Stream {
 	return &Stream{
 		req:            req,
 		targetEndBlock: req.StopBlockNum,
 		client:         client,
 		callOpts:       callOpts,
 		headers:        headers,
+		ctx:            ctx,
 	}
 }
 
@@ -126,7 +127,7 @@ func (s *Stream) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (s *Stream) StartStream() tea.Msg {
-	streamCtx, cancel := context.WithCancel(context.Background())
+	streamCtx, cancel := context.WithCancel(s.ctx)
 	headerArray := make([]string, 0, len(s.headers)*2)
 	for k, v := range s.headers {
 		headerArray = append(headerArray, k, v)


### PR DESCRIPTION
This adds support for authentication using an `X-Api-Key` header set to the api key directly. The environment variable to read the api key from defaults to `SUBSTREAMS_API_KEY` but can be adapted using the `--substreams-api-key-envvar` flag. 

This does not remove support for token based authentication. If both the `SUBSTREAMS_API_KEY` and `SUBSTREAMS_API_TOKEN` env variable are set the api key takes precedence. 

Done:

- [x] Test `substreams run`
- [x] Test `substreams gui`
- [x] Test `substreams tools prometheus-exporter`
- [x] Add Changelog
- [x] Test `substreams proxy`

Todo:

- [ ] ~Test internal client authentication for tier1->tier2 calls~ (seems like this is not supported in firehose-core anymore?)
- [ ] Update docs (whenever your endpoints are ready)