### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/storage/index/configs.go
+++ b/storage/index/configs.go
@@ -16,10 +16,7 @@ type Configs struct {
 func NewConfigs(baseObjectStore dstore.Store, allRequestedModules []*pbsubstreams.Module, moduleHashes map[string]string, firstStreamableBlock uint64, logger *zap.Logger) (*Configs, error) {
 	out := make(map[string]*Config)
 	for _, mod := range allRequestedModules {
-		initialBlock := mod.InitialBlock
-		if initialBlock < firstStreamableBlock {
-			initialBlock = firstStreamableBlock
-		}
+		initialBlock := max(mod.InitialBlock, firstStreamableBlock)
 		conf, err := NewConfig(
 			mod.Name,
 			initialBlock,

--- a/storage/store/configmap.go
+++ b/storage/store/configmap.go
@@ -12,10 +12,7 @@ type ConfigMap map[string]*Config
 func NewConfigMap(baseObjectStore, quickSaveStore dstore.Store, storeModules []*pbsubstreams.Module, moduleHashes map[string]string, firstStreamableBlock uint64) (out ConfigMap, err error) {
 	out = make(ConfigMap)
 	for _, storeModule := range storeModules {
-		initialBlock := storeModule.InitialBlock
-		if initialBlock < firstStreamableBlock {
-			initialBlock = firstStreamableBlock
-		}
+		initialBlock := max(storeModule.InitialBlock, firstStreamableBlock)
 		c, err := NewConfig(
 			storeModule.Name,
 			initialBlock,


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.