### PR TITLE
Fix Typos

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ Ensure you have [sfreleaser](https://github.com/streamingfast/sfreleaser) CLI, i
 
 ### Preparing for a release
 
-- Ensure tests past `go test ./...`
+- Ensure tests pass `go test ./...`
 - Ensure you are in a clean and pushed Git state
 - Update the [./docs/release-notes/change-log.md](./docs/release-notes/change-log.md) to update the `## Unreleased` header to become `## [${version}](https://github.com/streamingfast/substreams/releases/tag/v${version})`
 - Commit everything with message `Preparing release of ${version}`.

--- a/sink/sinker.go
+++ b/sink/sinker.go
@@ -218,7 +218,7 @@ func (s *Sinker) OutputModuleTypeUnprefixed() (unprefixed string) {
 	return
 }
 
-// ClientConfig returns the the `SubstreamsClientConfig`used by this sinker instance.
+// ClientConfig returns the `SubstreamsClientConfig` used by this sinker instance.
 func (s *Sinker) ClientConfig() *client.SubstreamsClientConfig {
 	return s.SinkerConfig.ClientConfig
 }


### PR DESCRIPTION
Corrects minor typos and grammar issues in documentation and code comments:

- RELEASE.md: "tests past" → "tests pass"
- sink/sinker.go: removed duplicate "the" in comment

