### PR TITLE
Fix bug with block underflow in gui

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Substreams clients now enable gzip compression over the network (already supported by servers)
 * Fixed a failure in protogen where duplicate files would "appear multiple times" and fail
+* Fixed bug with block rate underflow in `gui`
 
 ## v1.7.0
 

--- a/tui2/pages/progress/progress.go
+++ b/tui2/pages/progress/progress.go
@@ -185,6 +185,10 @@ func (p *Progress) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			newBars[i] = newBar
 		}
 
+		if totalProcessedBlocks < p.lastCheckpointBlocks {
+			break
+		}
+
 		var mustResize bool
 		if len(newSlowestJobs) != len(p.slowestJobs) {
 			mustResize = true


### PR DESCRIPTION
Every few seconds (at least on our infra) gui would show wrong block rate due to uint underflow:

<img width="757" alt="Pasted Graphic 4" src="https://github.com/streamingfast/substreams/assets/29608734/6afe7f79-e136-4b8e-a3e3-bb19f9ae1a01">

I guess it happens because a progress message arrives in slightly wrong order.

This PR fixes it by making sure block count is always increasing.