### PR TITLE
fix panic when using an index that allows 'skip_empty_output' 

### DIFF
--- a/pipeline/exec/baseexec.go
+++ b/pipeline/exec/baseexec.go
@@ -100,7 +100,7 @@ func canSkipExecution(wasmArgumentValues map[string][]byte, hasSingleParams bool
 	return true
 }
 
-func (e *BaseExecutor) wasmCall(outputGetter execout.ExecutionOutputGetter) (call *wasm.Call, err error) {
+func (e *BaseExecutor) wasmCall(outputGetter execout.ExecutionOutputGetter, canSkipEmptyOutput bool) (call *wasm.Call, err error) {
 	e.logs = nil
 	e.logsTruncated = false
 
@@ -118,7 +118,7 @@ func (e *BaseExecutor) wasmCall(outputGetter execout.ExecutionOutputGetter) (cal
 
 	stats := reqctx.ReqStats(e.ctx)
 	//t0 := time.Now()
-	call = wasm.NewCall(clock, e.moduleName, e.entrypoint, stats, e.wasmArguments)
+	call = wasm.NewCall(clock, e.moduleName, e.entrypoint, stats, e.wasmArguments, canSkipEmptyOutput)
 	inst, err = e.wasmModule.ExecuteNewCall(e.ctx, call, e.cachedInstance, e.wasmArguments, argValues)
 	//Timer += time.Since(t0)
 	if panicErr := call.Err(); panicErr != nil {

--- a/pipeline/exec/indexexec.go
+++ b/pipeline/exec/indexexec.go
@@ -35,7 +35,7 @@ func (i *IndexModuleExecutor) run(ctx context.Context, reader execout.ExecutionO
 	i.ctx = ctx
 
 	var call *wasm.Call
-	if call, err = i.wasmCall(reader); err != nil {
+	if call, err = i.wasmCall(reader, false); err != nil {
 		return nil, nil, nil, fmt.Errorf("maps wasm call: %w", err)
 	}
 

--- a/pipeline/exec/mapexec.go
+++ b/pipeline/exec/mapexec.go
@@ -37,7 +37,7 @@ func (e *MapperModuleExecutor) run(ctx context.Context, reader execout.Execution
 
 	e.ctx = ctx
 	var call *wasm.Call
-	if call, err = e.wasmCall(reader); err != nil {
+	if call, err = e.wasmCall(reader, true); err != nil {
 		return nil, nil, nil, fmt.Errorf("maps wasm call: %w", err)
 	}
 

--- a/pipeline/exec/storeexec.go
+++ b/pipeline/exec/storeexec.go
@@ -37,7 +37,7 @@ func (e *StoreModuleExecutor) run(ctx context.Context, reader execout.ExecutionO
 	defer span.EndWithErr(&err)
 	e.ctx = ctx
 
-	if _, err := e.wasmCall(reader); err != nil {
+	if _, err := e.wasmCall(reader, true); err != nil {
 		return nil, nil, nil, fmt.Errorf("store wasm call: %w", err)
 	}
 

--- a/wasm/bench/bench_test.go
+++ b/wasm/bench/bench_test.go
@@ -82,7 +82,7 @@ func BenchmarkExecution(b *testing.B) {
 				require.NoError(b, err)
 				defer cachedInstance.Close(ctx)
 
-				call := wasm.NewCall(nil, testCase.tag, testCase.entrypoint, stats, []wasm.Argument{testCase.argument.arg})
+				call := wasm.NewCall(nil, testCase.tag, testCase.entrypoint, stats, []wasm.Argument{testCase.argument.arg}, true)
 
 				b.ReportAllocs()
 				b.ResetTimer()

--- a/wasm/bench/cmd/wasigo/main.go
+++ b/wasm/bench/cmd/wasigo/main.go
@@ -47,7 +47,7 @@ func main() {
 			wasm.NewStoreWriterOutput("out", createStore(ctx, "out"), 1, "string"),
 		)
 
-		call := wasm.NewCall(nil, "mapBlock", "mapBlock", nil, args)
+		call := wasm.NewCall(nil, "mapBlock", "mapBlock", nil, args, false)
 		_, err = module.ExecuteNewCall(ctx, call, instance, args, map[string][]byte{argsVals.arg.Name(): argsVals.val})
 		if err != nil {
 			panic(fmt.Errorf("executing call: %w", err))

--- a/wasm/call.go
+++ b/wasm/call.go
@@ -24,9 +24,10 @@ type Call struct {
 
 	valueType string
 
-	returnValue     []byte
-	skipEmptyOutput bool
-	panicError      *PanicError
+	returnValue        []byte
+	skipEmptyOutput    bool
+	canSkipEmptyOutput bool // if false, takes precedence over skipEmptyOutput and disables that feature
+	panicError         *PanicError
 
 	Logs           []string
 	LogsByteCount  uint64
@@ -34,7 +35,7 @@ type Call struct {
 	stats          *metrics.Stats
 }
 
-func NewCall(clock *pbsubstreams.Clock, moduleName string, entrypoint string, stats *metrics.Stats, arguments []Argument) *Call {
+func NewCall(clock *pbsubstreams.Clock, moduleName string, entrypoint string, stats *metrics.Stats, arguments []Argument, canSkipEmptyOutput bool) *Call {
 	call := &Call{
 		Clock:      clock,
 		ModuleName: moduleName,
@@ -81,7 +82,7 @@ func (c *Call) SkipEmptyOutput() {
 }
 
 func (c *Call) CanSkipOutput() bool {
-	return c.skipEmptyOutput && len(c.returnValue) == 0
+	return c.canSkipEmptyOutput && c.skipEmptyOutput && len(c.returnValue) == 0
 }
 
 func (c *Call) SetPanicError(message string, filename string, lineNo int, colNo int) {


### PR DESCRIPTION
fix panic when using an index that allows 'skip_empty_output'  on blocks that don't produce any key for that index module