### PR TITLE
speed up modules lookup for stores

### DIFF
--- a/block/segmenter.go
+++ b/block/segmenter.go
@@ -94,3 +94,7 @@ func (s *Segmenter) EndsOnInterval(segmentIndex int) bool {
 	}
 	return s.Range(segmentIndex).ExclusiveEndBlock%s.interval == 0
 }
+
+func (s *Segmenter) SegmentSize() uint64 {
+	return s.interval
+}

--- a/orchestrator/parallelprocessor.go
+++ b/orchestrator/parallelprocessor.go
@@ -89,28 +89,14 @@ func BuildParallelProcessor(
 		}
 	}
 
-	// we may be here only for mapper, without stores
-	if reqPlan.BuildStores != nil {
-		err := stages.FetchStoresState(
-			ctx,
-			reqPlan.StoresSegmenter(),
-			storeConfigs,
-			execoutStorage,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("fetch stores storage state: %w", err)
-		}
-	} else {
-		err := stages.FetchStoresState(
-			ctx,
-			reqPlan.WriteOutSegmenter(),
-			storeConfigs,
-			execoutStorage,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("fetch stores storage state: %w", err)
-		}
-
+	err := stages.FetchCacheState(
+		ctx,
+		storeConfigs,
+		execoutStorage,
+		reqPlan.LinearPipeline != nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetch stores storage state: %w", err)
 	}
 
 	if os.Getenv("SUBSTREAMS_DEBUG_SCHEDULER_STATE") == "true" {

--- a/orchestrator/plan/requestplan.go
+++ b/orchestrator/plan/requestplan.go
@@ -123,6 +123,9 @@ func (p *RequestPlan) ModuleSegmenter(modInitBlock uint64) *block.Segmenter {
 }
 
 func (p *RequestPlan) WriteOutSegmenter() *block.Segmenter {
+	if p.WriteExecOut == nil {
+		return nil
+	}
 	return block.NewSegmenter(p.segmentInterval, p.WriteExecOut.StartBlock, p.WriteExecOut.ExclusiveEndBlock)
 }
 

--- a/orchestrator/stage/fetchstorage.go
+++ b/orchestrator/stage/fetchstorage.go
@@ -2,7 +2,6 @@ package stage
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/streamingfast/bstream"
 	"github.com/streamingfast/substreams/block"
@@ -13,45 +12,222 @@ import (
 	"github.com/streamingfast/substreams/storage/store/state"
 )
 
-func (s *Stages) FetchStoresState(
-	ctx context.Context,
-	segmenter *block.Segmenter,
-	storeConfigMap store.ConfigMap,
-	execoutConfigs *execout.Configs,
-) error {
+/*
+
+1) mappers-only (do not call fetchStoresStates) -> get mappers on the outputMapper range only
+
+2) stores, no linear segment (obviously bound)
+   a. check if we have the full mapper outputs cached on the segment
+   (if we do, break)
+   b. if not, check if we have the full stores at the beginning of each of our mapper output segments
+   (if we do, check the mappers on that range too and break)
+   c. if not, walk through all the stores (do we have to walk through the mappers anyway?)
+
+3) stores, with linear segment
+   a. check if we have the full mapper outputs cached on the segment AND the full store at the beginning of the linear segment
+    (if we do, break)
+   b. if not, check if we have the full stores at the beginning of each of our mapper output segments that needs to be reprocessed
+    (if we do, check the mappers on that range too and break)
+   c. if not, walk through all the stores (do we have to walk through the mappers anyway?)
+
+*/
+
+func (s *Stages) applyState(
+	mapperFiles execout.FileInfos,
+	state map[string]*state.StoreSnapshots,
+	resolvedStartBlock uint64,
+) (complete bool) {
+	var mapperName string
+
+	segmenter := s.storeSegmenter
+	if segmenter == nil {
+		segmenter = s.mapSegmenter
+	}
+
 	completes := make(unitMap)
 	partials := make(unitMap)
 
-	upToBlock := segmenter.ExclusiveEndBlock()
-
-	var mapperName string
-	var mapperFiles execout.FileInfos
-	if lastStage := s.stages[len(s.stages)-1]; lastStage.kind == KindMap {
-		if len(lastStage.storeModuleStates) != 1 {
-			panic("assertion: mapper stage should contain a single module")
+	for stageIdx, stage := range s.stages {
+		firstIndexes := make(map[string]int)
+		for _, mod := range stage.storeModuleStates {
+			firstIndexes[mod.name] = mod.segmenter.FirstIndex()
+		}
+		moduleCount := func(unit Unit) (out int) {
+			for _, mod := range stage.storeModuleStates {
+				if unit.Segment >= firstIndexes[mod.name] {
+					out++
+				}
+			}
+			return
 		}
 
-		mapperName = lastStage.storeModuleStates[0].name
-		conf := execoutConfigs.ConfigMap[mapperName]
-
-		if upToBlock != 0 {
-			from := segmenter.InitialBlock()
-			if upToBlock != from {
-				files, err := conf.ListSnapshotFiles(ctx, bstream.NewInclusiveRange(from, upToBlock))
-				if err != nil {
-					return fmt.Errorf("fetching mapper storage state: %w", err)
+		if stage.kind == KindMap {
+			if mapperFiles == nil {
+				continue
+			}
+			if stageIdx != len(s.stages)-1 {
+				panic("assertion: mapper stage is not the last stage")
+			}
+			for _, outputFile := range mapperFiles {
+				segmentIdx := s.mapSegmenter.IndexForEndBlock(outputFile.BlockRange.ExclusiveEndBlock)
+				rng := s.mapSegmenter.Range(segmentIdx)
+				if rng == nil || rng.ExclusiveEndBlock != outputFile.BlockRange.ExclusiveEndBlock {
+					continue
 				}
-				mapperFiles = files
+				unit := Unit{Stage: stageIdx, Segment: segmentIdx}
+				if allDone := markFound(completes, unit, mapperName, moduleCount(unit)); allDone {
+					s.markSegmentCompleted(unit)
+				}
+			}
+
+			continue
+		}
+
+		for _, mod := range stage.storeModuleStates {
+			files := state[mod.name]
+			modSegmenter := mod.segmenter
+
+			// TODO: what happens to the Unit's state if we don't have
+			// complete sores for all modules within?
+			// We'll need to do the same alignment of Complete stores
+			for _, fullKV := range files.FullKVFiles {
+				segmentIdx := modSegmenter.IndexForEndBlock(fullKV.Range.ExclusiveEndBlock)
+				rng := segmenter.Range(segmentIdx)
+				if rng == nil || rng.ExclusiveEndBlock != fullKV.Range.ExclusiveEndBlock {
+					continue
+				}
+				unit := Unit{Stage: stageIdx, Segment: segmentIdx}
+				if allDone := markFound(completes, unit, mod.name, moduleCount(unit)); allDone {
+					s.markSegmentCompleted(unit)
+				}
+			}
+
+			for _, partial := range files.Partials {
+				segmentIdx := modSegmenter.IndexForStartBlock(partial.Range.StartBlock)
+				rng := segmenter.Range(segmentIdx)
+				if rng == nil {
+					continue
+				}
+				if !rng.Equals(partial.Range) {
+					continue
+				}
+				unit := Unit{Stage: stageIdx, Segment: segmentIdx}
+
+				if s.getState(unit) == UnitCompleted {
+					// FullKVs take precedence over partial stores' presence.
+					continue
+				}
+
+				if allDone := markFound(partials, unit, mod.name, moduleCount(unit)); allDone {
+					s.MarkSegmentPartialPresent(unit)
+				}
+			}
+		}
+
+		s.MoveSegmentCompletedForward(stageIdx)
+	}
+
+	// here: must determine if we have enough or if we need to go back up
+	return true
+
+}
+
+func (s *Stages) FetchCacheState(
+	ctx context.Context,
+	storeConfigMap store.ConfigMap,
+	execoutConfigs *execout.Configs,
+	withLinearSegment bool,
+	resolvedStartBlock uint64,
+) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	outputMapper := s.getOutputMapperCache(ctx, s.mapSegmenter, execoutConfigs)
+
+	var nearStartBlock, nearEndBlock uint64
+	if s.mapSegmenter != nil {
+		nearStartBlock = s.mapSegmenter.InitialBlock()
+		nearEndBlock = s.mapSegmenter.ExclusiveEndBlock()
+	} else {
+		nearStartBlock = resolvedStartBlock / s.storeSegmenter.SegmentSize() * s.storeSegmenter.SegmentSize()
+		nearEndBlock = s.storeSegmenter.ExclusiveEndBlock()
+	}
+
+	stateFilesInNearRange := s.getStoreStates(ctx, storeConfigMap, nearStartBlock, nearEndBlock)
+
+	var outputMapperRes execout.FileInfos
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case res := <-outputMapper:
+		if res.Err != nil {
+			return res.Err
+		}
+		outputMapperRes = res.Ok
+	}
+	if outputMapperRes != nil {
+		start, end := consecutiveFilesRange(outputMapperRes)
+		if start <= s.mapSegmenter.InitialBlock() && end >= s.mapSegmenter.ExclusiveEndBlock() {
+			s.markAllOutputMapperSegmentsCompleted()
+			if !withLinearSegment {
+				return nil
 			}
 		}
 	}
 
-	// TODO: OPTIMIZATION: why load stores if there could be ExecOut data present
-	// on disk already, which avoid the need to do _any_ processing whatsoever?
-	state, err := state.FetchState(ctx, storeConfigMap, upToBlock)
-	if err != nil {
-		return fmt.Errorf("fetching stores storage state: %w", err)
+	var stateFilesInNearRangeRes map[string]*state.StoreSnapshots
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case res := <-stateFilesInNearRange:
+		if res.Err != nil {
+			return res.Err
+		}
+		stateFilesInNearRangeRes = res.Ok
 	}
+	if s.applyState(outputMapperRes, stateFilesInNearRangeRes, resolvedStartBlock) {
+		s.setShadowableSegment(s.globalSegmenter.IndexForStartBlock(resolvedStartBlock))
+		return nil
+	}
+
+	stateFilesBelowNearRange := s.getStoreStates(ctx, storeConfigMap, 0, nearStartBlock)
+
+	var stateFilesBelowNearRangeRes map[string]*state.StoreSnapshots
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case res := <-stateFilesBelowNearRange:
+		if res.Err != nil {
+			return res.Err
+		}
+		stateFilesBelowNearRangeRes = res.Ok
+	}
+	allStateFiles := appendStateFiles(stateFilesBelowNearRangeRes, stateFilesInNearRangeRes)
+	_ = s.applyState(outputMapperRes, allStateFiles, resolvedStartBlock)
+	s.setShadowableSegment(s.globalSegmenter.IndexForStartBlock(resolvedStartBlock))
+	return nil
+
+}
+
+func (s *Stages) getStoreStates(
+	ctx context.Context,
+	storeConfigMap store.ConfigMap,
+	from uint64,
+	to uint64,
+) <-chan ChanResult[map[string]*state.StoreSnapshots] {
+
+	var mapperName string
+	var mapperFiles execout.FileInfos
+
+	segmenter := s.storeSegmenter
+	if segmenter == nil {
+		segmenter = s.mapSegmenter
+	}
+
+	completes := make(unitMap)
+	partials := make(unitMap)
+
 	for stageIdx, stage := range s.stages {
 		firstIndexes := make(map[string]int)
 		for _, mod := range stage.storeModuleStates {
@@ -134,6 +310,86 @@ func (s *Stages) FetchStoresState(
 	// right after we fetch the state on disk, we can determine the shadowable segments
 	s.setShadowableSegment(segmenter.IndexForStartBlock(reqctx.Details(ctx).ResolvedStartBlockNum))
 	return nil
+}
+
+type ChanResult[T any] struct {
+	Ok  T
+	Err error
+}
+
+func (s *Stages) getOutputMapperCache(
+	ctx context.Context,
+	segmenter *block.Segmenter,
+	execoutConfigs *execout.Configs,
+) <-chan ChanResult[execout.FileInfos] {
+	out := make(chan ChanResult[execout.FileInfos], 1)
+
+	if segmenter == nil {
+		out <- ChanResult[execout.FileInfos]{Ok: nil, Err: nil}
+		return out
+	}
+
+	fromBlock := segmenter.InitialBlock()
+	upToBlock := segmenter.ExclusiveEndBlock()
+	if upToBlock == fromBlock {
+		out <- ChanResult[execout.FileInfos]{Ok: nil, Err: nil}
+		return out
+	}
+
+	lastStage := s.stages[len(s.stages)-1]
+	conf := execoutConfigs.ConfigMap[lastStage.storeModuleStates[0].name]
+
+	go func() {
+		files, err := conf.ListSnapshotFiles(ctx, bstream.NewInclusiveRange(fromBlock, upToBlock))
+		if err != nil {
+			out <- ChanResult[execout.FileInfos]{Ok: files, Err: nil}
+		} else {
+			out <- ChanResult[execout.FileInfos]{Ok: files, Err: nil}
+		}
+	}()
+
+	return out
+}
+
+func consecutiveFilesRange(files execout.FileInfos) (start uint64, exclusiveEnd uint64) {
+	if len(files) == 0 {
+		return 0, 0
+	}
+
+	start = files[0].BlockRange.StartBlock
+	last := files[0].BlockRange.ExclusiveEndBlock
+	for _, file := range files[1:] {
+		if last != file.BlockRange.StartBlock {
+			return
+		}
+		last = file.BlockRange.ExclusiveEndBlock
+	}
+	return
+}
+
+// caution: this modifies left and returns it
+func appendStateFiles(
+	left map[string]*state.StoreSnapshots,
+	right map[string]*state.StoreSnapshots,
+) map[string]*state.StoreSnapshots {
+	for name, files := range right {
+		if _, found := left[name]; !found {
+			left[name] = files
+		} else {
+			left[name].FullKVFiles = append(left[name].FullKVFiles, files.FullKVFiles...)
+			left[name].Partials = append(left[name].Partials, files.Partials...)
+			// left[name].Sort() already sorted in input
+		}
+	}
+	return left
+}
+
+func (s *Stages) markAllOutputMapperSegmentsCompleted() {
+	stageIdx := len(s.stages) - 1
+	for segmentIdx := s.mapSegmenter.FirstIndex(); segmentIdx <= s.mapSegmenter.LastIndex(); segmentIdx++ {
+		unit := Unit{Stage: stageIdx, Segment: segmentIdx}
+		s.markSegmentCompleted(unit)
+	}
 }
 
 type unitMap map[Unit]map[string]struct{}

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -2,6 +2,7 @@ package stage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -517,20 +518,57 @@ func (s *Stages) previousUnitComplete(u Unit) bool {
 	return state == UnitCompleted || state == UnitNoOp
 }
 
+type loadedStore struct {
+	name string
+	kv   *store.FullKV
+	err  error
+}
+
 func (s *Stages) FinalStoreMap(exclusiveEndBlock uint64) (store.Map, error) {
-	out := store.NewMap()
+
+	var storeModuleStates []*StoreModuleState
 	for _, stage := range s.stages {
 		if stage.kind != KindStore {
 			continue
 		}
 		for _, modState := range stage.storeModuleStates {
-			fullKV, err := modState.getStore(s.ctx, exclusiveEndBlock)
-			if err != nil {
-				return nil, fmt.Errorf("stores didn't sync up properly, expected store %q to be at block %d but was at %d: %w", modState.name, exclusiveEndBlock, modState.lastBlockInStore, err)
-			}
-			out[modState.name] = fullKV
+			storeModuleStates = append(storeModuleStates, modState)
 		}
 	}
+
+	out := store.NewMap()
+	if len(storeModuleStates) == 0 {
+		return out, nil
+	}
+
+	loadingChan := make(chan loadedStore, len(storeModuleStates))
+	for _, modState := range storeModuleStates {
+		modState := modState
+		go func() {
+			fullKV, err := modState.getStore(s.ctx, exclusiveEndBlock)
+			loadingChan <- loadedStore{
+				name: modState.name,
+				kv:   fullKV,
+				err:  err,
+			}
+		}()
+	}
+
+	var errs error
+	for loaded := range loadingChan {
+		if loaded.err != nil {
+			errs = errors.Join(errs, fmt.Errorf("while loading %s: %w", loaded.name, loaded.err))
+			continue
+		}
+		out[loaded.name] = loaded.kv
+		if len(out) == len(storeModuleStates) {
+			close(loadingChan)
+		}
+	}
+	if errs != nil {
+		return nil, errs
+	}
+
 	return out, nil
 }
 

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -130,6 +130,14 @@ func NewStages(
 	return out
 }
 
+func (s *Stages) HasStores() bool {
+	return s.storeSegmenter != nil
+}
+
+func (s *Stages) LastStageIsMapper() bool {
+	return s.mapSegmenter != nil
+}
+
 func layerKind(layer exec.LayerModules) Kind {
 	if layer.IsStoreLayer() {
 		return KindStore

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -29,6 +29,8 @@ import (
 	_ "github.com/streamingfast/substreams/wasm/wazero"
 )
 
+const testSegmentSize = uint64(100)
+
 func TestPipeline_runExecutor(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -187,7 +189,7 @@ func testConfigMap(t *testing.T, configs []testStoreConfig) store2.ConfigMap {
 	objStore := dstore.NewMockStore(nil)
 
 	for _, conf := range configs {
-		newStore, err := store2.NewConfig(conf.name, conf.initBlock, conf.name, pbsubstreams.Module_KindStore_UPDATE_POLICY_SET, "string", objStore)
+		newStore, err := store2.NewConfig(conf.name, conf.initBlock, testSegmentSize, conf.name, pbsubstreams.Module_KindStore_UPDATE_POLICY_SET, "string", objStore)
 		require.NoError(t, err)
 		confMap[newStore.Name()] = newStore
 
@@ -220,7 +222,7 @@ func withTestRequest(t *testing.T, outputModule string, startBlock uint64) conte
 		func() (uint64, error) { return 0, nil },
 		newTestCursorResolver().resolveCursor,
 		func() (uint64, error) { return 0, nil },
-		100,
+		testSegmentSize,
 	)
 	require.NoError(t, err)
 	return reqctx.WithRequest(context.Background(), req)

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -534,7 +534,7 @@ func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Requ
 		return fmt.Errorf("new config map: %w", err)
 	}
 
-	storeConfigs, err := store.NewConfigMap(cacheStore, execGraph.Stores(), execGraph.ModuleHashes(), chainFirstStreamableBlock)
+	storeConfigs, err := store.NewConfigMap(cacheStore, execGraph.Stores(), execGraph.ModuleHashes(), chainFirstStreamableBlock, segmentSize)
 	if err != nil {
 		return fmt.Errorf("configuring stores: %w", err)
 	}

--- a/service/tier2.go
+++ b/service/tier2.go
@@ -308,7 +308,7 @@ func (s *Tier2Service) processRange(ctx context.Context, request *pbssinternal.P
 		return fmt.Errorf("new config map: %w", err)
 	}
 
-	storeConfigs, err := store.NewConfigMap(cacheStore, execGraph.Stores(), execGraph.ModuleHashes(), request.FirstStreamableBlock)
+	storeConfigs, err := store.NewConfigMap(cacheStore, execGraph.Stores(), execGraph.ModuleHashes(), request.FirstStreamableBlock, request.SegmentSize)
 	if err != nil {
 		return fmt.Errorf("configuring stores: %w", err)
 	}

--- a/storage/store/config.go
+++ b/storage/store/config.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"runtime/trace"
 
 	"github.com/streamingfast/derr"
 	"github.com/streamingfast/dstore"
@@ -25,6 +26,7 @@ type Config struct {
 	updatePolicy       pbsubstreams.Module_KindStore_UpdatePolicy
 	valueType          string
 
+	segmentSize    uint64
 	appendLimit    uint64
 	totalSizeLimit uint64
 	itemSizeLimit  uint64
@@ -33,6 +35,7 @@ type Config struct {
 func NewConfig(
 	name string,
 	moduleInitialBlock uint64,
+	segmentSize uint64,
 	moduleHash string,
 	updatePolicy pbsubstreams.Module_KindStore_UpdatePolicy,
 	valueType string,
@@ -55,6 +58,7 @@ func NewConfig(
 		outputsStore:       outputsStore,
 		moduleInitialBlock: moduleInitialBlock,
 		moduleHash:         moduleHash,
+		segmentSize:        segmentSize,
 		appendLimit:        8_388_608,     // 8MiB = 8 * 1024 * 1024,
 		totalSizeLimit:     1_073_741_824, // 1GiB
 		itemSizeLimit:      10_485_760,    // 10MiB
@@ -130,12 +134,67 @@ func (c *Config) FileSize(ctx context.Context, fileInfo *FileInfo) (int64, error
 	return size, nil
 }
 
+func (c *Config) lowestAlignedBoundary() uint64 {
+	lowestBoundary := c.moduleInitialBlock / c.segmentSize * c.segmentSize
+	if lowestBoundary < c.moduleInitialBlock {
+		lowestBoundary += c.segmentSize
+	}
+	return lowestBoundary
+}
+
+func (c *Config) optimisticGetHighestFullSnapshotFile(ctx context.Context, upTo uint64) *FileInfo {
+	lowestAlignedBoundary := c.lowestAlignedBoundary()
+	if upTo <= (lowestAlignedBoundary + (c.segmentSize * 1000)) {
+		// below 1000 files we don't bother with this optimisation
+		return nil
+	}
+
+	lowestLookupBlock := upTo - c.segmentSize*10 // look for an existing 'fullKV snapshot' in the last 10 segments to skip the full walk
+
+	var highest *FileInfo
+	if err := derr.RetryContext(ctx, 3, func(ctx context.Context) error {
+		return c.objStore.WalkFrom(ctx, "", fmt.Sprintf("%010d", lowestLookupBlock), func(filename string) error {
+			fileInfo, ok := parseFileName(c.Name(), filename)
+			if !ok || fileInfo.Partial {
+				return nil
+			}
+
+			if fileInfo.Range.ExclusiveEndBlock > upTo {
+				return dstore.StopIteration
+			}
+			// Walk is always in ascending order
+			highest = fileInfo
+			return nil
+		})
+	}); err != nil {
+		return nil
+	}
+
+	return highest
+}
+
 func (c *Config) ListSnapshotFiles(ctx context.Context, below uint64) (files []*FileInfo, err error) {
+	logger := logging.Logger(ctx, zlog)
 	if below == 0 {
+		if trace.IsEnabled() {
+			logger.Debug("no files to list", zap.String("module_hash", c.moduleHash))
+		}
 		return nil, nil
 	}
 
-	logger := logging.Logger(ctx, zlog)
+	if highestFile := c.optimisticGetHighestFullSnapshotFile(ctx, below); highestFile != nil {
+		if trace.IsEnabled() {
+			logger.Debug("found a store fullKV file close to head, optimistically assuming existence of previous segments", zap.String("module_hash", c.moduleHash), zap.String("filename", highestFile.Filename))
+		}
+		lowestAlignedBoundary := c.lowestAlignedBoundary()
+		var files []*FileInfo
+		for i := lowestAlignedBoundary; i <= below; i += c.segmentSize {
+			fileInfo := NewCompleteFileInfo(c.Name(), c.ModuleInitialBlock(), i)
+			files = append(files, fileInfo)
+		}
+		return files, nil
+	}
+
 	err = derr.RetryContext(ctx, 3, func(ctx context.Context) error {
 		// We need to clear each time we start because a previous retry could have accumulated a partial state
 		files = nil
@@ -160,7 +219,10 @@ func (c *Config) ListSnapshotFiles(ctx context.Context, below uint64) (files []*
 				return nil
 			}
 
-			if fileInfo.Range.StartBlock >= below {
+			if fileInfo.Partial && fileInfo.Range.StartBlock > below {
+				return dstore.StopIteration
+			}
+			if !fileInfo.Partial && fileInfo.Range.ExclusiveEndBlock > below {
 				return dstore.StopIteration
 			}
 

--- a/storage/store/config.go
+++ b/storage/store/config.go
@@ -142,57 +142,18 @@ func (c *Config) lowestAlignedBoundary() uint64 {
 	return lowestBoundary
 }
 
-func (c *Config) optimisticGetHighestFullSnapshotFile(ctx context.Context, upTo uint64) *FileInfo {
-	lowestAlignedBoundary := c.lowestAlignedBoundary()
-	if upTo <= (lowestAlignedBoundary + (c.segmentSize * 1000)) {
-		// below 1000 files we don't bother with this optimisation
-		return nil
-	}
-
-	lowestLookupBlock := upTo - c.segmentSize*10 // look for an existing 'fullKV snapshot' in the last 10 segments to skip the full walk
-
-	var highest *FileInfo
-	if err := derr.RetryContext(ctx, 3, func(ctx context.Context) error {
-		return c.objStore.WalkFrom(ctx, "", fmt.Sprintf("%010d", lowestLookupBlock), func(filename string) error {
-			fileInfo, ok := parseFileName(c.Name(), filename)
-			if !ok || fileInfo.Partial {
-				return nil
-			}
-
-			if fileInfo.Range.ExclusiveEndBlock > upTo {
-				return dstore.StopIteration
-			}
-			// Walk is always in ascending order
-			highest = fileInfo
-			return nil
-		})
-	}); err != nil {
-		return nil
-	}
-
-	return highest
-}
-
-func (c *Config) ListSnapshotFiles(ctx context.Context, below uint64) (files []*FileInfo, err error) {
+func (c *Config) ListSnapshotFiles(ctx context.Context, from, upto uint64) (files []*FileInfo, err error) {
 	logger := logging.Logger(ctx, zlog)
-	if below == 0 {
+	if upto == 0 {
 		if trace.IsEnabled() {
 			logger.Debug("no files to list", zap.String("module_hash", c.moduleHash))
 		}
 		return nil, nil
 	}
 
-	if highestFile := c.optimisticGetHighestFullSnapshotFile(ctx, below); highestFile != nil {
-		if trace.IsEnabled() {
-			logger.Debug("found a store fullKV file close to head, optimistically assuming existence of previous segments", zap.String("module_hash", c.moduleHash), zap.String("filename", highestFile.Filename))
-		}
-		lowestAlignedBoundary := c.lowestAlignedBoundary()
-		var files []*FileInfo
-		for i := lowestAlignedBoundary; i <= below; i += c.segmentSize {
-			fileInfo := NewCompleteFileInfo(c.Name(), c.ModuleInitialBlock(), i)
-			files = append(files, fileInfo)
-		}
-		return files, nil
+	var fromStr string
+	if from != 0 {
+		fromStr = fmt.Sprintf("%010d", from)
 	}
 
 	err = derr.RetryContext(ctx, 3, func(ctx context.Context) error {
@@ -200,7 +161,7 @@ func (c *Config) ListSnapshotFiles(ctx context.Context, below uint64) (files []*
 		files = nil
 
 		deletedOldFiles := 0
-		return c.objStore.Walk(ctx, "", func(filename string) (err error) {
+		return c.objStore.WalkFrom(ctx, "", fromStr, func(filename string) (err error) {
 			fileInfo, ok := parseFileName(c.Name(), filename)
 			if !ok {
 				logger.Warn("seen snapshot file that we don't know how to parse", zap.String("filename", filename))
@@ -219,10 +180,10 @@ func (c *Config) ListSnapshotFiles(ctx context.Context, below uint64) (files []*
 				return nil
 			}
 
-			if fileInfo.Partial && fileInfo.Range.StartBlock > below {
+			if fileInfo.Partial && fileInfo.Range.StartBlock > upto {
 				return dstore.StopIteration
 			}
-			if !fileInfo.Partial && fileInfo.Range.ExclusiveEndBlock > below {
+			if !fileInfo.Partial && fileInfo.Range.ExclusiveEndBlock > upto {
 				return dstore.StopIteration
 			}
 

--- a/storage/store/config_test.go
+++ b/storage/store/config_test.go
@@ -41,7 +41,7 @@ func TestConfig_ListSnapshotFiles(t *testing.T) {
 
 	c := &Config{objStore: testStore, segmentSize: 1000}
 
-	files, err := c.ListSnapshotFiles(context.Background(), 10000)
+	files, err := c.ListSnapshotFiles(context.Background(), 0, 10000)
 	require.NoError(t, err)
 
 	var actualFiles []string

--- a/storage/store/config_test.go
+++ b/storage/store/config_test.go
@@ -39,7 +39,7 @@ func TestConfig_ListSnapshotFiles(t *testing.T) {
 		return nil
 	}
 
-	c := &Config{objStore: testStore}
+	c := &Config{objStore: testStore, segmentSize: 1000}
 
 	files, err := c.ListSnapshotFiles(context.Background(), 10000)
 	require.NoError(t, err)
@@ -50,4 +50,52 @@ func TestConfig_ListSnapshotFiles(t *testing.T) {
 	}
 
 	assert.Equal(t, expectedFiles, actualFiles)
+}
+
+func TestLowestAlignedBoundary(t *testing.T) {
+	tests := []struct {
+		name               string
+		moduleInitialBlock uint64
+		segmentSize        uint64
+		expected           uint64
+	}{
+		{
+			name:               "aligned initial block",
+			moduleInitialBlock: 1000,
+			segmentSize:        100,
+			expected:           1000,
+		},
+		{
+			name:               "unaligned initial block",
+			moduleInitialBlock: 1234,
+			segmentSize:        100,
+			expected:           1300,
+		},
+		{
+			name:               "initial block zero",
+			moduleInitialBlock: 0,
+			segmentSize:        100,
+			expected:           0,
+		},
+		{
+			name:               "large segment size",
+			moduleInitialBlock: 5000,
+			segmentSize:        10000,
+			expected:           10000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				moduleInitialBlock: tt.moduleInitialBlock,
+				segmentSize:        tt.segmentSize,
+			}
+
+			got := cfg.lowestAlignedBoundary()
+			if got != tt.expected {
+				t.Errorf("lowestAlignedBoundary() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
 }

--- a/storage/store/configmap.go
+++ b/storage/store/configmap.go
@@ -10,7 +10,7 @@ import (
 
 type ConfigMap map[string]*Config
 
-func NewConfigMap(baseObjectStore dstore.Store, storeModules []*pbsubstreams.Module, moduleHashes *manifest.ModuleHashes, firstStreamableBlock uint64) (out ConfigMap, err error) {
+func NewConfigMap(baseObjectStore dstore.Store, storeModules []*pbsubstreams.Module, moduleHashes *manifest.ModuleHashes, firstStreamableBlock uint64, segmentSize uint64) (out ConfigMap, err error) {
 	out = make(ConfigMap)
 	for _, storeModule := range storeModules {
 		initialBlock := storeModule.InitialBlock
@@ -20,6 +20,7 @@ func NewConfigMap(baseObjectStore dstore.Store, storeModules []*pbsubstreams.Mod
 		c, err := NewConfig(
 			storeModule.Name,
 			initialBlock,
+			segmentSize,
 			moduleHashes.Get(storeModule.Name),
 			storeModule.GetKindStore().UpdatePolicy,
 			storeModule.GetKindStore().ValueType,

--- a/storage/store/init_test.go
+++ b/storage/store/init_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testSegmentSize = uint64(100)
+
 func newTestBaseStore(
 	t require.TestingT,
 	updatePolicy pbsubstreams.Module_KindStore_UpdatePolicy,
@@ -25,7 +27,7 @@ func newTestBaseStore(
 		appendLimit = 10
 	}
 
-	config, err := NewConfig("test", 0, "test.module.hash", updatePolicy, valueType, store)
+	config, err := NewConfig("test", 0, testSegmentSize, "test.module.hash", updatePolicy, valueType, store)
 	config.appendLimit = appendLimit
 	config.totalSizeLimit = 9999
 	config.itemSizeLimit = 10_485_760

--- a/storage/store/state/snapshot.go
+++ b/storage/store/state/snapshot.go
@@ -8,10 +8,10 @@ import (
 	"github.com/streamingfast/substreams/storage/store"
 )
 
-func listSnapshots(ctx context.Context, storeConfig *store.Config, below uint64) (*storeSnapshots, error) {
-	out := &storeSnapshots{}
+func listSnapshots(ctx context.Context, storeConfig *store.Config, from, upto uint64) (*StoreSnapshots, error) {
+	out := &StoreSnapshots{}
 
-	files, err := storeConfig.ListSnapshotFiles(ctx, below)
+	files, err := storeConfig.ListSnapshotFiles(ctx, from, upto)
 	if err != nil {
 		return nil, fmt.Errorf("list snapshots: %w", err)
 	}
@@ -27,12 +27,12 @@ func listSnapshots(ctx context.Context, storeConfig *store.Config, below uint64)
 	return out, nil
 }
 
-type storeSnapshots struct {
+type StoreSnapshots struct {
 	FullKVFiles store.FileInfos // Shortest FullKVs first, largest last.
 	Partials    store.FileInfos // First partials first, last
 }
 
-func (s *storeSnapshots) Sort() {
+func (s *StoreSnapshots) Sort() {
 	sort.SliceStable(s.FullKVFiles, func(i, j int) bool {
 		return s.FullKVFiles[i].Range.ExclusiveEndBlock < s.FullKVFiles[j].Range.ExclusiveEndBlock
 	})
@@ -44,6 +44,6 @@ func (s *storeSnapshots) Sort() {
 	})
 }
 
-func (s *storeSnapshots) String() string {
+func (s *StoreSnapshots) String() string {
 	return fmt.Sprintf("completes=%s, partials=%s", s.FullKVFiles, s.Partials)
 }

--- a/storage/store/state/snapshotmap.go
+++ b/storage/store/state/snapshotmap.go
@@ -10,12 +10,12 @@ import (
 	"github.com/streamingfast/substreams/storage/store"
 )
 
-type storeSnapshotsMap struct {
+type StoreSnapshotsMap struct {
 	sync.Mutex
-	Snapshots map[string]*storeSnapshots
+	Snapshots map[string]*StoreSnapshots
 }
 
-func (s *storeSnapshotsMap) String() string {
+func (s *StoreSnapshotsMap) String() string {
 	var out []string
 	for k, v := range s.Snapshots {
 		out = append(out, fmt.Sprintf("store=%s (%s)", k, v))
@@ -23,9 +23,9 @@ func (s *storeSnapshotsMap) String() string {
 	return strings.Join(out, ", ")
 }
 
-func FetchState(ctx context.Context, storeConfigMap store.ConfigMap, below uint64) (*storeSnapshotsMap, error) {
-	state := &storeSnapshotsMap{
-		Snapshots: map[string]*storeSnapshots{},
+func FetchState(ctx context.Context, storeConfigMap store.ConfigMap, from, upto uint64) (*StoreSnapshotsMap, error) {
+	state := &StoreSnapshotsMap{
+		Snapshots: map[string]*StoreSnapshots{},
 	}
 
 	eg := llerrgroup.New(10)
@@ -39,7 +39,7 @@ func FetchState(ctx context.Context, storeConfigMap store.ConfigMap, below uint6
 		storeConfig := config
 
 		eg.Go(func() error {
-			snapshots, err := listSnapshots(ctx, storeConfig, below)
+			snapshots, err := listSnapshots(ctx, storeConfig, from, upto)
 			if err != nil {
 				return err
 			}

--- a/tools/analytics_store_stats.go
+++ b/tools/analytics_store_stats.go
@@ -246,7 +246,7 @@ func initializeStoreStats(conf *store.Config) *StoreStats {
 
 func getStore(ctx context.Context, conf *store.Config, below uint64) (store.Store, []*store.FileInfo, error) {
 	start := time.Now()
-	files, err := conf.ListSnapshotFiles(ctx, below)
+	files, err := conf.ListSnapshotFiles(ctx, 0, below)
 	if err != nil {
 		return nil, nil, fmt.Errorf("listing snapshot files: %w", err)
 	}

--- a/tools/analytics_store_stats.go
+++ b/tools/analytics_store_stats.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli/sflags"
 	"github.com/streamingfast/dstore"
 	"github.com/streamingfast/substreams/block"
 	"github.com/streamingfast/substreams/manifest"
@@ -29,6 +30,7 @@ var analyticsStoreStatsCmd = &cobra.Command{
 
 func init() {
 	analyticsCmd.AddCommand(analyticsStoreStatsCmd)
+	analyticsStoreStatsCmd.Flags().Uint64("segment-size", 1000, "number of blocks in each state file")
 }
 
 var ErrEmptyStore = errors.New("store is empty")
@@ -111,6 +113,7 @@ func StoreStatsE(cmd *cobra.Command, args []string) error {
 			conf, err := store.NewConfig(
 				module.Name,
 				module.InitialBlock,
+				sflags.MustGetUint64(cmd, "segment-size"),
 				hash,
 				module.GetKind().(*pbsubstreams.Module_KindStore_).KindStore.UpdatePolicy,
 				module.GetKind().(*pbsubstreams.Module_KindStore_).KindStore.ValueType,

--- a/tools/check.go
+++ b/tools/check.go
@@ -33,7 +33,7 @@ func checkE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create store: %w", err)
 	}
-	files, err := stateStore.ListSnapshotFiles(ctx, math.MaxUint64)
+	files, err := stateStore.ListSnapshotFiles(ctx, 0, math.MaxUint64)
 	if err != nil {
 		return fmt.Errorf("listing snapshots: %w", err)
 	}

--- a/tools/check.go
+++ b/tools/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/streamingfast/cli/sflags"
 	store2 "github.com/streamingfast/substreams/storage/store"
 	"go.uber.org/zap"
 
@@ -22,12 +23,13 @@ var checkCmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(checkCmd)
+	checkCmd.Flags().Uint64("segment-size", 1000, "number of blocks in each state file")
 }
 
 func checkE(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	stateStore, _, err := newStore(args[0])
+	stateStore, _, err := newStore(args[0], sflags.MustGetUint64(cmd, "segment-size"))
 	if err != nil {
 		return fmt.Errorf("failed to create store: %w", err)
 	}
@@ -58,13 +60,13 @@ func checkE(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func newStore(storeURL string) (*store2.FullKV, dstore.Store, error) {
+func newStore(storeURL string, segmentSize uint64) (*store2.FullKV, dstore.Store, error) {
 	remoteStore, err := dstore.NewStore(storeURL, "zst", "zstd", false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not create store from %s: %w", storeURL, err)
 	}
 
-	config, err := store2.NewConfig("", 0, "", pbsubstreams.Module_KindStore_UPDATE_POLICY_SET_IF_NOT_EXISTS, "", remoteStore)
+	config, err := store2.NewConfig("", 0, segmentSize, "", pbsubstreams.Module_KindStore_UPDATE_POLICY_SET_IF_NOT_EXISTS, "", remoteStore)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tools/cleanup.go
+++ b/tools/cleanup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/abourget/llerrgroup"
 	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli/sflags"
 	"go.uber.org/zap"
 )
 
@@ -18,14 +19,16 @@ var cleanUpCmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(cleanUpCmd)
+	cleanUpCmd.Flags().Uint64("segment-size", 1000, "number of blocks in each state file")
 }
 
 // delete all partial files which are already merged into the kv store
 func cleanUpE(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
+	segmentSize := sflags.MustGetUint64(cmd, "segment-size")
 	dsn := args[0]
-	store, remoteStore, err := newStore(dsn)
+	store, remoteStore, err := newStore(dsn, segmentSize)
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}

--- a/tools/cleanup.go
+++ b/tools/cleanup.go
@@ -36,7 +36,7 @@ func cleanUpE(cmd *cobra.Command, args []string) error {
 	highestKVBlock := uint64(0)
 	partialFiles := map[uint64]string{}
 
-	files, err := store.ListSnapshotFiles(ctx, math.MaxUint64)
+	files, err := store.ListSnapshotFiles(ctx, 0, math.MaxUint64)
 	if err != nil {
 		return fmt.Errorf("failed to list snapshots: %w", err)
 	}

--- a/tools/decode.go
+++ b/tools/decode.go
@@ -169,7 +169,7 @@ func runDecodeStatesModuleRunE(cmd *cobra.Command, args []string) error {
 	case *pbsubstreams.Module_KindMap_:
 		return fmt.Errorf("no states are available for a mapper")
 	case *pbsubstreams.Module_KindStore_:
-		return searchStateModule(ctx, startBlock, moduleHash, key, matchingModule, objStore, protoFiles)
+		return searchStateModule(ctx, startBlock, saveInterval, moduleHash, key, matchingModule, objStore, protoFiles)
 	}
 	return fmt.Errorf("module has an unknown")
 }
@@ -449,13 +449,14 @@ func searchOutputsModuleKvOps(
 func searchStateModule(
 	ctx context.Context,
 	startBlock uint64,
+	segmentSize uint64,
 	moduleHash string,
 	key string,
 	module *pbsubstreams.Module,
 	stateStore dstore.Store,
 	protoFiles []*descriptorpb.FileDescriptorProto,
 ) error {
-	config, err := store.NewConfig(module.Name, module.InitialBlock, moduleHash, module.GetKindStore().GetUpdatePolicy(), module.GetKindStore().GetValueType(), stateStore)
+	config, err := store.NewConfig(module.Name, module.InitialBlock, segmentSize, moduleHash, module.GetKindStore().GetUpdatePolicy(), module.GetKindStore().GetValueType(), stateStore)
 	if err != nil {
 		return fmt.Errorf("initializing store config module %q: %w", module.Name, err)
 	}

--- a/tools/module.go
+++ b/tools/module.go
@@ -126,7 +126,7 @@ func moduleRunE(cmd *cobra.Command, args []string) error {
 		)
 		cli.NoError(err, "unable to create store config")
 
-		out, err := store.ListSnapshotFiles(ctx, math.MaxUint64)
+		out, err := store.ListSnapshotFiles(ctx, 0, math.MaxUint64)
 		cli.NoError(err, "list snapshots")
 		for _, o := range out {
 			if o.Partial {

--- a/tools/module.go
+++ b/tools/module.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/streamingfast/cli"
+	"github.com/streamingfast/cli/sflags"
 	"github.com/streamingfast/derr"
 	"github.com/streamingfast/substreams/manifest"
 	store2 "github.com/streamingfast/substreams/storage/store"
@@ -30,6 +31,7 @@ var moduleCmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(moduleCmd)
+	moduleCmd.Flags().Uint64("segment-size", 1000, "number of blocks in each state file")
 }
 
 func moduleRunE(cmd *cobra.Command, args []string) error {
@@ -116,6 +118,7 @@ func moduleRunE(cmd *cobra.Command, args []string) error {
 		store, err := store2.NewConfig(
 			module.Name,
 			module.InitialBlock,
+			sflags.MustGetUint64(cmd, "segment-size"),
 			moduleHash,
 			module.GetKindStore().UpdatePolicy,
 			module.GetKindStore().ValueType,

--- a/wasm/bench/cmd/wasigo/main.go
+++ b/wasm/bench/cmd/wasigo/main.go
@@ -81,7 +81,7 @@ func createStore(_ context.Context, name string) *store.FullKV {
 	if err != nil {
 		panic(err)
 	}
-	storeConfig, err := store.NewConfig(name, 0, "hash.1", pbsubstreams.Module_KindStore_UPDATE_POLICY_UNSET, "string", ds)
+	storeConfig, err := store.NewConfig(name, 0, 1000, "hash.1", pbsubstreams.Module_KindStore_UPDATE_POLICY_UNSET, "string", ds)
 	if err != nil {
 		panic(err)
 	}

--- a/wasm/call_test.go
+++ b/wasm/call_test.go
@@ -482,7 +482,7 @@ func Test_CallStoreOps(t *testing.T) {
 
 func newTestCall(updatePolicy pbsubstreams.Module_KindStore_UpdatePolicy, valueType string) *Call {
 	myStore := dstore.NewMockStore(nil)
-	storeConf, err := store.NewConfig("test", 0, "", updatePolicy, valueType, myStore)
+	storeConf, err := store.NewConfig("test", 0, 100, "", updatePolicy, valueType, myStore)
 	if err != nil {
 		panic("failed")
 	}


### PR DESCRIPTION
*  if the last few snapshots before start-block are present, we don't walk the full stores.
* Since GCP cannot walk files in reverse, doing a lookup close to requested block first will most likely prevent doing a full walk on hundreds of thousands of files.
* Also, store loading is now in parallel.

Only effective in development mode now: we'll have to skip the lookups of the mappers in production mode too...