### PR TITLE
Feature/faster deleteprefix

### DIFF
--- a/pipeline/cache/engine.go
+++ b/pipeline/cache/engine.go
@@ -29,7 +29,7 @@ type Engine struct {
 	blockType         string
 	reversibleBuffers map[uint64]*execout.Buffer // block num to modules' outputs for that given block
 	execOutputWriters map[string]*execout.Writer // moduleName => writer (single file)
-	existingExecOuts  map[string]*execout.File
+	existingExecOuts  map[string]*execout.File   // on Tier2 requests, this contains any existing outputs that we could load from disk, skipping module execution
 	indexWriters      map[string]*index.Writer
 
 	logger *zap.Logger
@@ -87,8 +87,13 @@ func (e *Engine) HandleFinal(clock *pbsubstreams.Clock) error {
 		writer.Write(clock, execOutBuf)
 	}
 
+	// once a block is final, no need to keep it in reversible buffer
 	delete(e.reversibleBuffers, clock.Number)
-	for _, existingExecOut := range e.existingExecOuts { // delete mapper outputs from previous blocks to free up memory ASAP. The existingExecOuts are only used on tier2
+
+	// delete mapper outputs that were loaded from disk cache to free up memory ASAP and that have already been used.
+	// since `HandleFinal` is always called AFTER `HandleNew` on any given block, we know that the block is behind us.
+	// Note: the existingExecOuts only exist on tier2 requests, which does not process live blocks either.
+	for _, existingExecOut := range e.existingExecOuts {
 		delete(existingExecOut.Kv, clock.Id)
 	}
 

--- a/pipeline/cache/engine.go
+++ b/pipeline/cache/engine.go
@@ -88,6 +88,9 @@ func (e *Engine) HandleFinal(clock *pbsubstreams.Clock) error {
 	}
 
 	delete(e.reversibleBuffers, clock.Number)
+	for _, existingExecOut := range e.existingExecOuts { // delete mapper outputs from previous blocks to free up memory ASAP. The existingExecOuts are only used on tier2
+		delete(existingExecOut.Kv, clock.Id)
+	}
 
 	return nil
 }

--- a/storage/store/base_store.go
+++ b/storage/store/base_store.go
@@ -22,7 +22,7 @@ type baseStore struct {
 	lastOrdinal             uint64
 	marshaller              marshaller.Marshaller
 	totalSizeBytes          uint64
-	recentlyDeletedPrefixes map[string]struct{} // we cache them here to speed up future deletePrefix()
+	recentlyDeletedPrefixes DeletedPrefixes // we cache them here to speed up future deletePrefix()
 
 	logger *zap.Logger
 }

--- a/storage/store/base_store.go
+++ b/storage/store/base_store.go
@@ -18,10 +18,11 @@ type baseStore struct {
 	kvOps *pbssinternal.Operations // operations to the curent block called from the WASM module
 	// deltas are always deltas for the given block. they are produced when store is flushed
 	// 	and used to read back in the store at different ordinals
-	deltas         []*pbsubstreams.StoreDelta
-	lastOrdinal    uint64
-	marshaller     marshaller.Marshaller
-	totalSizeBytes uint64
+	deltas                  []*pbsubstreams.StoreDelta
+	lastOrdinal             uint64
+	marshaller              marshaller.Marshaller
+	totalSizeBytes          uint64
+	recentlyDeletedPrefixes map[string]struct{} // we cache them here to speed up future deletePrefix()
 
 	logger *zap.Logger
 }

--- a/storage/store/config.go
+++ b/storage/store/config.go
@@ -78,7 +78,7 @@ func (c *Config) newBaseStore(logger *zap.Logger) *baseStore {
 		kv:                      make(map[string][]byte),
 		logger:                  logger.Named("store").With(zap.String("store_name", c.name), zap.String("module_hash", c.moduleHash)),
 		marshaller:              marshaller.Default(),
-		recentlyDeletedPrefixes: make(map[string]struct{}),
+		recentlyDeletedPrefixes: make(DeletedPrefixes),
 	}
 }
 

--- a/storage/store/config.go
+++ b/storage/store/config.go
@@ -73,11 +73,12 @@ func NewConfig(
 
 func (c *Config) newBaseStore(logger *zap.Logger) *baseStore {
 	return &baseStore{
-		Config:     c,
-		kvOps:      &pbssinternal.Operations{},
-		kv:         make(map[string][]byte),
-		logger:     logger.Named("store").With(zap.String("store_name", c.name), zap.String("module_hash", c.moduleHash)),
-		marshaller: marshaller.Default(),
+		Config:                  c,
+		kvOps:                   &pbssinternal.Operations{},
+		kv:                      make(map[string][]byte),
+		logger:                  logger.Named("store").With(zap.String("store_name", c.name), zap.String("module_hash", c.moduleHash)),
+		marshaller:              marshaller.Default(),
+		recentlyDeletedPrefixes: make(map[string]struct{}),
 	}
 }
 

--- a/storage/store/delta.go
+++ b/storage/store/delta.go
@@ -3,6 +3,7 @@ package store
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 )
@@ -21,6 +22,12 @@ func (b *baseStore) ApplyDelta(delta *pbsubstreams.StoreDelta) {
 	keySize := uint64(len(delta.Key))
 	switch delta.Operation {
 	case pbsubstreams.StoreDelta_UPDATE:
+		for k := range b.recentlyDeletedPrefixes {
+			if strings.HasPrefix(delta.Key, k) {
+				delete(b.recentlyDeletedPrefixes, k) // we added a key matching this prefix, it is not considered deleted anymore
+			}
+		}
+
 		b.kv[delta.Key] = delta.NewValue
 		switch {
 		case newSize > oldSize:
@@ -30,6 +37,12 @@ func (b *baseStore) ApplyDelta(delta *pbsubstreams.StoreDelta) {
 		}
 
 	case pbsubstreams.StoreDelta_CREATE:
+		for k := range b.recentlyDeletedPrefixes {
+			if strings.HasPrefix(delta.Key, k) {
+				delete(b.recentlyDeletedPrefixes, k) // we added a key matching this prefix, it is not considered deleted anymore
+			}
+		}
+
 		b.kv[delta.Key] = delta.NewValue
 		b.totalSizeBytes += newSize
 		b.totalSizeBytes += keySize
@@ -53,6 +66,8 @@ func storeTooBigError(storeName string, size, limit uint64) error {
 }
 
 func (b *baseStore) ApplyDeltasReverse(deltas []*pbsubstreams.StoreDelta) {
+	b.recentlyDeletedPrefixes = make(map[string]struct{}) // whenever we have an undo block, we delete this cache to avoid any bug
+
 	for i := len(deltas) - 1; i >= 0; i-- {
 		delta := deltas[i]
 

--- a/storage/store/delta.go
+++ b/storage/store/delta.go
@@ -8,6 +8,38 @@ import (
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 )
 
+// DeletedPrefixes is a specialized map to track deleted prefixes
+type DeletedPrefixes map[string]struct{}
+
+// Clear removes all entries in the DeletedPrefixes map
+func (dp DeletedPrefixes) Clear() {
+	for k := range dp {
+		delete(dp, k)
+	}
+}
+
+// RemoveMatching removes all prefixes of the given string
+func (dp DeletedPrefixes) RemoveMatching(key string) {
+	for prefix := range dp {
+		if strings.HasPrefix(key, prefix) {
+			delete(dp, prefix)
+		}
+	}
+}
+
+// Add adds a key to the DeletedPrefixes map
+func (dp DeletedPrefixes) Add(prefix string) {
+	if len(dp) > 100 {
+		dp.Clear() // keep this under reasonable size
+	}
+	dp[prefix] = struct{}{}
+}
+
+func (dp DeletedPrefixes) Exists(prefix string) bool {
+	_, ok := dp[prefix]
+	return ok
+}
+
 func (b *baseStore) ApplyDelta(delta *pbsubstreams.StoreDelta) {
 	// Keys need to have at least one character, and mustn't start with 0xFF is reserved for internal use.
 	if len(delta.Key) == 0 {
@@ -22,11 +54,7 @@ func (b *baseStore) ApplyDelta(delta *pbsubstreams.StoreDelta) {
 	keySize := uint64(len(delta.Key))
 	switch delta.Operation {
 	case pbsubstreams.StoreDelta_UPDATE:
-		for k := range b.recentlyDeletedPrefixes {
-			if strings.HasPrefix(delta.Key, k) {
-				delete(b.recentlyDeletedPrefixes, k) // we added a key matching this prefix, it is not considered deleted anymore
-			}
-		}
+		b.recentlyDeletedPrefixes.RemoveMatching(delta.Key)
 
 		b.kv[delta.Key] = delta.NewValue
 		switch {
@@ -37,11 +65,7 @@ func (b *baseStore) ApplyDelta(delta *pbsubstreams.StoreDelta) {
 		}
 
 	case pbsubstreams.StoreDelta_CREATE:
-		for k := range b.recentlyDeletedPrefixes {
-			if strings.HasPrefix(delta.Key, k) {
-				delete(b.recentlyDeletedPrefixes, k) // we added a key matching this prefix, it is not considered deleted anymore
-			}
-		}
+		b.recentlyDeletedPrefixes.RemoveMatching(delta.Key)
 
 		b.kv[delta.Key] = delta.NewValue
 		b.totalSizeBytes += newSize
@@ -66,7 +90,7 @@ func storeTooBigError(storeName string, size, limit uint64) error {
 }
 
 func (b *baseStore) ApplyDeltasReverse(deltas []*pbsubstreams.StoreDelta) {
-	b.recentlyDeletedPrefixes = make(map[string]struct{}) // whenever we have an undo block, we delete this cache to avoid any bug
+	b.recentlyDeletedPrefixes.Clear() // whenever we have an undo block, we clear this cache to avoid any bug
 
 	for i := len(deltas) - 1; i >= 0; i-- {
 		delta := deltas[i]

--- a/storage/store/init_test.go
+++ b/storage/store/init_test.go
@@ -31,10 +31,11 @@ func newTestBaseStore(
 	config.itemSizeLimit = 10_485_760
 	require.NoError(t, err)
 	return &baseStore{
-		Config:     config,
-		kvOps:      &pbssinternal.Operations{},
-		kv:         make(map[string][]byte),
-		logger:     zap.NewNop(),
-		marshaller: &marshaller.Binary{},
+		Config:                  config,
+		kvOps:                   &pbssinternal.Operations{},
+		kv:                      make(map[string][]byte),
+		logger:                  zap.NewNop(),
+		marshaller:              &marshaller.Binary{},
+		recentlyDeletedPrefixes: make(map[string]struct{}),
 	}
 }

--- a/storage/store/init_test.go
+++ b/storage/store/init_test.go
@@ -36,6 +36,6 @@ func newTestBaseStore(
 		kv:                      make(map[string][]byte),
 		logger:                  zap.NewNop(),
 		marshaller:              &marshaller.Binary{},
-		recentlyDeletedPrefixes: make(map[string]struct{}),
+		recentlyDeletedPrefixes: make(DeletedPrefixes),
 	}
 }

--- a/storage/store/merge.go
+++ b/storage/store/merge.go
@@ -16,11 +16,7 @@ import (
 )
 
 func (b *baseStore) setKV(k string, v []byte) {
-	for pref := range b.recentlyDeletedPrefixes {
-		if strings.HasPrefix(k, pref) {
-			delete(b.recentlyDeletedPrefixes, pref) // we added a key matching this prefix, it is not considered deleted anymore
-		}
-	}
+	b.recentlyDeletedPrefixes.RemoveMatching(k)
 
 	if prev, ok := b.kv[k]; ok {
 		b.totalSizeBytes -= uint64(len(prev))
@@ -32,11 +28,7 @@ func (b *baseStore) setKV(k string, v []byte) {
 }
 
 func (b *baseStore) setNewKV(k string, v []byte) {
-	for pref := range b.recentlyDeletedPrefixes {
-		if strings.HasPrefix(k, pref) {
-			delete(b.recentlyDeletedPrefixes, pref) // we added a key matching this prefix, it is not considered deleted anymore
-		}
-	}
+	b.recentlyDeletedPrefixes.RemoveMatching(k)
 
 	b.totalSizeBytes += uint64(len(k) + len(v))
 	b.kv[k] = v

--- a/storage/store/merge.go
+++ b/storage/store/merge.go
@@ -16,6 +16,12 @@ import (
 )
 
 func (b *baseStore) setKV(k string, v []byte) {
+	for pref := range b.recentlyDeletedPrefixes {
+		if strings.HasPrefix(k, pref) {
+			delete(b.recentlyDeletedPrefixes, pref) // we added a key matching this prefix, it is not considered deleted anymore
+		}
+	}
+
 	if prev, ok := b.kv[k]; ok {
 		b.totalSizeBytes -= uint64(len(prev))
 	} else {
@@ -26,6 +32,12 @@ func (b *baseStore) setKV(k string, v []byte) {
 }
 
 func (b *baseStore) setNewKV(k string, v []byte) {
+	for pref := range b.recentlyDeletedPrefixes {
+		if strings.HasPrefix(k, pref) {
+			delete(b.recentlyDeletedPrefixes, pref) // we added a key matching this prefix, it is not considered deleted anymore
+		}
+	}
+
 	b.totalSizeBytes += uint64(len(k) + len(v))
 	b.kv[k] = v
 }

--- a/storage/store/merge_test.go
+++ b/storage/store/merge_test.go
@@ -497,7 +497,7 @@ func newStore(kv map[string][]byte, updatePolicy pbsubstreams.Module_KindStore_U
 			valueType:    valueType,
 		},
 		logger:                  zap.NewNop(),
-		recentlyDeletedPrefixes: make(map[string]struct{}),
+		recentlyDeletedPrefixes: make(DeletedPrefixes),
 	}
 	return &FullKV{baseStore: b}
 }

--- a/storage/store/merge_test.go
+++ b/storage/store/merge_test.go
@@ -482,6 +482,7 @@ func newPartialStore(kv map[string][]byte, updatePolicy pbsubstreams.Module_Kind
 			updatePolicy: updatePolicy,
 			valueType:    valueType,
 		},
+		recentlyDeletedPrefixes: make(map[string]struct{}),
 	}
 
 	return &PartialKV{baseStore: b, DeletedPrefixes: deletedPrefixes, seen: make(map[string]bool)}
@@ -495,7 +496,8 @@ func newStore(kv map[string][]byte, updatePolicy pbsubstreams.Module_KindStore_U
 			updatePolicy: updatePolicy,
 			valueType:    valueType,
 		},
-		logger: zap.NewNop(),
+		logger:                  zap.NewNop(),
+		recentlyDeletedPrefixes: make(map[string]struct{}),
 	}
 	return &FullKV{baseStore: b}
 }

--- a/storage/store/value_delete.go
+++ b/storage/store/value_delete.go
@@ -17,6 +17,13 @@ func (b *baseStore) DeletePrefix(ord uint64, prefix string) {
 }
 
 func (b *baseStore) deletePrefix(ord uint64, prefix string) {
+	if _, ok := b.recentlyDeletedPrefixes[prefix]; ok {
+		return
+	}
+	if len(b.recentlyDeletedPrefixes) > 100 {
+		b.recentlyDeletedPrefixes = make(map[string]struct{}) // keep this under reasonable size
+	}
+	b.recentlyDeletedPrefixes[prefix] = struct{}{}
 
 	var deltas []*pbsubstreams.StoreDelta
 	for key, val := range b.kv {

--- a/storage/store/value_delete.go
+++ b/storage/store/value_delete.go
@@ -17,13 +17,10 @@ func (b *baseStore) DeletePrefix(ord uint64, prefix string) {
 }
 
 func (b *baseStore) deletePrefix(ord uint64, prefix string) {
-	if _, ok := b.recentlyDeletedPrefixes[prefix]; ok {
+	if b.recentlyDeletedPrefixes.Exists(prefix) {
 		return
 	}
-	if len(b.recentlyDeletedPrefixes) > 100 {
-		b.recentlyDeletedPrefixes = make(map[string]struct{}) // keep this under reasonable size
-	}
-	b.recentlyDeletedPrefixes[prefix] = struct{}{}
+	b.recentlyDeletedPrefixes.Add(prefix)
 
 	var deltas []*pbsubstreams.StoreDelta
 	for key, val := range b.kv {


### PR DESCRIPTION
- every deletePrefix caches the given prefix in a map.
- Next deletePrefix on the SAME prefix will be a noop.
- Any write to the store's map will look cause a lookup to the cache, invalidating any prefix matched by that entry.

This addresses the scenario where a module will constantly try to delete stores that begin by the prefix of the "previous month" or similar.