### PR TITLE
handle all 'untrusted headers' that can lower auth-provided parallel values in substreams

### DIFF
--- a/docs/new/references/cli/command-line-interface.md
+++ b/docs/new/references/cli/command-line-interface.md
@@ -123,7 +123,7 @@ The `-H` option of the `run` or `gui` command allows you to dynamically pass hea
 
 ##### X-Sf-Substreams-Parallel-Jobs Header
 
-The `X-Sf-Substreams-Parallel-Jobs` header sets the number of parallel jobs to use in the Substreams execution. By default, 10 jobs are used.
+The `X-Sf-Substreams-Parallel-Jobs` header sets the number of parallel jobs to use in the Substreams execution. By default, 10 jobs are used. Most authentication backends will prevent setting this header to a higher value than the what the auth provides.
 
 ```bash
 substreams run -e mainnet.eth.streamingfast.io:443 \

--- a/docs/new/references/cli/command-line-interface.md
+++ b/docs/new/references/cli/command-line-interface.md
@@ -121,14 +121,14 @@ The details of the run command are:
 
 The `-H` option of the `run` or `gui` command allows you to dynamically pass headers with the gRPC request. This is useful when overriding default parameters in the Substreams execution.
 
-##### X-Sf-Substreams-Parallel-Jobs Header
+##### X-Substreams-Parallel-Workers Header
 
-The `X-Sf-Substreams-Parallel-Jobs` header sets the number of parallel jobs to use in the Substreams execution. By default, 10 jobs are used. Most authentication backends will prevent setting this header to a higher value than the what the auth provides.
+The `X-Substreams-Parallel-Workers` header sets the number of parallel jobs to use in the Substreams execution. By default, 10 jobs are used. Most authentication backends will prevent setting this header to a higher value than the what the auth provides.
 
 ```bash
 substreams run -e mainnet.eth.streamingfast.io:443 \
    -t +1 \
-   -H "X-Sf-Substreams-Parallel-Jobs: 20" \
+   -H "X-Substreams-Parallel-Workers: 20" \
    ./substreams.yaml \
    module_name
 ```

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Server
 
 * Fix zstd thread/mem leak on filereader
+* Allow decreasing 'X-Sf-Substreams-Parallel-Jobs' and "X-Sf-Substreams-Stage-Layer-Parallel-Executor-Max-Count" through HTTP headers (auth layer determines higher bound)
+
 
 ## v1.16.3
 

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -13,9 +13,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Server
 
-* Fix zstd thread/mem leak on filereader
-* Allow decreasing 'X-Sf-Substreams-Parallel-Jobs' and "X-Sf-Substreams-Stage-Layer-Parallel-Executor-Max-Count" through HTTP headers (auth layer determines higher bound)
+#### Memory leak
 
+* Fix zstd thread/mem leak on filereader
+
+#### Authentication changes
+
+People using their own authentication layer will need to consider these changes before upgrading!
+
+* Renamed config headers that come from authentication layer:
+  - `x-sf-user-id` renamed to `x-user-id` (from dauth module)
+  - `x-sf-api-key-id` renamed to `x-api-key-id` (from dauth module)
+  - `x-sf-meta` renamed to `x-meta` (from dauth module)
+  - `x-sf-substreams-parallel-jobs` renamed to `x-substreams-parallel-workers`
+* Allow decreasing `x-substreams-parallel-workers` through an HTTP headers (auth layer determines higher bound)
+* Detect value for the 'stage layer parallel executor max count' based on the `x-plan-tier` header (removed `x-sf-substreams-stage-layer-parallel-executor-max-count` handling)
+
+#### New authentication plugin
+
+* Added `tgm://auth.thegraph.market?indexer-api-key=<API_KEY>&reissue-jwt-max-age-secs=600` plugin that allows an indexer to use The Graph Market as the authentication source.
+  An API key with special "indexer" feature is needed to allow repeated calls to the API without rate limiting (for Key-based authentication and reissuance of "untrusted long-lived JWTs").
 
 ## v1.16.3
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/streamingfast/bstream v0.0.2-0.20250221181559-fb0809660f91
 	github.com/streamingfast/cli v0.0.4-0.20241119021815-815afa473375
-	github.com/streamingfast/dauth v0.0.0-20250129222106-6e8709b44acf
+	github.com/streamingfast/dauth v0.0.0-20250820114409-1f350c4304cc
 	github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c
 	github.com/streamingfast/derr v0.0.0-20250321151415-6b4fbbcb1bb5
 	github.com/streamingfast/dgrpc v0.0.0-20250423172640-223250ed2391

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/streamingfast/bstream v0.0.2-0.20250221181559-fb0809660f91
 	github.com/streamingfast/cli v0.0.4-0.20241119021815-815afa473375
-	github.com/streamingfast/dauth v0.0.0-20250820114409-1f350c4304cc
+	github.com/streamingfast/dauth v0.0.0-20250821195214-8e2a3c300f97
 	github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c
 	github.com/streamingfast/derr v0.0.0-20250321151415-6b4fbbcb1bb5
 	github.com/streamingfast/dgrpc v0.0.0-20250423172640-223250ed2391

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/streamingfast/bstream v0.0.2-0.20250221181559-fb0809660f91 h1:n4Ws5vS
 github.com/streamingfast/bstream v0.0.2-0.20250221181559-fb0809660f91/go.mod h1:n5wy+Vmwp4xbjXO7B81MAkAgjnf1vJ/lI2y6hWWyFbg=
 github.com/streamingfast/cli v0.0.4-0.20241119021815-815afa473375 h1:nwuFSEJtQfqTuN62WvysfAtDT4qqwQ6ghFX0i2VY1fY=
 github.com/streamingfast/cli v0.0.4-0.20241119021815-815afa473375/go.mod h1:qOksW3DPhHVYBo8dcYxS7K3Q09wlcOChSdopeOjLWng=
-github.com/streamingfast/dauth v0.0.0-20250129222106-6e8709b44acf h1:RFkRnIRUk51fcPn6eWuuecUSYFqmCP5affIMKywPIDU=
-github.com/streamingfast/dauth v0.0.0-20250129222106-6e8709b44acf/go.mod h1:d8NTrjIoiqplrZEYOUXwwFaeB2C8fVeHYLvaJFfa9Xo=
+github.com/streamingfast/dauth v0.0.0-20250820114409-1f350c4304cc h1:EIsGvt0cQZpGhlfQFVjn0NyLlSA1w1hCbfbncjuNWo0=
+github.com/streamingfast/dauth v0.0.0-20250820114409-1f350c4304cc/go.mod h1:d8NTrjIoiqplrZEYOUXwwFaeB2C8fVeHYLvaJFfa9Xo=
 github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c h1:6WjE2yInE+5jnI7cmCcxOiGZiEs2FQm9Zsg2a9Ivp0Q=
 github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c/go.mod h1:dbfiy9ORrL8c6ldSq+L0H9pg8TOqqu/FsghsgUEWK54=
 github.com/streamingfast/derr v0.0.0-20250321151415-6b4fbbcb1bb5 h1:Lj4MlmrciCrXWOkIvseI3oovghtMzl2g+/arxJkgsPc=

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/streamingfast/bstream v0.0.2-0.20250221181559-fb0809660f91 h1:n4Ws5vS
 github.com/streamingfast/bstream v0.0.2-0.20250221181559-fb0809660f91/go.mod h1:n5wy+Vmwp4xbjXO7B81MAkAgjnf1vJ/lI2y6hWWyFbg=
 github.com/streamingfast/cli v0.0.4-0.20241119021815-815afa473375 h1:nwuFSEJtQfqTuN62WvysfAtDT4qqwQ6ghFX0i2VY1fY=
 github.com/streamingfast/cli v0.0.4-0.20241119021815-815afa473375/go.mod h1:qOksW3DPhHVYBo8dcYxS7K3Q09wlcOChSdopeOjLWng=
-github.com/streamingfast/dauth v0.0.0-20250820114409-1f350c4304cc h1:EIsGvt0cQZpGhlfQFVjn0NyLlSA1w1hCbfbncjuNWo0=
-github.com/streamingfast/dauth v0.0.0-20250820114409-1f350c4304cc/go.mod h1:d8NTrjIoiqplrZEYOUXwwFaeB2C8fVeHYLvaJFfa9Xo=
+github.com/streamingfast/dauth v0.0.0-20250821195214-8e2a3c300f97 h1:Lcack+Yv9KWBeKfRrjQ+KUegwHbh6/aFLJuDyYzcXZ4=
+github.com/streamingfast/dauth v0.0.0-20250821195214-8e2a3c300f97/go.mod h1:d8NTrjIoiqplrZEYOUXwwFaeB2C8fVeHYLvaJFfa9Xo=
 github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c h1:6WjE2yInE+5jnI7cmCcxOiGZiEs2FQm9Zsg2a9Ivp0Q=
 github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c/go.mod h1:dbfiy9ORrL8c6ldSq+L0H9pg8TOqqu/FsghsgUEWK54=
 github.com/streamingfast/derr v0.0.0-20250321151415-6b4fbbcb1bb5 h1:Lj4MlmrciCrXWOkIvseI3oovghtMzl2g+/arxJkgsPc=

--- a/pipeline/resolve.go
+++ b/pipeline/resolve.go
@@ -112,7 +112,8 @@ func BuildRequestDetailsFromSubrequest(ctx context.Context, request *pbssinterna
 		IsStreamingTier2:      request.StreamOutput,
 	}
 
-	req.SetStageLayerParallelExecutorCountFromContext(ctx)
+	// note: we don't touch the maxParallelJobs here
+	_, req.MaxStageLayerParallelExecutor = reqctx.GetEffectiveHeaderValues(ctx, nil, 0, reqctx.DefaultMaxStageLayerParallelExecutorCount)
 
 	return req
 }

--- a/reqctx/context.go
+++ b/reqctx/context.go
@@ -104,7 +104,7 @@ func WithEmitter(ctx context.Context, emitter dmetering.EventEmitter) context.Co
 	return context.WithValue(ctx, emitterKey, emitter)
 }
 
-const defaultMaxStageLayerParallelExecutorCount = 2
+const DefaultMaxStageLayerParallelExecutorCount = 2
 
 const safeguardMaxStageLayerParallelExecutorCount = 16
 
@@ -128,7 +128,7 @@ func MaxStageLayerParallelExecutor(ctx context.Context) uint64 {
 
 	// If unset, provide default value which is 2 for now
 	if details.MaxStageLayerParallelExecutor == 0 {
-		return defaultMaxStageLayerParallelExecutorCount
+		return DefaultMaxStageLayerParallelExecutorCount
 	}
 
 	// Protect in case of misconfiguration to cap at a sane system max value

--- a/reqctx/headers.go
+++ b/reqctx/headers.go
@@ -8,9 +8,9 @@ import (
 	"github.com/streamingfast/dauth"
 )
 
-const HeaderParallelJobs = "X-Sf-Substreams-Parallel-Jobs"
-const HeaderCacheTag = "X-Sf-Substreams-Cache-Tag"
-const HeaderParallelExecutor = "X-Sf-Substreams-Stage-Layer-Parallel-Executor-Max-Count"
+const HeaderParallelJobs = "x-sf-substreams-parallel-jobs"
+const HeaderCacheTag = "x-sf-substreams-cache-tag"
+const HeaderParallelExecutor = "x-sf-substreams-stage-layer-parallel-executor-max-count"
 
 // GetEffectiveHeaderValues compares the request headers to the 'trusted headers' sent by the authentication layer.
 // It contains some business logic:
@@ -29,7 +29,7 @@ func GetEffectiveHeaderValues(ctx context.Context, headers http.Header, defaultP
 		}
 		if parallelExecutorsStr := trustedHeaders.Get(HeaderParallelExecutor); parallelExecutorsStr != "" {
 			if count, err := strconv.ParseUint(parallelExecutorsStr, 10, 64); err == nil {
-				parallelJobs = count
+				parallelExecutors = count
 			}
 		}
 	}
@@ -38,17 +38,15 @@ func GetEffectiveHeaderValues(ctx context.Context, headers http.Header, defaultP
 	if parallelJobsStr := headers.Get(HeaderParallelJobs); parallelJobsStr != "" {
 		if count, err := strconv.ParseUint(parallelJobsStr, 10, 64); err == nil {
 			if count < parallelJobs {
-				count = parallelJobs
+				parallelJobs = count
 			}
-			parallelJobs = count
 		}
 	}
 	if parallelExecutorsStr := headers.Get(HeaderParallelExecutor); parallelExecutorsStr != "" {
 		if count, err := strconv.ParseUint(parallelExecutorsStr, 10, 64); err == nil {
 			if count < parallelExecutors {
-				count = parallelExecutors
+				parallelExecutors = count
 			}
-			parallelExecutors = count
 		}
 	}
 

--- a/reqctx/headers.go
+++ b/reqctx/headers.go
@@ -1,0 +1,56 @@
+package reqctx
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/streamingfast/dauth"
+)
+
+const HeaderParallelJobs = "X-Sf-Substreams-Parallel-Jobs"
+const HeaderCacheTag = "X-Sf-Substreams-Cache-Tag"
+const HeaderParallelExecutor = "X-Sf-Substreams-Stage-Layer-Parallel-Executor-Max-Count"
+
+// GetEffectiveHeaderValues compares the request headers to the 'trusted headers' sent by the authentication layer.
+// It contains some business logic:
+//   - prevents overriding the numeric values to lower ones for parallel jobs and stage layer executors
+func GetEffectiveHeaderValues(ctx context.Context, headers http.Header, defaultParallelJobs uint64, defaultParallelExecutors uint64) (parallelJobs uint64, parallelExecutors uint64) {
+
+	parallelJobs = defaultParallelJobs
+	parallelExecutors = defaultParallelExecutors
+
+	// TrustedHeaders can always override these values
+	if trustedHeaders := dauth.FromContext(ctx); trustedHeaders != nil {
+		if parallelJobsStr := trustedHeaders.Get(HeaderParallelJobs); parallelJobsStr != "" {
+			if count, err := strconv.ParseUint(parallelJobsStr, 10, 64); err == nil {
+				parallelJobs = count
+			}
+		}
+		if parallelExecutorsStr := trustedHeaders.Get(HeaderParallelExecutor); parallelExecutorsStr != "" {
+			if count, err := strconv.ParseUint(parallelExecutorsStr, 10, 64); err == nil {
+				parallelJobs = count
+			}
+		}
+	}
+
+	// Normal headers can only lower those values
+	if parallelJobsStr := headers.Get(HeaderParallelJobs); parallelJobsStr != "" {
+		if count, err := strconv.ParseUint(parallelJobsStr, 10, 64); err == nil {
+			if count < parallelJobs {
+				count = parallelJobs
+			}
+			parallelJobs = count
+		}
+	}
+	if parallelExecutorsStr := headers.Get(HeaderParallelExecutor); parallelExecutorsStr != "" {
+		if count, err := strconv.ParseUint(parallelExecutorsStr, 10, 64); err == nil {
+			if count < parallelExecutors {
+				count = parallelExecutors
+			}
+			parallelExecutors = count
+		}
+	}
+
+	return
+}

--- a/reqctx/headers.go
+++ b/reqctx/headers.go
@@ -8,9 +8,9 @@ import (
 	"github.com/streamingfast/dauth"
 )
 
-const HeaderParallelJobs = "x-sf-substreams-parallel-jobs"
-const HeaderCacheTag = "x-sf-substreams-cache-tag"
-const HeaderParallelExecutor = "x-sf-substreams-stage-layer-parallel-executor-max-count"
+const HeaderParallelWorkers = "x-substreams-parallel-workers"
+const legacyHeaderParallelWorkers = "x-sf-substreams-parallel-jobs"
+const HeaderCacheTag = "x-substreams-cache-tag"
 
 // GetEffectiveHeaderValues compares the request headers to the 'trusted headers' sent by the authentication layer.
 // It contains some business logic:
@@ -22,33 +22,35 @@ func GetEffectiveHeaderValues(ctx context.Context, headers http.Header, defaultP
 
 	// TrustedHeaders can always override these values
 	if trustedHeaders := dauth.FromContext(ctx); trustedHeaders != nil {
-		if parallelJobsStr := trustedHeaders.Get(HeaderParallelJobs); parallelJobsStr != "" {
+		if parallelJobsStr := trustedHeaders.Get(HeaderParallelWorkers); parallelJobsStr != "" {
 			if count, err := strconv.ParseUint(parallelJobsStr, 10, 64); err == nil {
 				parallelJobs = count
 			}
 		}
-		if parallelExecutorsStr := trustedHeaders.Get(HeaderParallelExecutor); parallelExecutorsStr != "" {
-			if count, err := strconv.ParseUint(parallelExecutorsStr, 10, 64); err == nil {
-				parallelExecutors = count
-			}
+
+		switch trustedHeaders.SubstreamsPlanTier() {
+		case "ENTERPRISE":
+			parallelExecutors = 10
+		case "PRO":
+			parallelExecutors = 8
+		case "SCALING":
+			parallelExecutors = 5
+		default:
+			parallelExecutors = 2
 		}
 	}
 
-	// Normal headers can only lower those values
-	if parallelJobsStr := headers.Get(HeaderParallelJobs); parallelJobsStr != "" {
-		if count, err := strconv.ParseUint(parallelJobsStr, 10, 64); err == nil {
+	// untrusted headers (from the request) can only reduce the number of parallel workers
+	untrustedParallelWorkers := headers.Get(HeaderParallelWorkers)
+	if untrustedParallelWorkers == "" {
+		untrustedParallelWorkers = headers.Get(legacyHeaderParallelWorkers)
+	}
+	if untrustedParallelWorkers != "" {
+		if count, err := strconv.ParseUint(untrustedParallelWorkers, 10, 64); err == nil {
 			if count < parallelJobs {
 				parallelJobs = count
 			}
 		}
 	}
-	if parallelExecutorsStr := headers.Get(HeaderParallelExecutor); parallelExecutorsStr != "" {
-		if count, err := strconv.ParseUint(parallelExecutorsStr, 10, 64); err == nil {
-			if count < parallelExecutors {
-				parallelExecutors = count
-			}
-		}
-	}
-
 	return
 }

--- a/reqctx/headers_test.go
+++ b/reqctx/headers_test.go
@@ -1,0 +1,90 @@
+package reqctx
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/streamingfast/dauth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEffectiveHeaderValues(t *testing.T) {
+	tests := []struct {
+		name                      string
+		trustedHeaders            dauth.TrustedHeaders
+		normalHeaders             http.Header
+		defaultParallelJobs       uint64
+		defaultParallelExecutors  uint64
+		expectedParallelJobs      uint64
+		expectedParallelExecutors uint64
+	}{
+		{
+			name:                      "uses defaults when no headers provided",
+			trustedHeaders:            nil,
+			normalHeaders:             http.Header{},
+			defaultParallelJobs:       10,
+			defaultParallelExecutors:  5,
+			expectedParallelJobs:      10,
+			expectedParallelExecutors: 5,
+		},
+		{
+			name: "trusted headers override defaults",
+			trustedHeaders: dauth.TrustedHeaders{
+				HeaderParallelJobs:     "20",
+				HeaderParallelExecutor: "8",
+			},
+			normalHeaders:             http.Header{},
+			defaultParallelJobs:       10,
+			defaultParallelExecutors:  5,
+			expectedParallelJobs:      20,
+			expectedParallelExecutors: 8,
+		},
+		{
+			name:           "normal headers can only lower values",
+			trustedHeaders: nil,
+			normalHeaders: http.Header{
+				http.CanonicalHeaderKey(HeaderParallelJobs):     []string{"5"},  // lower than default 10
+				http.CanonicalHeaderKey(HeaderParallelExecutor): []string{"16"}, // higher than default 5, should be ignored
+			},
+			defaultParallelJobs:       10,
+			defaultParallelExecutors:  5,
+			expectedParallelJobs:      5, // lowered
+			expectedParallelExecutors: 5, // unchanged (cannot increase)
+		},
+		{
+			name: "normal headers cannot override trusted headers upward",
+			trustedHeaders: dauth.TrustedHeaders{
+				HeaderParallelJobs:     "20",
+				HeaderParallelExecutor: "8",
+			},
+			normalHeaders: http.Header{
+				http.CanonicalHeaderKey(HeaderParallelJobs):     []string{"15"}, // lower than trusted 20
+				http.CanonicalHeaderKey(HeaderParallelExecutor): []string{"10"}, // higher than trusted 8, should be ignored
+			},
+			defaultParallelJobs:       10,
+			defaultParallelExecutors:  5,
+			expectedParallelJobs:      15, // lowered from trusted value
+			expectedParallelExecutors: 8,  // unchanged (cannot increase from trusted)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.trustedHeaders != nil {
+				ctx = dauth.WithTrustedHeaders(ctx, tt.trustedHeaders)
+			}
+
+			parallelJobs, parallelExecutors := GetEffectiveHeaderValues(
+				ctx,
+				tt.normalHeaders,
+				tt.defaultParallelJobs,
+				tt.defaultParallelExecutors,
+			)
+
+			assert.Equal(t, tt.expectedParallelJobs, parallelJobs, "parallel jobs mismatch")
+			assert.Equal(t, tt.expectedParallelExecutors, parallelExecutors, "parallel executors mismatch")
+		})
+	}
+}

--- a/reqctx/headers_test.go
+++ b/reqctx/headers_test.go
@@ -11,61 +11,58 @@ import (
 
 func TestGetEffectiveHeaderValues(t *testing.T) {
 	tests := []struct {
-		name                      string
-		trustedHeaders            dauth.TrustedHeaders
-		normalHeaders             http.Header
-		defaultParallelJobs       uint64
-		defaultParallelExecutors  uint64
-		expectedParallelJobs      uint64
-		expectedParallelExecutors uint64
+		name                    string
+		trustedHeaders          dauth.TrustedHeaders
+		normalHeaders           http.Header
+		defaultParallelWorkers  uint64
+		defaultStageExecutors   uint64
+		expectedParallelWorkers uint64
+		expectedStageExecutors  uint64
 	}{
 		{
-			name:                      "uses defaults when no headers provided",
-			trustedHeaders:            nil,
-			normalHeaders:             http.Header{},
-			defaultParallelJobs:       10,
-			defaultParallelExecutors:  5,
-			expectedParallelJobs:      10,
-			expectedParallelExecutors: 5,
+			name:                    "uses defaults when no headers provided",
+			trustedHeaders:          nil,
+			normalHeaders:           http.Header{},
+			defaultParallelWorkers:  10,
+			defaultStageExecutors:   5,
+			expectedParallelWorkers: 10,
+			expectedStageExecutors:  5,
 		},
 		{
 			name: "trusted headers override defaults",
 			trustedHeaders: dauth.TrustedHeaders{
-				HeaderParallelJobs:     "20",
-				HeaderParallelExecutor: "8",
+				HeaderParallelWorkers: "20",
 			},
-			normalHeaders:             http.Header{},
-			defaultParallelJobs:       10,
-			defaultParallelExecutors:  5,
-			expectedParallelJobs:      20,
-			expectedParallelExecutors: 8,
+			normalHeaders:           http.Header{},
+			defaultParallelWorkers:  10,
+			defaultStageExecutors:   5,
+			expectedParallelWorkers: 20,
+			expectedStageExecutors:  2, // default for free
 		},
 		{
 			name:           "normal headers can only lower values",
 			trustedHeaders: nil,
 			normalHeaders: http.Header{
-				http.CanonicalHeaderKey(HeaderParallelJobs):     []string{"5"},  // lower than default 10
-				http.CanonicalHeaderKey(HeaderParallelExecutor): []string{"16"}, // higher than default 5, should be ignored
+				http.CanonicalHeaderKey(HeaderParallelWorkers): []string{"5"}, // lower than default 10
 			},
-			defaultParallelJobs:       10,
-			defaultParallelExecutors:  5,
-			expectedParallelJobs:      5, // lowered
-			expectedParallelExecutors: 5, // unchanged (cannot increase)
+			defaultParallelWorkers:  10,
+			defaultStageExecutors:   5,
+			expectedParallelWorkers: 5, // lowered
+			expectedStageExecutors:  5, // unchanged (cannot increase)
 		},
 		{
 			name: "normal headers cannot override trusted headers upward",
 			trustedHeaders: dauth.TrustedHeaders{
-				HeaderParallelJobs:     "20",
-				HeaderParallelExecutor: "8",
+				HeaderParallelWorkers:          "20",
+				dauth.HeaderSubstreamsPlanTier: "PRO",
 			},
 			normalHeaders: http.Header{
-				http.CanonicalHeaderKey(HeaderParallelJobs):     []string{"15"}, // lower than trusted 20
-				http.CanonicalHeaderKey(HeaderParallelExecutor): []string{"10"}, // higher than trusted 8, should be ignored
+				http.CanonicalHeaderKey(HeaderParallelWorkers): []string{"15"}, // lower than trusted 20
 			},
-			defaultParallelJobs:       10,
-			defaultParallelExecutors:  5,
-			expectedParallelJobs:      15, // lowered from trusted value
-			expectedParallelExecutors: 8,  // unchanged (cannot increase from trusted)
+			defaultParallelWorkers:  10,
+			defaultStageExecutors:   5,
+			expectedParallelWorkers: 15, // lowered from trusted value
+			expectedStageExecutors:  8,  // increased from the "PRO" plan
 		},
 	}
 
@@ -79,12 +76,12 @@ func TestGetEffectiveHeaderValues(t *testing.T) {
 			parallelJobs, parallelExecutors := GetEffectiveHeaderValues(
 				ctx,
 				tt.normalHeaders,
-				tt.defaultParallelJobs,
-				tt.defaultParallelExecutors,
+				tt.defaultParallelWorkers,
+				tt.defaultStageExecutors,
 			)
 
-			assert.Equal(t, tt.expectedParallelJobs, parallelJobs, "parallel jobs mismatch")
-			assert.Equal(t, tt.expectedParallelExecutors, parallelExecutors, "parallel executors mismatch")
+			assert.Equal(t, tt.expectedParallelWorkers, parallelJobs, "parallel jobs mismatch")
+			assert.Equal(t, tt.expectedStageExecutors, parallelExecutors, "parallel executors mismatch")
 		})
 	}
 }

--- a/reqctx/request.go
+++ b/reqctx/request.go
@@ -1,12 +1,10 @@
 package reqctx
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"time"
 
-	"github.com/streamingfast/dauth"
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 )
 
@@ -61,19 +59,4 @@ func (d *RequestDetails) ShouldReturnWrittenPartials(modName string) bool {
 func (d *RequestDetails) ShouldStreamCachedOutputs() bool {
 	return d.ProductionMode &&
 		d.ResolvedStartBlockNum < d.LinearHandoffBlockNum
-}
-
-// SetStageLayerParallelExecutorCountFromContext sets the MaxStageLayerParallelExecutor from the context
-// by first retrieving the dauth trusted headers and then parsing the value from the header, if present.
-func (d *RequestDetails) SetStageLayerParallelExecutorCountFromContext(ctx context.Context) {
-	trustedHeaders := dauth.FromContext(ctx)
-	if trustedHeaders == nil {
-		return
-	}
-
-	if parallelExecutors := trustedHeaders.Get("X-Sf-Substreams-Stage-Layer-Parallel-Executor-Max-Count"); parallelExecutors != "" {
-		if count, err := strconv.ParseUint(parallelExecutors, 10, 64); err == nil {
-			d.MaxStageLayerParallelExecutor = count
-		}
-	}
 }

--- a/service/testing.go
+++ b/service/testing.go
@@ -44,7 +44,7 @@ func (s *Tier1Service) TestBlocks(ctx context.Context, isSubRequest bool, reques
 		return stream.NewErrInvalidArg("%s", err.Error())
 	}
 
-	return s.blocks(ctx, request, execGraph, respFunc, metrics.NewReqStats(&metrics.Config{}, zap.NewNop()), nil)
+	return s.blocks(ctx, request, nil, execGraph, respFunc, metrics.NewReqStats(&metrics.Config{}, zap.NewNop()), nil)
 }
 
 func TestNewServiceTier2(moduleExecutionTracing bool, streamFactoryFunc StreamFactoryFunc) *Tier2Service {

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -336,7 +336,7 @@ func (s *Tier1Service) Blocks(
 			fields = append(fields, zap.String("deployment_id", auth["x-deployment-id"]))
 		}
 
-		if cacheTag := auth.Get("X-Sf-Substreams-Cache-Tag"); cacheTag != "" {
+		if cacheTag := auth.Get(reqctx.HeaderCacheTag); cacheTag != "" {
 			fields = append(fields,
 				zap.String("cache_tag", cacheTag),
 			)
@@ -440,7 +440,7 @@ func (s *Tier1Service) Blocks(
 	}()
 
 	respFunc := tier1ResponseHandler(respContext, &mut, logger, stream, request.NoopMode, reqStats, req.Msg.DevOutputModules)
-	err = s.blocks(runningContext, request, execGraph, respFunc, reqStats, fields)
+	err = s.blocks(runningContext, request, req.Header(), execGraph, respFunc, reqStats, fields)
 
 	if connectError := toConnectError(runningContext, err); connectError != nil {
 		switch connect.CodeOf(connectError) {
@@ -502,7 +502,7 @@ func (s *Tier1Service) writeLastUsed(ctx context.Context, execGraph *exec.Graph,
 
 var IsValidCacheTag = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString
 
-func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Request, execGraph *exec.Graph, respFunc substreams.ResponseFunc, reqStats *metrics.Stats, logFields []zap.Field) (err error) {
+func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Request, header http.Header, execGraph *exec.Graph, respFunc substreams.ResponseFunc, reqStats *metrics.Stats, logFields []zap.Field) (err error) {
 	chainFirstStreamableBlock := bstream.GetProtocolFirstStreamableBlock
 	if request.StartBlockNum > 0 && request.StartBlockNum < int64(chainFirstStreamableBlock) {
 		return bsstream.NewErrInvalidArg("invalid start block %d, must be >= %d (the first streamable block of the chain)", request.StartBlockNum, chainFirstStreamableBlock)
@@ -543,24 +543,16 @@ func (s *Tier1Service) blocks(ctx context.Context, request *pbsubstreamsrpc.Requ
 	}
 	requestDetails.UpdateInterval = time.Duration(request.ProgressMessagesIntervalMs) * time.Millisecond
 
-	requestDetails.MaxParallelJobs = s.runtimeConfig.DefaultParallelSubrequests
 	cacheTag := s.runtimeConfig.DefaultCacheTag
-	if auth := dauth.FromContext(ctx); auth != nil {
-		if parallelJobs := auth.Get("X-Sf-Substreams-Parallel-Jobs"); parallelJobs != "" {
-			if count, err := strconv.ParseUint(parallelJobs, 10, 64); err == nil {
-				requestDetails.MaxParallelJobs = count
-			}
+	if ct := dauth.FromContext(ctx).Get(reqctx.HeaderCacheTag); ct != "" {
+		if IsValidCacheTag(ct) {
+			cacheTag = ct
 		}
-		if tag := auth.Get("X-Sf-Substreams-Cache-Tag"); tag != "" {
-			if IsValidCacheTag(tag) {
-				cacheTag = tag
-			} else {
-				return fmt.Errorf("invalid value for X-Sf-Substreams-Cache-Tag %s, should only contain letters, numbers, hyphens and underscores", tag)
-			}
-		}
-
-		requestDetails.SetStageLayerParallelExecutorCountFromContext(ctx)
 	}
+
+	parallelJobs, parallelExecutors := reqctx.GetEffectiveHeaderValues(ctx, header, s.runtimeConfig.DefaultParallelSubrequests, reqctx.DefaultMaxStageLayerParallelExecutorCount)
+	requestDetails.MaxParallelJobs = parallelJobs
+	requestDetails.MaxStageLayerParallelExecutor = parallelExecutors
 
 	ctx = reqctx.WithRequest(ctx, requestDetails)
 	if s.runtimeConfig.ModuleExecutionTracing {

--- a/service/tier2.go
+++ b/service/tier2.go
@@ -220,7 +220,7 @@ func (s *Tier2Service) ProcessRange(request *pbssinternal.ProcessRangeRequest, s
 			zap.String("key_id", auth.APIKeyID()),
 			zap.String("ip_address", auth.RealIP()),
 		)
-		if cacheTag := auth.Get("X-Sf-Substreams-Cache-Tag"); cacheTag != "" {
+		if cacheTag := auth.Get(reqctx.HeaderCacheTag); cacheTag != "" {
 			fields = append(fields,
 				zap.String("cache_tag", cacheTag),
 			)
@@ -587,11 +587,11 @@ func (s *Tier2Service) getStores(ctx context.Context, request *pbssinternal.Proc
 
 	cacheTag := request.StateStoreDefaultTag
 	if auth := dauth.FromContext(ctx); auth != nil {
-		if ct := auth.Get("X-Sf-Substreams-Cache-Tag"); ct != "" {
+		if ct := auth.Get(reqctx.HeaderCacheTag); ct != "" {
 			if IsValidCacheTag(ct) {
 				cacheTag = ct
 			} else {
-				return nil, nil, nil, fmt.Errorf("invalid value for X-Sf-Substreams-Cache-Tag %s, should only contain letters, numbers, hyphens and undescores", ct)
+				return nil, nil, nil, fmt.Errorf("invalid value for %s: %q, should only contain letters, numbers, hyphens and underscores", reqctx.HeaderCacheTag, ct)
 			}
 		}
 	}


### PR DESCRIPTION
This magic was done in some custom authentication layer.

Now the auth layer will not passthrough all the headers: substreams can decide itself if a request header has precedence over the auth-provided ones.