### PR TITLE
dedupe modules with same hash when computing graph.

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   buf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: "${{ !startsWith(github.event.head_commit.message, 'GitBook: [#') }}"
     permissions:
       contents: read
@@ -34,7 +34,7 @@ jobs:
         uses: bufbuild/buf-breaking-action@v1
         with:
           input: proto
-          against: 'https://github.com/${{ github.repository }}.git#branch=${{ github.base_ref }}'
+          against: "https://github.com/${{ github.repository }}.git#branch=${{ github.base_ref }}"
 
       - uses: bufbuild/buf-push-action@v1
         if: github.event_name != 'pull_request'

--- a/pipeline/exec/graph.go
+++ b/pipeline/exec/graph.go
@@ -14,7 +14,7 @@ type Graph struct {
 	requestModules        *pbsubstreams.Modules
 	usedModules           []*pbsubstreams.Module // all modules that need to be processed (requested directly or a required module ancestor)
 	stagedUsedModules     ExecutionStages        // all modules that need to be processed (requested directly or a required module ancestor)
-	moduleHashes          *manifest.ModuleHashes
+	moduleHashes          map[string]string
 	stores                []*pbsubstreams.Module // subset of allModules: only the stores
 	modulesInitBlocks     map[string]uint64
 	lowestInitBlock       uint64
@@ -23,6 +23,8 @@ type Graph struct {
 
 	schedulableModules      []*pbsubstreams.Module // stores and output mappers needed to execute to produce output for all `output_modules`.
 	schedulableAncestorsMap map[string][]string    // modules that are ancestors (therefore dependencies) of a given module
+
+	deduped bool
 }
 
 func (g *Graph) OutputModule() *pbsubstreams.Module  { return g.outputModule }
@@ -63,7 +65,7 @@ func (g *Graph) UsedIndexesModulesUpToStage(stage int) (out []*pbsubstreams.Modu
 }
 func (g *Graph) StagedUsedModules() ExecutionStages   { return g.stagedUsedModules }
 func (g *Graph) IsOutputModule(name string) bool      { return g.outputModule.Name == name }
-func (g *Graph) ModuleHashes() *manifest.ModuleHashes { return g.moduleHashes }
+func (g *Graph) ModuleHashes() map[string]string      { return g.moduleHashes }
 func (g *Graph) LowestInitBlock() uint64              { return g.lowestInitBlock }
 func (g *Graph) LowestStoresInitBlock() *uint64       { return g.lowestStoresInitBlock }
 func (g *Graph) ModulesInitBlocks() map[string]uint64 { return g.modulesInitBlocks }
@@ -80,6 +82,85 @@ func NewOutputModuleGraph(outputModule string, productionMode bool, modules *pbs
 	return out, nil
 }
 
+// copyMod will copy the module and replace all its dependencies with their canonical names.
+func copyMod(inMod *pbsubstreams.Module, nameToCanonical map[string]string) *pbsubstreams.Module {
+	outMod := &pbsubstreams.Module{
+		Name:             inMod.Name,
+		Kind:             inMod.Kind,
+		BinaryIndex:      inMod.BinaryIndex,
+		BinaryEntrypoint: inMod.BinaryEntrypoint,
+		InitialBlock:     inMod.InitialBlock,
+		Output:           inMod.Output,
+	}
+
+	for _, input := range inMod.Inputs {
+		switch {
+		case input.GetParams() != nil,
+			input.GetSource() != nil:
+			outMod.Inputs = append(outMod.Inputs, input)
+		case input.GetMap() != nil:
+			outMod.Inputs = append(outMod.Inputs, &pbsubstreams.Module_Input{
+				Input: &pbsubstreams.Module_Input_Map_{
+					Map: &pbsubstreams.Module_Input_Map{
+						ModuleName: nameToCanonical[input.GetMap().ModuleName],
+					},
+				},
+			})
+		case input.GetStore() != nil:
+			outMod.Inputs = append(outMod.Inputs, &pbsubstreams.Module_Input{
+				Input: &pbsubstreams.Module_Input_Store_{
+					Store: &pbsubstreams.Module_Input_Store{
+						ModuleName: nameToCanonical[input.GetStore().ModuleName],
+						Mode:       input.GetStore().Mode,
+					},
+				},
+			})
+		}
+	}
+
+	if inMod.BlockFilter != nil {
+		outMod.BlockFilter = &pbsubstreams.Module_BlockFilter{
+			Module: nameToCanonical[inMod.BlockFilter.Module],
+			Query:  inMod.BlockFilter.Query,
+		}
+	}
+	return outMod
+}
+
+func (g *Graph) dedupeModules(mods *pbsubstreams.Modules) (*pbsubstreams.Modules, bool) {
+	hashToNames := make(map[string][]string)
+	for name, hash := range g.moduleHashes {
+		hashToNames[hash] = append(hashToNames[hash], name)
+	}
+
+	nameToCanonical := make(map[string]string)
+	for _, names := range hashToNames {
+		canonicalName := names[0]
+		for _, name := range names {
+			fmt.Println("comparing name", name, "with", canonicalName)
+			if name < canonicalName {
+				canonicalName = name
+			}
+		}
+		for _, name := range names {
+			nameToCanonical[name] = canonicalName
+		}
+	}
+
+	var deduped bool
+	var filteredModules []*pbsubstreams.Module
+
+	for _, mod := range mods.Modules {
+		if mod.Name == nameToCanonical[mod.Name] {
+			filteredModules = append(filteredModules, copyMod(mod, nameToCanonical))
+			continue
+		}
+		deduped = true
+	}
+
+	return &pbsubstreams.Modules{Modules: filteredModules}, deduped
+}
+
 func (g *Graph) computeGraph(outputModule string, productionMode bool, modules *pbsubstreams.Modules, firstStreamableBlock uint64) error {
 	graph, err := manifest.NewModuleGraph(modules.Modules)
 	if err != nil {
@@ -92,17 +173,6 @@ func (g *Graph) computeGraph(outputModule string, productionMode bool, modules *
 		return fmt.Errorf("building execution moduleGraph: %w", err)
 	}
 	g.usedModules = processModules
-	g.modulesInitBlocks = map[string]uint64{}
-	for _, mod := range g.usedModules {
-		initialBlock := mod.InitialBlock
-		if initialBlock == 0 {
-			initialBlock = firstStreamableBlock
-		} else if initialBlock < firstStreamableBlock {
-			return fmt.Errorf("module %q has initial block %d smaller than first streamable block %d", mod.Name, initialBlock, firstStreamableBlock)
-		}
-		g.modulesInitBlocks[mod.Name] = initialBlock
-	}
-
 	g.stagedUsedModules, err = computeStages(g.usedModules, g.modulesInitBlocks)
 	if err != nil {
 		return err
@@ -112,6 +182,34 @@ func (g *Graph) computeGraph(outputModule string, productionMode bool, modules *
 	g.lowestStoresInitBlock = computeLowestStoresInitBlock(processModules, firstStreamableBlock)
 	if err := g.hashModules(graph); err != nil {
 		return fmt.Errorf("cannot hash module: %w", err)
+	}
+
+	if newModules, deduped := g.dedupeModules(modules); deduped {
+		graph, err = manifest.NewModuleGraph(newModules.Modules)
+		if err != nil {
+			return fmt.Errorf("compute graph: %w", err)
+		}
+		g.deduped = true
+		processModules, err = graph.ModulesDownTo(outputModuleName)
+		if err != nil {
+			return fmt.Errorf("building execution moduleGraph: %w", err)
+		}
+		g.usedModules = processModules
+		g.stagedUsedModules, err = computeStages(g.usedModules, g.modulesInitBlocks)
+		if err != nil {
+			return err
+		}
+	}
+
+	g.modulesInitBlocks = map[string]uint64{}
+	for _, mod := range g.usedModules {
+		initialBlock := mod.InitialBlock
+		if initialBlock == 0 {
+			initialBlock = firstStreamableBlock
+		} else if initialBlock < firstStreamableBlock {
+			return fmt.Errorf("module %q has initial block %d smaller than first streamable block %d", mod.Name, initialBlock, firstStreamableBlock)
+		}
+		g.modulesInitBlocks[mod.Name] = initialBlock
 	}
 
 	g.outputModule = computeOutputModule(g.usedModules, outputModuleName)
@@ -385,12 +483,21 @@ func moduleNames(modules []*pbsubstreams.Module) (out []string) {
 }
 
 func (g *Graph) hashModules(graph *manifest.ModuleGraph) error {
-	g.moduleHashes = manifest.NewModuleHashes()
+	if g.deduped {
+		return fmt.Errorf("cannot hash modules after deduping")
+	}
+	hashes := manifest.NewModuleHashes()
 	for _, module := range g.usedModules {
-		if _, err := g.moduleHashes.HashModule(g.requestModules, module, graph); err != nil {
+		if _, err := hashes.HashModule(g.requestModules, module, graph); err != nil {
 			return err
 		}
 	}
+	g.moduleHashes = make(map[string]string)
+	hashes.Iter(func(hash, name string) error {
+		g.moduleHashes[name] = hash
+		return nil
+	})
+
 	return nil
 }
 

--- a/pipeline/exec/graph.go
+++ b/pipeline/exec/graph.go
@@ -137,7 +137,6 @@ func (g *Graph) dedupeModules(mods *pbsubstreams.Modules) (*pbsubstreams.Modules
 	for _, names := range hashToNames {
 		canonicalName := names[0]
 		for _, name := range names {
-			fmt.Println("comparing name", name, "with", canonicalName)
 			if name < canonicalName {
 				canonicalName = name
 			}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -650,7 +650,7 @@ func (p *Pipeline) BuildModuleExecutors(ctx context.Context) error {
 					baseExecutor := exec.NewBaseExecutor(
 						ctx,
 						module.Name,
-						p.execGraph.ModuleHashes().Get(module.Name),
+						p.execGraph.ModuleHashes()[module.Name],
 						modulesInitBlocks[module.Name],
 						mod,
 						p.wasmRuntime.InstanceCacheEnabled(),
@@ -675,7 +675,7 @@ func (p *Pipeline) BuildModuleExecutors(ctx context.Context) error {
 					baseExecutor := exec.NewBaseExecutor(
 						ctx,
 						module.Name,
-						p.execGraph.ModuleHashes().Get(module.Name),
+						p.execGraph.ModuleHashes()[module.Name],
 						modulesInitBlocks[module.Name],
 						mod,
 						p.wasmRuntime.InstanceCacheEnabled(),
@@ -694,7 +694,7 @@ func (p *Pipeline) BuildModuleExecutors(ctx context.Context) error {
 					baseExecutor := exec.NewBaseExecutor(
 						ctx,
 						module.Name,
-						p.execGraph.ModuleHashes().Get(module.Name),
+						p.execGraph.ModuleHashes()[module.Name],
 						modulesInitBlocks[module.Name],
 						mod,
 						p.wasmRuntime.InstanceCacheEnabled(),

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -345,7 +345,7 @@ func (s *Tier1Service) Blocks(
 		return err
 	}
 
-	outputModuleHash := execGraph.ModuleHashes().Get(request.OutputModule)
+	outputModuleHash := execGraph.ModuleHashes()[request.OutputModule]
 
 	ctx = reqctx.WithOutputModuleHash(ctx, outputModuleHash)
 	fields = append(fields, zap.String("output_module_hash", outputModuleHash))
@@ -446,7 +446,7 @@ func (s *Tier1Service) writePackage(ctx context.Context, request *pbsubstreamsrp
 		return fmt.Errorf("marshalling package: %w", err)
 	}
 
-	moduleStore, err := cacheStore.SubStore(execGraph.ModuleHashes().Get(request.OutputModule))
+	moduleStore, err := cacheStore.SubStore(execGraph.ModuleHashes()[request.OutputModule])
 	if err != nil {
 		return fmt.Errorf("getting substore: %w", err)
 	}
@@ -464,7 +464,7 @@ func (s *Tier1Service) writePackage(ctx context.Context, request *pbsubstreamsrp
 
 func (s *Tier1Service) writeLastUsed(ctx context.Context, execGraph *exec.Graph, cacheStore dstore.Store) error {
 	for _, module := range execGraph.UsedModules() {
-		moduleStore, err := cacheStore.SubStore(execGraph.ModuleHashes().Get(module.Name))
+		moduleStore, err := cacheStore.SubStore(execGraph.ModuleHashes()[module.Name])
 		if err != nil {
 			return fmt.Errorf("getting substore: %w", err)
 		}
@@ -830,7 +830,7 @@ func tier1ResponseHandler(ctx context.Context, mut *sync.Mutex, logger *zap.Logg
 
 func (s *Tier1Service) containsDeterministicError(ctx context.Context, startBlock, endBlock uint64, execGraph *exec.Graph, cacheStore dstore.Store) error {
 	for _, module := range execGraph.UsedModules() {
-		moduleStore, err := cacheStore.SubStore(execGraph.ModuleHashes().Get(module.Name))
+		moduleStore, err := cacheStore.SubStore(execGraph.ModuleHashes()[module.Name])
 		if err != nil {
 			return fmt.Errorf("getting substore: %w", err)
 		}

--- a/service/tier2.go
+++ b/service/tier2.go
@@ -229,7 +229,7 @@ func (s *Tier2Service) ProcessRange(request *pbssinternal.ProcessRangeRequest, s
 		logger.Info("refusing Substreams ProcessRange request", fields...)
 		return err
 	}
-	outputModuleHash := execGraph.ModuleHashes().Get(request.OutputModule)
+	outputModuleHash := execGraph.ModuleHashes()[request.OutputModule]
 
 	logger.Info("incoming substreams ProcessRange request", fields...)
 

--- a/storage/execout/configs.go
+++ b/storage/execout/configs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/streamingfast/dstore"
 	"github.com/streamingfast/substreams/block"
-	"github.com/streamingfast/substreams/manifest"
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 	"go.uber.org/zap"
 )
@@ -16,7 +15,7 @@ type Configs struct {
 	logger                 *zap.Logger
 }
 
-func NewConfigs(baseObjectStore dstore.Store, allRequestedModules []*pbsubstreams.Module, moduleHashes *manifest.ModuleHashes, execOutputSaveInterval uint64, firstStreamableBlock uint64, logger *zap.Logger) (*Configs, error) {
+func NewConfigs(baseObjectStore dstore.Store, allRequestedModules []*pbsubstreams.Module, moduleHashes map[string]string, execOutputSaveInterval uint64, firstStreamableBlock uint64, logger *zap.Logger) (*Configs, error) {
 	out := make(map[string]*Config)
 	for _, mod := range allRequestedModules {
 
@@ -28,7 +27,7 @@ func NewConfigs(baseObjectStore dstore.Store, allRequestedModules []*pbsubstream
 			mod.Name,
 			initialBlock,
 			mod.ModuleKind(),
-			moduleHashes.Get(mod.Name),
+			moduleHashes[mod.Name],
 			baseObjectStore,
 			logger,
 		)

--- a/storage/execout/file.go
+++ b/storage/execout/file.go
@@ -1,7 +1,6 @@
 package execout
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -11,6 +10,7 @@ import (
 	"sync"
 
 	pboutput "github.com/streamingfast/substreams/storage/execout/pb"
+	"github.com/streamingfast/substreams/storage/execout/streamproto"
 
 	"go.uber.org/zap/zapcore"
 
@@ -157,16 +157,20 @@ func (c *File) Load(ctx context.Context) error {
 
 func (c *File) Save(ctx context.Context) error {
 	filename := c.Filename()
-	outputData := &pboutput.Map{Kv: c.Kv}
-	cnt, err := outputData.MarshalFast()
-	if err != nil {
-		return fmt.Errorf("unmarshalling file %s: %w", filename, err)
-	}
 
 	c.logger.Info("writing execution output file", zap.String("filename", filename))
 	return derr.RetryContext(ctx, 10, func(ctx context.Context) error { // more than the usual 5 retries here because if we fail, we have to reprocess the whole segment
-		reader := bytes.NewReader(cnt)
-		err := c.store.WriteObject(ctx, filename, reader)
+		r, w := io.Pipe()
+		go func() {
+			for _, item := range c.Kv {
+				if err := streamproto.WriteItem(w, item); err != nil {
+					w.CloseWithError(err)
+					return
+				}
+			}
+			w.Close()
+		}()
+		err := c.store.WriteObject(ctx, filename, r)
 		return err
 	})
 }

--- a/storage/execout/streamproto/protostream.go
+++ b/storage/execout/streamproto/protostream.go
@@ -1,0 +1,34 @@
+package streamproto
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	pb "github.com/streamingfast/substreams/storage/execout/pb"
+)
+
+func WriteItem(writer io.Writer, item *pb.Item) error {
+	data, err := item.MarshalVT()
+	if err != nil {
+		return fmt.Errorf("failed to marshal item: %w", err)
+	}
+
+	prefixedSizeEncoding := varintEncodeWithArrayPrefix(uint64(len(data)))
+
+	if _, err := writer.Write(append(prefixedSizeEncoding, data...)); err != nil {
+		return fmt.Errorf("failed to write array item: %w", err)
+	}
+	return nil
+}
+
+// When you marshal an Array object, the first bytes will encode field 1 (items) with wire type 2:
+// `(1 << 3) | 2 = 8 | 2 = 10 = 0x0a`
+const arrayPrefix = byte(10)
+
+func varintEncodeWithArrayPrefix(i uint64) []byte {
+	var buf [11]byte // Max varint size for uint64 + 1 byte for prefix
+	buf[0] = arrayPrefix
+	n := binary.PutUvarint(buf[1:], i)
+	return buf[:n+1]
+}

--- a/storage/execout/streamproto/protostream_test.go
+++ b/storage/execout/streamproto/protostream_test.go
@@ -1,0 +1,142 @@
+package streamproto
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	pb "github.com/streamingfast/substreams/storage/execout/pb"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func Benchmark_VarintEncode(b *testing.B) {
+	testCases := []uint64{
+		0,
+		127,
+		128,
+		16383,
+		16384,
+		2097151,
+		2097152,
+		268435455,
+		268435456,
+		4294967295,
+		4294967296,
+		549755813887,
+		549755813888,
+		70368744177663,
+		70368744177664,
+		9223372036854775807,
+		9223372036854775808,
+		18446744073709551615,
+	}
+
+	for _, tc := range testCases {
+		b.Run(fmt.Sprintf("encode_%d", tc), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = varintEncodeWithArrayPrefix(tc)
+			}
+		})
+	}
+}
+
+func TestVarintEncodeWithArrayPrefix(t *testing.T) {
+	testCases := []struct {
+		input    uint64
+		expected []byte
+	}{
+		{0, []byte{arrayPrefix, 0}},
+		{1, []byte{arrayPrefix, 1}},
+		{127, []byte{arrayPrefix, 127}},
+		{128, []byte{arrayPrefix, 128, 1}},
+		{300, []byte{arrayPrefix, 172, 2}},
+		{16384, []byte{arrayPrefix, 128, 128, 1}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("encode_%d", tc.input), func(t *testing.T) {
+			result := varintEncodeWithArrayPrefix(tc.input)
+			if len(result) != len(tc.expected) {
+				t.Fatalf("Expected length %d, got %d for input %d",
+					len(tc.expected), len(result), tc.input)
+			}
+			for i := range result {
+				if result[i] != tc.expected[i] {
+					t.Fatalf("Mismatch at position %d for input %d: expected %d, got %d",
+						i, tc.input, tc.expected[i], result[i])
+				}
+			}
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	// Create some sample items
+	items := []*pb.Item{
+		{
+			BlockNum:  100,
+			BlockId:   "abc123",
+			Payload:   []byte("payload1"),
+			Timestamp: timestamppb.New(time.Now()),
+			Cursor:    "cursor1",
+		},
+		{
+			BlockNum:  101,
+			BlockId:   "def456",
+			Payload:   []byte("payload2"),
+			Timestamp: timestamppb.New(time.Now()),
+			Cursor:    "cursor2",
+		},
+
+		{
+			BlockNum:  102,
+			BlockId:   "def789",
+			Payload:   bytes.Repeat([]byte("hello"), 9999999),
+			Timestamp: timestamppb.New(time.Now()),
+			Cursor:    "cursor2",
+		},
+	}
+
+	arr := pb.Array{
+		Items: items,
+	}
+
+	encodedFull, err := proto.Marshal(&arr)
+	if err != nil {
+		t.Fatalf("Failed to encode data: %v", err)
+	}
+
+	writer := bytes.NewBuffer(nil)
+	var encodedStream []byte
+
+	for _, item := range items {
+		err := WriteItem(writer, item)
+		if err != nil {
+			t.Fatalf("Failed to stream item: %v", err)
+		}
+	}
+
+	encodedStream = writer.Bytes()
+
+	// Compare lengths
+	t.Logf("Full encoded length: %d, Streamed encoded length: %d",
+		len(encodedFull), len(encodedStream))
+
+	// For debugging, you can also compare the actual bytes
+	if !bytes.Equal(encodedFull, encodedStream) {
+		t.Logf("Encoding methods produced different results")
+		// You might want to examine the first few bytes to see where they differ
+		compareLength := min(len(encodedFull), len(encodedStream))
+		if compareLength > 20 {
+			compareLength = 20 // Limit to first 20 bytes for readability
+		}
+
+		t.Logf("First %d bytes of full encoding: %v", compareLength, encodedFull[:compareLength])
+		t.Logf("First %d bytes of streamed encoding: %v", compareLength, encodedStream[:compareLength])
+	} else {
+		t.Logf("Both encoding methods produced identical results")
+	}
+
+}

--- a/storage/index/configs.go
+++ b/storage/index/configs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/streamingfast/dstore"
-	"github.com/streamingfast/substreams/manifest"
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 	"go.uber.org/zap"
 )
@@ -14,7 +13,7 @@ type Configs struct {
 	logger    *zap.Logger
 }
 
-func NewConfigs(baseObjectStore dstore.Store, allRequestedModules []*pbsubstreams.Module, moduleHashes *manifest.ModuleHashes, firstStreamableBlock uint64, logger *zap.Logger) (*Configs, error) {
+func NewConfigs(baseObjectStore dstore.Store, allRequestedModules []*pbsubstreams.Module, moduleHashes map[string]string, firstStreamableBlock uint64, logger *zap.Logger) (*Configs, error) {
 	out := make(map[string]*Config)
 	for _, mod := range allRequestedModules {
 		initialBlock := mod.InitialBlock
@@ -24,7 +23,7 @@ func NewConfigs(baseObjectStore dstore.Store, allRequestedModules []*pbsubstream
 		conf, err := NewConfig(
 			mod.Name,
 			initialBlock,
-			moduleHashes.Get(mod.Name),
+			moduleHashes[mod.Name],
 			baseObjectStore,
 			logger,
 		)

--- a/storage/store/configmap.go
+++ b/storage/store/configmap.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 
 	"github.com/streamingfast/dstore"
-	"github.com/streamingfast/substreams/manifest"
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 )
 
 type ConfigMap map[string]*Config
 
-func NewConfigMap(baseObjectStore, quickSaveStore dstore.Store, storeModules []*pbsubstreams.Module, moduleHashes *manifest.ModuleHashes, firstStreamableBlock uint64) (out ConfigMap, err error) {
+func NewConfigMap(baseObjectStore, quickSaveStore dstore.Store, storeModules []*pbsubstreams.Module, moduleHashes map[string]string, firstStreamableBlock uint64) (out ConfigMap, err error) {
 	out = make(ConfigMap)
 	for _, storeModule := range storeModules {
 		initialBlock := storeModule.InitialBlock
@@ -20,7 +19,7 @@ func NewConfigMap(baseObjectStore, quickSaveStore dstore.Store, storeModules []*
 		c, err := NewConfig(
 			storeModule.Name,
 			initialBlock,
-			moduleHashes.Get(storeModule.Name),
+			moduleHashes[storeModule.Name],
 			storeModule.GetKindStore().UpdatePolicy,
 			storeModule.GetKindStore().ValueType,
 			baseObjectStore,


### PR DESCRIPTION
same module would be executed multiple times if it is used at multiple places in the graph under different names.

* shortest name will be used as canonical
* `substreams info` correctly shows the stages without duplicates.
  - if used with `--used-modules-only`, a single copy of each module is shown.
* prevents writing the same output files multiple times