### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/orchestrator/stage/squash.go
+++ b/orchestrator/stage/squash.go
@@ -32,7 +32,6 @@ func (s *Stages) multiSquash(stage *Stage, mergeUnit Unit) error {
 			continue
 		}
 
-		modState := modState // capture in loop
 		stage.syncWork.Go(func() error {
 			stats := reqctx.ReqStats(s.ctx)
 			stats.RecordModuleMerging(modState.name)

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -589,7 +589,6 @@ func (s *Stages) FinalStoreMap(exclusiveEndBlock uint64) (store.Map, error) {
 	}
 
 	for _, modState := range storeModuleStates {
-		modState := modState
 		go func() {
 			fullKV, err := modState.getStore(s.ctx, exclusiveEndBlock)
 			loaded := loadedStore{

--- a/tui2/ui.go
+++ b/tui2/ui.go
@@ -110,7 +110,6 @@ func (ui *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if bundle, ok := msg.(streamui.ReplayBundle); ok {
 		var seq []tea.Cmd
 		for _, el := range bundle {
-			el := el
 			seq = append(seq, func() tea.Msg { return el })
 		}
 		return ui, tea.Sequence(seq...)


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore