### PR TITLE
chore: improve code comments clarity and consistency across manifest and client packages

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -209,7 +209,7 @@ func NewSubstreamsClientConfig(opts SubstreamsClientConfigOptions) *SubstreamsCl
 		}
 	} else {
 		if resolvedEndpoint := networks.GetSubstreamsEndpoint(endpoint); resolvedEndpoint != "" {
-			// Resolved endpoint from alias is always non-plaintext
+			// Resolved endpoint from alias is always using non-plaintext
 			endpoint = resolvedEndpoint
 			plaintext = false
 		}

--- a/manifest/graph.go
+++ b/manifest/graph.go
@@ -16,8 +16,8 @@ import (
 type ModuleGraph struct {
 	*graph.Mutable
 
-	currentHashesCache map[string][]byte // moduleName => hash
-
+	currentHashesCache map[string][]byte // moduleName -> moduleHash
+	
 	modules         []*pbsubstreams.Module
 	moduleIndex     map[string]int
 	indexIndex      map[int]*pbsubstreams.Module

--- a/manifest/package.go
+++ b/manifest/package.go
@@ -20,7 +20,7 @@ type manifestConverter struct {
 	reader     *Reader
 
 	// Runtime assigned while manifest is being converted, this feels weird
-	// but I haven't the "flemme" to refactor this right now.
+	// but I haven't had the time/motivation to refactor this right now.
 	sinkConfigDynamicMessage *dynamic.Message
 }
 

--- a/manifest/reader.go
+++ b/manifest/reader.go
@@ -489,6 +489,7 @@ func (r *Reader) registryBaseURL() string {
 	}
 	// This is an extreme fallback, because this should be
 	// set by the WithRegistryURL option.
+	// Default registry URL: https://spkg.io
 	return "https://spkg.io"
 }
 

--- a/manifest/signature.go
+++ b/manifest/signature.go
@@ -47,7 +47,7 @@ func (m *ModuleHashes) Iter(cb func(hash, name string) error) error {
 }
 
 func (m *ModuleHashes) HashModule(modules *pbsubstreams.Modules, module *pbsubstreams.Module, graph *ModuleGraph) (ModuleHash, error) {
-	//Simplified hash for testing purposes
+	// Simplified hash for testing purposes
 	if TestUseSimpleHash {
 		return m.hashModuleSimple(modules, module, graph)
 	}

--- a/sink/examples/simple-sink/main.go
+++ b/sink/examples/simple-sink/main.go
@@ -140,7 +140,7 @@ func (s *SimpleSink) HandleBlockScopedData(ctx context.Context, data *pbsubstrea
 	return nil
 }
 
-// handleBlockUndoSignal handles undo signals
+// HandleBlockUndoSignal handles undo signals
 func (s *SimpleSink) HandleBlockUndoSignal(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *sink.Cursor) error {
 
 	// Do something with the information about the UNDO event (chain reorg)


### PR DESCRIPTION


This commit enhances code readability by fixing inconsistent comment formatting, clarifying ambiguous comments, and standardizing terminology across various files in the manifest and client packages. 

The changes include correcting spacing issues, replacing informal language with professional terminology, and adding context to make comments more understandable for developers who are not familiar with the codebase internals.