### PR TITLE
Fixed typos in several files

### DIFF
--- a/docs/new/how-to-guides/publish-package.md
+++ b/docs/new/how-to-guides/publish-package.md
@@ -31,4 +31,4 @@ In this guide, you'll learn how to publish a Substreams package to the [Substrea
 
 <figure><img src="../../.gitbook/assets/tutorials/publish-package/4_confirm.png" alt="" width="100%"></figure>
 
-That's it! You have succesfully published a package in the Substreams registry.
+That's it! You have successfully published a package in the Substreams registry.

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -657,7 +657,7 @@ func getFoundationalStores(inputs []wasm.Argument) []*foundational.Store {
 // BuildModuleExecutors builds the ModuleExecutors, and the loadedModules.
 func (p *Pipeline) BuildModuleExecutors(ctx context.Context) error {
 	if p.StagedModuleExecutors != nil {
-		// Eventually, we can invalidate our catch to accomodate the PATCH
+		// Eventually, we can invalidate our catch to accommodate the PATCH
 		// and rebuild all the modules, and tear down the previously loaded ones.
 		return nil
 	}

--- a/wasm/wazero/module.go
+++ b/wasm/wazero/module.go
@@ -211,13 +211,13 @@ func (m *Module) instantiateModule(ctx context.Context) (api.Module, error) {
 
 	if m.runtimeExtensions.Has(wasm.RuntimeExtensionIDWASMBindgenShims) {
 		// This must happen after the host modules are instantiated and just before we actually instantiate the user module.
-		// This is to ensure that we do not bind moddules that would be provided by us.
+		// This is to ensure that we do not bind modules that would be provided by us.
 		unboundedImports := m.gatherUnboundedModuleImports()
 
 		for moduleName, imports := range unboundedImports {
 			_, found := wasm.WASMBindgenModules[moduleName]
 			if !found {
-				// We only shims bindgen module, it will fail later since this module we skip is unbounded
+				// We only shim bindgen modules, it will fail later since this module we skip is unbounded
 				continue
 			}
 


### PR DESCRIPTION
Fix typos
Quick cleanup of a few spelling mistakes I spotted:
What changed:
accomodate → accommodate (pipeline.go comment)
moddules → modules (module.go comment)
succesfully → successfully (docs)