### PR TITLE
fix(sink): stop progressBlockRate janitor in Stats.Close()

### DIFF
--- a/sink/stats.go
+++ b/sink/stats.go
@@ -133,6 +133,7 @@ func (s *Stats) Close() {
 	s.Shutdown(nil)
 	s.dataMsgRate.Stop()
 	s.undoMsgRate.Stop()
+	s.progressBlockRate.Stop()
 }
 
 type unsetBlockRef struct{}

--- a/sink/stats_test.go
+++ b/sink/stats_test.go
@@ -1,0 +1,37 @@
+package sink
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestStatsCloseStopsAllRateJanitors verifies that Stats.Close() stops all
+// three dmetrics rate objects (dataMsgRate, undoMsgRate, progressBlockRate).
+//
+// Each AvgRate* object spawns an internal janitor goroutine on construction.
+// Before this fix, progressBlockRate.Stop() was missing, leaking one goroutine
+// per Stats lifecycle. In sink.Sinker's continuous-mode usage this produces a
+// linear goroutine slope over time.
+func TestStatsCloseStopsAllRateJanitors(t *testing.T) {
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	const iterations = 50
+	for range iterations {
+		s := newStats(zlog)
+		s.Close()
+	}
+
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	delta := after - before
+	if delta > 2 {
+		t.Errorf("goroutine leak: started=%d ended=%d delta=%d (want ≤2); "+
+			"likely progressBlockRate.Stop() is not called in Stats.Close()",
+			before, after, delta)
+	}
+}


### PR DESCRIPTION
Fixes #786

## Problem

\`Stats.Close()\` stops \`dataMsgRate\` and \`undoMsgRate\` but omits \`progressBlockRate.Stop()\`.

Each \`dmetrics.AvgRate*\` object spawns an internal janitor goroutine on construction. Without \`Stop()\`, that goroutine leaks for the process lifetime.

In code paths that repeatedly construct and tear down a \`Sinker\` — for example a continuous-mode loop that builds a fresh \`Sinker\` each collection interval — this produces **one leaked goroutine per iteration**, creating a linear goroutine growth visible in runtime metrics over hours/days.

## Fix

Add the missing \`s.progressBlockRate.Stop()\` call, symmetric with the other two.

## Test

\`sink/stats_test.go\` — \`TestStatsCloseStopsAllRateJanitors\`: creates and closes 50 \`Stats\` objects in a loop and asserts \`runtime.NumGoroutine()\` does not drift upward (delta ≤ 2). Pre-fix: delta = 50. Post-fix: delta ≈ 0.

## Context

Discovered while investigating a goroutine leak in a service using \`streamingfast/substreams/sink\` in continuous mode. The same bug existed in the now-deprecated \`streamingfast/substreams-sink\` package and was carried over when the \`sink\` package was ported into this repo.