### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/orchestrator/stage/squash_test.go
+++ b/orchestrator/stage/squash_test.go
@@ -120,7 +120,6 @@ func TestMultiSquashWithDifferentSegments(t *testing.T) {
 	mergeUnit := Unit{Stage: 0, Segment: 1}
 
 	for _, modState := range stage.storeModuleStates {
-		modState := modState
 		if mergeUnit.Segment < modState.segmenter.FirstIndex() {
 			continue
 		}
@@ -175,7 +174,6 @@ func TestMultiSquashErrorHandling(t *testing.T) {
 
 	// Simulate error in one of the goroutines
 	for idx := range stage.storeModuleStates {
-		idx := idx
 		stage.syncWork.Go(func() error {
 			if idx == 1 {
 				return assert.AnError // Simulate error in second module
@@ -327,7 +325,6 @@ func TestSyncWorkGroupBehavior(t *testing.T) {
 
 	// Spawn multiple goroutines with different execution times
 	for i := range 5 {
-		i := i
 		group.Go(func() error {
 			sleepTime := time.Duration(5-i) * 10 * time.Millisecond
 			time.Sleep(sleepTime)


### PR DESCRIPTION
Inspired by https://github.com/streamingfast/substreams/pull/711 and replace all.

The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore
