### PR TITLE
Allow tier2 to run from existing mapper outputs only or to use them to skip some module re-execution

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Pick up docs from the README.md or README in the same directory as the manifest, when top-level package.doc is empty
 * Tier2 service now supports a maximum concurrent requests limit. Default set to 0 (unlimited). 
 * Improved file listing performance for Google Storage backends by 25%
+* Tier2 will now read back mapper outputs (if they exist) to prevent running them again. It will skip processing completely if their output_module is a mapper that has already been processed.
 
 ## v1.3.7
 

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Pick up docs from the README.md or README in the same directory as the manifest, when top-level package.doc is empty
 * Tier2 service now supports a maximum concurrent requests limit. Default set to 0 (unlimited). 
 * Improved file listing performance for Google Storage backends by 25%
-* Tier2 will now read back mapper outputs (if they exist) to prevent running them again. It will skip processing completely if their output_module is a mapper that has already been processed.
+* Tier2 will now read back mapper outputs (if they exist) to prevent running them again. Additionally, it will not read back the full blocks if its inputs can be satisfied from existing cached mapper outputs.
+* Tier2 will skip processing completely if the output_module is a mapper that has already been processed (ex: when multiple requests are indexing the same data at the same time)
 
 ## v1.3.7
 

--- a/pipeline/exec/module_executor_test.go
+++ b/pipeline/exec/module_executor_test.go
@@ -25,6 +25,10 @@ func (t *MockExecOutput) Clock() *pbsubstreams.Clock {
 	return t.clockFunc()
 }
 
+func (t *MockExecOutput) Len() int {
+	return 0
+}
+
 func (t *MockExecOutput) Get(name string) ([]byte, bool, error) {
 	v, ok := t.cacheMap[name]
 	if !ok {

--- a/pipeline/init_test.go
+++ b/pipeline/init_test.go
@@ -64,6 +64,13 @@ func NewExecOutputTesting(t *testing.T, block *pbbstream.Block, clock *pbsubstre
 	}
 }
 
+func (i *ExecOutputTesting) Len() (out int) {
+	for _, v := range i.Values {
+		out += len(v)
+	}
+	return
+}
+
 func (i *ExecOutputTesting) Get(moduleName string) (value []byte, cached bool, err error) {
 	val, found := i.Values[moduleName]
 	if !found {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -112,7 +112,7 @@ func New(
 	return pipe
 }
 
-func (p *Pipeline) init(ctx context.Context) (err error) {
+func (p *Pipeline) Init(ctx context.Context) (err error) {
 	reqDetails := reqctx.Details(ctx)
 
 	p.forkHandler.registerUndoHandler(func(clock *pbsubstreams.Clock, moduleOutputs []*pbssinternal.ModuleOutput) {
@@ -138,9 +138,6 @@ func (p *Pipeline) init(ctx context.Context) (err error) {
 }
 
 func (p *Pipeline) InitTier2Stores(ctx context.Context) (err error) {
-	if err := p.init(ctx); err != nil {
-		return err
-	}
 
 	storeMap, err := p.setupSubrequestStores(ctx)
 	if err != nil {
@@ -156,9 +153,6 @@ func (p *Pipeline) InitTier2Stores(ctx context.Context) (err error) {
 }
 
 func (p *Pipeline) InitTier1StoresAndBackprocess(ctx context.Context, reqPlan *plan.RequestPlan) (err error) {
-	if err := p.init(ctx); err != nil {
-		return err
-	}
 
 	if reqPlan.RequiresParallelProcessing() {
 		storeMap, err := p.runParallelProcess(ctx, reqPlan)

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/streamingfast/dmetering"
 	"github.com/streamingfast/substreams/metrics"
 	pbssinternal "github.com/streamingfast/substreams/pb/sf/substreams/intern/v2"
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
@@ -51,12 +50,16 @@ func (p *Pipeline) ProcessBlock(block *pbbstream.Block, obj interface{}) (err er
 		step = bstream.StepNewIrreversible // with finalBlocksOnly, we never get NEW signals so we fake any 'irreversible' signal as both
 	}
 
-	finalBlockHeight := obj.(bstream.Stepable).FinalBlockHeight()
 	reorgJunctionBlock := obj.(bstream.Stepable).ReorgJunctionBlock()
 
 	reqctx.ReqStats(ctx).RecordBlock(block.AsRef())
 	p.gate.processBlock(block.Number, step)
-	if err = p.processBlock(ctx, block, clock, cursor, step, finalBlockHeight, reorgJunctionBlock); err != nil {
+	execOutput, err := p.execOutputCache.NewBuffer(block, clock, cursor)
+	if err != nil {
+		return fmt.Errorf("setting up exec output: %w", err)
+	}
+
+	if err = p.processBlock(ctx, execOutput, clock, cursor, step, reorgJunctionBlock); err != nil {
 		return err // watch out, io.EOF needs to go through undecorated
 	}
 	return
@@ -79,11 +82,10 @@ func blockRefToPB(block bstream.BlockRef) *pbsubstreams.BlockRef {
 
 func (p *Pipeline) processBlock(
 	ctx context.Context,
-	block *pbbstream.Block,
+	execOutput execout.ExecutionOutput,
 	clock *pbsubstreams.Clock,
 	cursor *bstream.Cursor,
 	step bstream.StepType,
-	finalBlockHeight uint64,
 	reorgJunctionBlock bstream.BlockRef,
 ) (err error) {
 	var eof bool
@@ -102,10 +104,11 @@ func (p *Pipeline) processBlock(
 	case bstream.StepNew:
 		p.blockStepMap[bstream.StepNew]++
 		// metering of live blocks
-		payload := block.Payload.Value
-		dmetering.GetBytesMeter(ctx).AddBytesRead(len(payload))
+		// FIXME stepd
+		//payload := block.Payload.Value
+		//dmetering.GetBytesMeter(ctx).AddBytesRead(len(payload))
 
-		err = p.handleStepNew(ctx, block, clock, cursor)
+		err = p.handleStepNew(ctx, clock, cursor, execOutput)
 		if err != nil && err != io.EOF {
 			return fmt.Errorf("step new: handler step new: %w", err)
 		}
@@ -114,7 +117,7 @@ func (p *Pipeline) processBlock(
 		}
 	case bstream.StepNewIrreversible:
 		p.blockStepMap[bstream.StepNewIrreversible]++
-		err := p.handleStepNew(ctx, block, clock, cursor)
+		err = p.handleStepNew(ctx, clock, cursor, execOutput)
 		if err != nil && err != io.EOF {
 			return fmt.Errorf("step new irr: handler step new: %w", err)
 		}
@@ -133,11 +136,11 @@ func (p *Pipeline) processBlock(
 		}
 	}
 
-	if block.Number%500 == 0 {
+	if clock.Number%500 == 0 {
 		logger := reqctx.Logger(ctx)
 		// log the total number of StepNew and StepNewIrreversible blocks, and the ratio of the two
 		logger.Debug("block stats",
-			zap.Uint64("block_num", block.Number),
+			zap.Uint64("block_num", clock.Number),
 			zap.Uint64("step_new", p.blockStepMap[bstream.StepNew]),
 			zap.Uint64("step_new_irreversible", p.blockStepMap[bstream.StepNewIrreversible]),
 			zap.Float64("ratio", float64(p.blockStepMap[bstream.StepNewIrreversible])/float64(p.blockStepMap[bstream.StepNew])),
@@ -197,7 +200,7 @@ func (p *Pipeline) handleStepFinal(clock *pbsubstreams.Clock) error {
 	return nil
 }
 
-func (p *Pipeline) handleStepNew(ctx context.Context, block *pbbstream.Block, clock *pbsubstreams.Clock, cursor *bstream.Cursor) (err error) {
+func (p *Pipeline) handleStepNew(ctx context.Context, clock *pbsubstreams.Clock, cursor *bstream.Cursor, execOutput execout.ExecutionOutput) (err error) {
 	p.insideReorgUpTo = nil
 	reqDetails := reqctx.Details(ctx)
 
@@ -241,16 +244,13 @@ func (p *Pipeline) handleStepNew(ctx context.Context, block *pbbstream.Block, cl
 	}
 
 	logger := reqctx.Logger(ctx)
-	execOutput, err := p.execOutputCache.NewBuffer(block, clock, cursor)
-	if err != nil {
-		return fmt.Errorf("setting up exec output: %w", err)
-	}
 
 	if err := p.runPreBlockHooks(ctx, clock); err != nil {
 		return fmt.Errorf("pre block hook: %w", err)
 	}
 
-	dmetering.GetBytesMeter(ctx).CountInc("wasm_input_bytes", len(block.Payload.Value))
+	// FIXME stepd
+	//dmetering.GetBytesMeter(ctx).CountInc("wasm_input_bytes", len(block.Payload.Value))
 
 	if err := p.executeModules(ctx, execOutput); err != nil {
 		return fmt.Errorf("execute modules: %w", err)
@@ -270,7 +270,7 @@ func (p *Pipeline) handleStepNew(ctx context.Context, block *pbbstream.Block, cl
 	}
 
 	p.stores.resetStores()
-	logger.Debug("block processed", zap.Uint64("block_num", block.Number))
+	logger.Debug("block processed", zap.Uint64("block_num", clock.Number))
 	return nil
 }
 

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -23,6 +23,25 @@ import (
 	"github.com/streamingfast/substreams/storage/execout"
 )
 
+func (p *Pipeline) ProcessFromExecOutput(
+	ctx context.Context,
+	clock *pbsubstreams.Clock,
+	cursor *bstream.Cursor,
+) (err error) {
+	// TODO @stepd: add metrics back here too
+	p.gate.processBlock(clock.Number, bstream.StepNewIrreversible)
+	execOutput, err := p.execOutputCache.NewBuffer(nil, clock, cursor)
+	if err != nil {
+		return fmt.Errorf("setting up exec output: %w", err)
+	}
+
+	if err = p.processBlock(ctx, execOutput, clock, cursor, bstream.StepNewIrreversible, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (p *Pipeline) ProcessBlock(block *pbbstream.Block, obj interface{}) (err error) {
 	ctx := p.ctx
 

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -468,6 +468,9 @@ func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Requ
 		zap.String("output_module", request.OutputModule),
 	)
 
+	if err := pipe.Init(ctx); err != nil {
+		return fmt.Errorf("error during pipeline init: %w", err)
+	}
 	if err := pipe.InitTier1StoresAndBackprocess(ctx, reqPlan); err != nil {
 		return fmt.Errorf("error during init_stores_and_backprocess: %w", err)
 	}

--- a/storage/execout/buffer.go
+++ b/storage/execout/buffer.go
@@ -19,18 +19,21 @@ type Buffer struct {
 }
 
 func NewBuffer(blockType string, block *pbbstream.Block, clock *pbsubstreams.Clock) (*Buffer, error) {
-	blkBytes := block.Payload.Value
+	values := make(map[string][]byte)
+
 	clockBytes, err := proto.Marshal(clock)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling clock %d %q: %w", clock.Number, clock.Id, err)
 	}
+	values[wasm.ClockType] = clockBytes
+
+	if block != nil {
+		values[blockType] = block.Payload.Value
+	}
 
 	return &Buffer{
-		clock: clock,
-		values: map[string][]byte{
-			blockType:      blkBytes,
-			wasm.ClockType: clockBytes,
-		},
+		clock:  clock,
+		values: values,
 	}, nil
 }
 
@@ -43,7 +46,7 @@ func (i *Buffer) Get(moduleName string) (value []byte, cached bool, err error) {
 	if !found {
 		return nil, false, NotFound
 	}
-	return val, false, nil
+	return val, true, nil
 }
 
 func (i *Buffer) Set(moduleName string, value []byte) (err error) {

--- a/storage/execout/buffer.go
+++ b/storage/execout/buffer.go
@@ -18,6 +18,14 @@ type Buffer struct {
 	clock  *pbsubstreams.Clock
 }
 
+func (b *Buffer) Len() (out int) {
+	for _, v := range b.values {
+		out += len(v)
+	}
+
+	return
+}
+
 func NewBuffer(blockType string, block *pbbstream.Block, clock *pbsubstreams.Clock) (*Buffer, error) {
 	values := make(map[string][]byte)
 

--- a/storage/execout/config.go
+++ b/storage/execout/config.go
@@ -80,3 +80,12 @@ func (c *Config) ListSnapshotFiles(ctx context.Context, inRange *bstream.Range) 
 
 	return files, nil
 }
+
+func (c *Config) ReadFile(ctx context.Context, inrange *block.Range) (*File, error) {
+
+	file := c.NewFile(inrange)
+	if err := file.Load(ctx); err != nil {
+		return nil, err
+	}
+	return file, nil
+}

--- a/storage/execout/interface.go
+++ b/storage/execout/interface.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ExecutionOutputGetter interface {
+	Len() int
 	Clock() *pbsubstreams.Clock
 	Get(name string) (value []byte, cached bool, err error)
 }


### PR DESCRIPTION
* https://github.com/streamingfast/substreams/issues/417

This immediately allows the usage of a pattern where:

1) we create "thin blocks" through a mapper module and index it (production-mode)
2) we depend on these thin blocks in another module and skip reading the full blocks