### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -328,10 +328,7 @@ func (p *Pipeline) setupSubrequestStores(ctx context.Context) (storeMap store.Ma
 			storeConfig := p.stores.configs[mod.Name]
 
 			if isLastStage {
-				initialBlock := reqDetails.ResolvedStartBlockNum
-				if storeConfig.ModuleInitialBlock() > reqDetails.ResolvedStartBlockNum {
-					initialBlock = storeConfig.ModuleInitialBlock()
-				}
+				initialBlock := max(storeConfig.ModuleInitialBlock(), reqDetails.ResolvedStartBlockNum)
 				partialStore := storeConfig.NewPartialKV(initialBlock, logger)
 				storeMap.Set(partialStore)
 

--- a/pipeline/resolve.go
+++ b/pipeline/resolve.go
@@ -84,10 +84,7 @@ func BuildRequestDetails(
 
 	req.LinearHandoffBlockNum = linearHandoff
 
-	req.LinearGateBlockNum = req.LinearHandoffBlockNum
-	if req.ResolvedStartBlockNum > req.LinearHandoffBlockNum {
-		req.LinearGateBlockNum = req.ResolvedStartBlockNum
-	}
+	req.LinearGateBlockNum = max(req.ResolvedStartBlockNum, req.LinearHandoffBlockNum)
 
 	// if we start under the linearHandoff, it means we are in an irreversible section of the chain,
 	// the cursor has been resolved to 'resolvedStartBlockNum' and 'undoSignal', so it is not needed anymore
@@ -189,10 +186,7 @@ func resolveStartBlockNum(ctx context.Context, req *pbsubstreamsrpc.Request, res
 		if err != nil {
 			return 0, "", nil, fmt.Errorf("resolving negative start block: %w", err)
 		}
-		req.StartBlockNum = int64(headBlock) + req.StartBlockNum
-		if req.StartBlockNum < 0 {
-			req.StartBlockNum = 0
-		}
+		req.StartBlockNum = max(int64(headBlock)+req.StartBlockNum, 0)
 	}
 
 	if req.StartCursor == "" {

--- a/service/tier2.go
+++ b/service/tier2.go
@@ -795,10 +795,7 @@ func GetExecutionPlan(
 
 		c := execoutConfigs.ConfigMap[name]
 
-		moduleStartBlock := startBlock
-		if mod.InitialBlock > startBlock {
-			moduleStartBlock = mod.InitialBlock
-		}
+		moduleStartBlock := max(mod.InitialBlock, startBlock)
 
 		switch mod.ModuleKind() {
 		case pbsubstreams.ModuleKindBlockIndex:
@@ -881,10 +878,7 @@ func GetExecutionPlan(
 			continue // for stores that need to be run for the partials, but already have cached execution outputs
 		}
 
-		writerStartBlock := startBlock
-		if module.InitialBlock > startBlock {
-			writerStartBlock = module.InitialBlock
-		}
+		writerStartBlock := max(module.InitialBlock, startBlock)
 
 		switch module.ModuleKind() {
 		case pbsubstreams.ModuleKindBlockIndex:

--- a/storage/execout/streamproto/protostream_test.go
+++ b/storage/execout/streamproto/protostream_test.go
@@ -284,10 +284,8 @@ func TestEncode(t *testing.T) {
 	if !bytes.Equal(encodedFull, encodedStream) {
 		t.Logf("Encoding methods produced different results")
 		// You might want to examine the first few bytes to see where they differ
-		compareLength := min(len(encodedFull), len(encodedStream))
-		if compareLength > 20 {
-			compareLength = 20 // Limit to first 20 bytes for readability
-		}
+		// Limit to first 20 bytes for readability
+		compareLength := min(min(len(encodedFull), len(encodedStream)), 20)
 
 		t.Logf("First %d bytes of full encoding: %v", compareLength, encodedFull[:compareLength])
 		t.Logf("First %d bytes of streamed encoding: %v", compareLength, encodedStream[:compareLength])
@@ -417,10 +415,7 @@ func (r *slowReader) Read(p []byte) (n int, err error) {
 	}
 
 	remaining := len(r.data) - r.pos
-	toRead := len(p)
-	if toRead > r.maxBytesPerRead {
-		toRead = r.maxBytesPerRead
-	}
+	toRead := min(len(p), r.maxBytesPerRead)
 	if toRead > remaining {
 		toRead = remaining
 	}


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.