### PR TITLE
Bugfix/metering

### DIFF
--- a/cmd/substreams/build.go
+++ b/cmd/substreams/build.go
@@ -39,11 +39,16 @@ func init() {
 func runBuildE(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
+	var manifestPath string
+	if len(args) > 1 && args[1] != "" {
+		manifestPath = args[1]
+	} else {
+		manifestPath = sflags.MustGetString(cmd, "manifest")
+	}
 	// Parse substreams.yaml
-	manifestPath := sflags.MustGetString(cmd, "manifest")
 	if manifestPath == "" {
 		var err error
-		manifestPath, err = findManifest()
+		manifestPath, err = findManifest(manifestPath)
 		if err != nil {
 			return fmt.Errorf("error finding manifest: %w", err)
 		}
@@ -316,17 +321,13 @@ func (s *SPKGPacker) Build(ctx context.Context) error {
 
 // findManifest searches for the substreams.yaml file starting from the current directory
 // and moving up to the parent directories until it finds the file or reaches the user's $HOME directory.
-func findManifest() (string, error) {
+func findManifest(originalPath string) (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("error getting user home directory: %w", err)
 	}
 
-	originalDir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("error getting current directory: %w", err)
-	}
-
+	originalDir := filepath.Dir(originalPath)
 	currentDir := originalDir
 	for {
 		manifestPath := filepath.Join(currentDir, "substreams.yaml")

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -125,7 +125,6 @@ func (p *Pipeline) processBlock(
 	case bstream.StepNew:
 		p.blockStepMap[bstream.StepNew]++
 
-		dmetering.GetBytesMeter(ctx).AddBytesRead(execOutput.Len())
 		err = p.handleStepNew(ctx, clock, cursor, execOutput)
 		if err != nil && err != io.EOF {
 			return fmt.Errorf("step new: handler step new: %w", err)

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -124,7 +124,6 @@ func (p *Pipeline) processBlock(
 		}
 	case bstream.StepNew:
 		p.blockStepMap[bstream.StepNew]++
-
 		err = p.handleStepNew(ctx, clock, cursor, execOutput)
 		if err != nil && err != io.EOF {
 			return fmt.Errorf("step new: handler step new: %w", err)

--- a/service/metering.go
+++ b/service/metering.go
@@ -17,11 +17,11 @@ func sendMetering(ctx context.Context, meter dmetering.Meter, userID, apiKeyID, 
 	inputBytes := meter.GetCount("wasm_input_bytes")
 	meter.ResetCount("wasm_input_bytes")
 
-	liveBytes := meter.GetCount("live_bytes_read")
-	if liveBytes > 0 {
-		panic("live_bytes should be 0 at this point")
-	}
-	meter.ResetCount("live_bytes_read")
+	uncompressedBytesRead := meter.GetCount("uncompressed_bytes_read")
+	meter.ResetCount("uncompressed_bytes_read")
+
+	uncompressedLiveBytesRead := meter.GetCount("uncompressed_live_bytes_read")
+	meter.ResetCount("uncompressed_live_bytes_read")
 
 	event := dmetering.Event{
 		UserID:    userID,
@@ -31,12 +31,13 @@ func sendMetering(ctx context.Context, meter dmetering.Meter, userID, apiKeyID, 
 
 		Endpoint: endpoint,
 		Metrics: map[string]float64{
-			"egress_bytes":     float64(egressBytes),
-			"written_bytes":    float64(bytesWritten),
-			"read_bytes":       float64(bytesRead),
-			"wasm_input_bytes": float64(inputBytes),
-			"live_bytes":       float64(liveBytes),
-			"message_count":    1,
+			"egress_bytes":                 float64(egressBytes),
+			"written_bytes":                float64(bytesWritten),
+			"read_bytes":                   float64(bytesRead),
+			"wasm_input_bytes":             float64(inputBytes),
+			"uncompressed_bytes_read":      float64(uncompressedBytesRead),
+			"uncompressed_live_bytes_read": float64(uncompressedLiveBytesRead),
+			"message_count":                1,
 		},
 		Timestamp: time.Now(),
 	}

--- a/service/metering.go
+++ b/service/metering.go
@@ -17,6 +17,12 @@ func sendMetering(ctx context.Context, meter dmetering.Meter, userID, apiKeyID, 
 	inputBytes := meter.GetCount("wasm_input_bytes")
 	meter.ResetCount("wasm_input_bytes")
 
+	liveBytes := meter.GetCount("live_bytes_read")
+	if liveBytes > 0 {
+		panic("live_bytes should be 0 at this point")
+	}
+	meter.ResetCount("live_bytes_read")
+
 	event := dmetering.Event{
 		UserID:    userID,
 		ApiKeyID:  apiKeyID,
@@ -29,6 +35,7 @@ func sendMetering(ctx context.Context, meter dmetering.Meter, userID, apiKeyID, 
 			"written_bytes":    float64(bytesWritten),
 			"read_bytes":       float64(bytesRead),
 			"wasm_input_bytes": float64(inputBytes),
+			"live_bytes":       float64(liveBytes),
 			"message_count":    1,
 		},
 		Timestamp: time.Now(),

--- a/service/metering.go
+++ b/service/metering.go
@@ -17,11 +17,11 @@ func sendMetering(ctx context.Context, meter dmetering.Meter, userID, apiKeyID, 
 	inputBytes := meter.GetCount("wasm_input_bytes")
 	meter.ResetCount("wasm_input_bytes")
 
-	uncompressedBytesRead := meter.GetCount("uncompressed_bytes_read")
-	meter.ResetCount("uncompressed_bytes_read")
+	uncompressedBytesRead := meter.GetCount("uncompressed_read_bytes")
+	meter.ResetCount("uncompressed_read_bytes")
 
-	uncompressedLiveBytesRead := meter.GetCount("uncompressed_live_bytes_read")
-	meter.ResetCount("uncompressed_live_bytes_read")
+	uncompressedLiveBytesRead := meter.GetCount("uncompressed_live_read_bytes")
+	meter.ResetCount("uncompressed_live_read_bytes")
 
 	event := dmetering.Event{
 		UserID:    userID,
@@ -35,8 +35,8 @@ func sendMetering(ctx context.Context, meter dmetering.Meter, userID, apiKeyID, 
 			"written_bytes":                float64(bytesWritten),
 			"read_bytes":                   float64(bytesRead),
 			"wasm_input_bytes":             float64(inputBytes),
-			"uncompressed_bytes_read":      float64(uncompressedBytesRead),
-			"uncompressed_live_bytes_read": float64(uncompressedLiveBytesRead),
+			"uncompressed_read_bytes":      float64(uncompressedBytesRead),
+			"uncompressed_live_read_bytes": float64(uncompressedLiveBytesRead),
 			"message_count":                1,
 		},
 		Timestamp: time.Now(),

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -577,11 +577,11 @@ func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Requ
 		case bstream.StepNewIrreversible:
 			// already metered by the store in compressed bytes.
 			// we will meter them here for potential future use
-			dmetering.GetBytesMeter(ctx).CountInc("uncompressed_bytes_read", len(blk.Payload.GetValue()))
+			dmetering.GetBytesMeter(ctx).CountInc("uncompressed_read_bytes", len(blk.Payload.GetValue()))
 		default:
 			// all other cases are live blocks to be metered
 			dmetering.GetBytesMeter(ctx).AddBytesRead(len(blk.Payload.GetValue()))
-			dmetering.GetBytesMeter(ctx).CountInc("uncompressed_live_bytes_read", len(blk.Payload.GetValue()))
+			dmetering.GetBytesMeter(ctx).CountInc("uncompressed_live_read_bytes", len(blk.Payload.GetValue()))
 		}
 
 		return streamHandler.ProcessBlock(blk, obj)

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -575,9 +575,11 @@ func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Requ
 		step := obj.(bstream.Stepable).Step()
 		switch step {
 		case bstream.StepNewIrreversible:
-			// comes from disk, already metered by dstore meters
-		default: // all other cases are live
-			dmetering.GetBytesMeter(ctx).CountInc("live_bytes_read", len(blk.Payload.GetValue()))
+			dmetering.GetBytesMeter(ctx).CountInc("uncompressed_bytes_read", len(blk.Payload.GetValue()))
+		default:
+			// all other cases are live blocks to be metered
+			dmetering.GetBytesMeter(ctx).AddBytesRead(len(blk.Payload.GetValue()))
+			dmetering.GetBytesMeter(ctx).CountInc("uncompressed_live_bytes_read", len(blk.Payload.GetValue()))
 		}
 
 		return streamHandler.ProcessBlock(blk, obj)

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -575,6 +575,8 @@ func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Requ
 		step := obj.(bstream.Stepable).Step()
 		switch step {
 		case bstream.StepNewIrreversible:
+			// already metered by the store in compressed bytes.
+			// we will meter them here for potential future use
 			dmetering.GetBytesMeter(ctx).CountInc("uncompressed_bytes_read", len(blk.Payload.GetValue()))
 		default:
 			// all other cases are live blocks to be metered


### PR DESCRIPTION
plan to fix metering:

* start by removing live bytes read at the old spot because this happens after some StepIrreversibles are converted to StepNewIrreversibles. 
* intercept the blocks in the hub to meter all blocks coming through