### PR TITLE
print the subgraph deployment id if available as trusted header

### DIFF
--- a/service/tier1.go
+++ b/service/tier1.go
@@ -251,6 +251,10 @@ func (s *Tier1Service) Blocks(
 			zap.String("key_id", auth.APIKeyID()),
 			zap.String("ip_address", auth.RealIP()),
 		)
+		if auth["x-deployment-id"] != "" {
+			fields = append(fields, zap.String("deployment_id", auth["x-deployment-id"]))
+		}
+
 		if cacheTag := auth.Get("X-Sf-Substreams-Cache-Tag"); cacheTag != "" {
 			fields = append(fields,
 				zap.String("cache_tag", cacheTag),


### PR DESCRIPTION
The graph-node is now passing the deployment id when connecting to Substream endpoints, see here: https://github.com/graphprotocol/graph-node/pull/5319