### PR TITLE
add mechanism to slow down tier2 processing ahead of execout walker

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Unreleased
 
 * Fix a bug where a 'worker pool' could incorrectly get exhausted
+* Added a mechanism for 'production-mode' requests where the tier1 will not schedule tier2 jobs over { max_parallel_subrequests } segments above the current block being streamed to the user.
+  This will ensure that a user slowly reading blocks 1, 2, 3... will not trigger a flood of tier2 jobs for higher blocks, let's say 300_000_000, that might never get read.
 
 ## v1.14.1
 

--- a/orchestrator/parallelprocessor.go
+++ b/orchestrator/parallelprocessor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/streamingfast/substreams"
 	orchestratorExecout "github.com/streamingfast/substreams/orchestrator/execout"
@@ -87,9 +88,23 @@ func (b *ParallelProcessor) Stages() *stage.Stages {
 	return b.scheduler.Stages
 }
 
-func (b *ParallelProcessor) Run(ctx context.Context) (storeMap store.Map, err error) {
+func (b *ParallelProcessor) Run(ctx context.Context, checkPendingShutdown func() bool) (storeMap store.Map, err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	go func() {
+		for {
+			select {
+			case <-time.Tick(time.Second):
+				if checkPendingShutdown() {
+					b.scheduler.Send(work.MsgPendingShutdown{})
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 
 	initCmd := b.scheduler.Init()
 	if err := b.scheduler.Run(ctx, initCmd); err != nil {

--- a/orchestrator/scheduler/scheduler.go
+++ b/orchestrator/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 	"github.com/streamingfast/substreams/reqctx"
 	"github.com/streamingfast/substreams/storage/store"
 )
+
+var errShuttingDown = errors.New("endpoint is shutting down, please reconnect")
 
 type Scheduler struct {
 	ctx context.Context
@@ -81,6 +84,9 @@ func (s *Scheduler) Update(msg loop.Msg) loop.Cmd {
 	var cmds []loop.Cmd
 
 	switch msg := msg.(type) {
+	case work.MsgPendingShutdown:
+		cmds = append(cmds, loop.Quit(errShuttingDown))
+
 	case work.MsgJobSucceeded:
 		shadowedUnits := s.Stages.MarkJobSuccess(msg.Unit)
 		s.WorkerPool.Return(s.ctx, msg.Worker)
@@ -143,10 +149,37 @@ func (s *Scheduler) Update(msg loop.Msg) loop.Cmd {
 				return nil //todo: wrap in a retry loop or just let it go through
 			}
 		}
-		workUnit, workRange := s.Stages.NextJob()
-		if workRange == nil { // End of job
+
+		notAboveSegment := math.MaxInt
+		if s.ExecOutWalker != nil {
+			first, current, _ := s.ExecOutWalker.Progress()
+			if current < first {
+				current = first // cover for execoutwalker initialisation
+			}
+			// if we have 10 maxParallelJobs, we don't schedule jobs more than 10 segments ahead of the execout walker
+			// This way, a client reading blocks very slowly will not cause the parallel processing of millions of blocks
+			notAboveSegment = current + int(reqctx.Details(s.ctx).MaxParallelJobs)
+		}
+
+		workUnit, workRange, skippedAboveSegment := s.Stages.NextJob(notAboveSegment)
+		if workRange == nil { // no job ready
 			s.WorkerPool.Return(s.ctx, worker)
-			return nil
+			if !skippedAboveSegment {
+				return nil
+			}
+
+			// this 'skippedAboveSegment' condition depends on the progress of the ExecOutWalker, which will not trigger a MsgScheduleNextJob,
+			// so we need to put it back in the loop ourselves.
+			// other conditions that would make new jobs available, like segment completion, will call 'MsgScheduleNextJob' themselves
+			if s.delayedScheduleNextJob {
+				s.logger.Debug("skipping ramp up delayed schedule next job")
+				return nil
+			}
+			s.delayedScheduleNextJob = true
+			return loop.Tick(10*time.Second, work.DelayedMsgScheduleNextJob{
+				TriggerBy: "linear reader backoff",
+			})
+
 		}
 
 		s.logger.Info("worker borrowed, scheduling work", zap.String("worker_id", worker.ID()), zap.Object("unit", workUnit))

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -376,7 +376,8 @@ func (s *Stages) WaitAsyncWork() error {
 	return nil
 }
 
-func (s *Stages) NextJob() (Unit, *block.Range) {
+// Returns the unit, its block range and a boolean indicating if we are backing off because of 'notAbove'
+func (s *Stages) NextJob(notAboveSegment int) (Unit, *block.Range, bool) {
 	// OPTIMIZATION: before calling NextJob, keep a small reserve (10% ?) of workers
 	//  so that when a job finishes, it can start immediately a potentially
 	//  higher priority one (we'll go do all those first-level jobs
@@ -422,16 +423,20 @@ func (s *Stages) NextJob() (Unit, *block.Range) {
 					u := Unit{Segment: segmentIdx, Stage: i}
 					if st := s.getState(u); st == UnitPending {
 						s.markSegmentScheduled(u)
-						return u, r
+						return u, r, false
 					}
 				}
 			}
 
+			if segmentIdx > notAboveSegment {
+				return Unit{}, nil, true
+			}
+
 			s.markSegmentScheduled(unit)
-			return unit, r
+			return unit, r, false
 		}
 	}
-	return Unit{}, nil
+	return Unit{}, nil, false
 }
 
 // setShadowableSegment sets the value to the first segment between

--- a/orchestrator/stage/stages_test.go
+++ b/orchestrator/stage/stages_test.go
@@ -3,6 +3,7 @@ package stage
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -58,12 +59,12 @@ func TestNewStageNextJobs(t *testing.T) {
 	)
 
 	noNextJob := func() {
-		_, r := stages.NextJob()
+		_, r, _ := stages.NextJob(math.MaxInt)
 		assert.Nil(t, r)
 	}
 
 	nextJob := func() Unit {
-		j, r := stages.NextJob()
+		j, r, _ := stages.NextJob(math.MaxInt)
 		if r == nil {
 			t.Error("no next job")
 		}
@@ -204,12 +205,12 @@ func TestNewStageNextJobs(t *testing.T) {
 }
 
 func assertNoNextJob(t *testing.T, stages *Stages) {
-	_, r := stages.NextJob()
+	_, r, _ := stages.NextJob(math.MaxInt)
 	assert.Nil(t, r)
 }
 
 func nextJob(t *testing.T, stages *Stages) Unit {
-	j, r := stages.NextJob()
+	j, r, _ := stages.NextJob(math.MaxInt)
 	if r == nil {
 		t.Error("no next job")
 	}

--- a/orchestrator/work/msgs.go
+++ b/orchestrator/work/msgs.go
@@ -20,6 +20,10 @@ type MsgJobSucceeded struct {
 	Worker Worker
 }
 
+type MsgPendingShutdown struct {
+	loop.IsMsg
+}
+
 type MsgScheduleNextJob struct {
 	loop.IsMsg
 	TriggerBy string

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -364,7 +364,7 @@ func (p *Pipeline) runParallelProcess(ctx context.Context, reqPlan *plan.Request
 
 	logger.Debug("starting parallel processing")
 
-	storeMap, err = parallelProcessor.Run(ctx)
+	storeMap, err = parallelProcessor.Run(ctx, p.checkPendingShutdown)
 	if err != nil {
 		return nil, fmt.Errorf("parallel processing run: %w", err)
 	}


### PR DESCRIPTION
* when there is an "execout walker", tier2 jobs will not be scheduled too far ahead of its progression. The limit has been set to 'current segment + max_parallel_workers'
* handle shutdown gracefully while processing tier2 jobs
