### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/docs/new/how-to-guides/sinks/sql/db_out.md
+++ b/docs/new/how-to-guides/sinks/sql/db_out.md
@@ -29,7 +29,7 @@ Consider that you want to dump all the Pump.Fun data decoded with an IDL into yo
 
 Clone the [Pump Fun Substreams GitHub repository](https://github.com/enoldev/pump-fun-substreams).
 
-### Inpsect the Project
+### Inspect the Project
 
 - Observe the `substreams.yaml` file:
 

--- a/docs/new/how-to-guides/sinks/sql/deployable-services/remote-service.md
+++ b/docs/new/how-to-guides/sinks/sql/deployable-services/remote-service.md
@@ -69,7 +69,7 @@ Services:
 1. **Service ID:** the identifier of the deployed service, which you can use to manage the service.
 2. **URL of the service status:** use this URL to verify the status of the service.
 3. **URL of the PostgreSQL client:** use this client to run SQL queries, update the SQL schema, and manage the SQL database in general.
-4. **URL of the GraphQL clent:** use this client to run GraphQL queries.
+4. **URL of the GraphQL client:** use this client to run GraphQL queries.
 
 ### Inspecting the PostgreSQL client
 

--- a/docs/new/references/old-references/gui.md
+++ b/docs/new/references/old-references/gui.md
@@ -23,7 +23,7 @@ The Substreams GUI is a command-line utility, so you use the keys in your keyboa
 | Navigate Modules - Forward                      | `i`  |
 | Navigate Modules - Backwards                    | `u`  |
 | Search                                          | `/` + *text* + `enter`  |
-| Commnads information                            | `?`  |
+| Commands information                            | `?`  |
 
 ## Launching the GUI
 
@@ -77,7 +77,7 @@ You can see the output of a different module by using the `u` and `i` keys. In t
 
 ### Searching in the Output
 
-To search for a speciifc text in the output:
+To search for a specific text in the output:
 
 1. Press the `/` key.
 2. Introduce the text.

--- a/wasm/bench/substreams_wasm/src/pb/sf.ethereum.type.v2.rs
+++ b/wasm/bench/substreams_wasm/src/pb/sf.ethereum.type.v2.rs
@@ -16,7 +16,7 @@ pub struct Block {
     /// and all other information the form a block.
     #[prost(message, optional, tag="5")]
     pub header: ::core::option::Option<BlockHeader>,
-    /// Uncles represents block produced with a valid solution but were not actually choosen
+    /// Uncles represents block produced with a valid solution but were not actually chosen
     /// as the canonical block for the given height so they are mostly "forked" blocks.
     ///
     /// If the Block has been produced using the Proof of Stake consensus algorithm, this
@@ -256,7 +256,7 @@ pub struct TransactionTrace {
     /// balance change for gas refunded to the transaction's emitter (e.g. `from`) and a balance change for the miner who
     /// received the transaction fees. There is also a nonce change for the transaction's emitter (e.g. `from`).
     ///
-    /// This means that to properly record the state changes for a transaction, you need to conditionally procees the
+    /// This means that to properly record the state changes for a transaction, you need to conditionally process the
     /// transaction's status.
     ///
     /// For a `SUCCEEDED` transaction, you iterate over the `calls` array and record the state changes for each call for
@@ -426,7 +426,7 @@ pub struct Call {
     #[prost(message, repeated, tag="28")]
     pub gas_changes: ::prost::alloc::vec::Vec<GasChange>,
     /// In Ethereum, a call can be either:
-    /// - Successfull, execution passes without any problem encountered
+    /// - Successful, execution passes without any problem encountered
     /// - Failed, execution failed, and remaining gas should be consumed
     /// - Reverted, execution failed, but only gas consumed so far is billed, remaining gas is refunded
     ///
@@ -441,7 +441,7 @@ pub struct Call {
     /// see above for details about those flags.
     #[prost(string, tag="11")]
     pub failure_reason: ::prost::alloc::string::String,
-    /// This field represents wheter or not the state changes performed
+    /// This field represents whether or not the state changes performed
     /// by this call were correctly recorded by the blockchain.
     ///
     /// On Ethereum, a transaction can record state changes even if some


### PR DESCRIPTION
 Corrects several typos found across documentation and generated code comments:
  - "Inpsect" → "Inspect"
  - "clent" → "client"
  - "Commnads" → "Commands"
  - "speciifc" → "specific"
  - "choosen" → "chosen"
  - "procees" → "process"
  - "Successfull" → "Successful"
  - "wheter" → "whether"