### PR TITLE
fix: surface per-block execution timeouts instead of silently swallowing them

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Server: per-block execution timeouts (`--substreams-block-execution-timeout`) are no longer silently swallowed when a WASM host-function panic (e.g. wasmtime) coincides with the deadline. Previously, `recoverExecutionPanic` would return `nil` instead of `CodeDeadlineExceeded`, causing the offending block to be skipped and the stream to complete successfully.
 - CI: Docker image login, build and push are now skipped for fork PRs; image is still built (without push) to validate the Dockerfile.
 
 ## v1.18.5

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -663,14 +663,16 @@ func recoverExecutionPanic(ctx context.Context, executionError error, recovered 
 		recoveredErr = fmt.Errorf("%v", recovered)
 	}
 
+	// If the context deadline was exceeded, return a deadline exceeded error RPC error.
+	// This must be checked before context.Canceled, because the catch-all `ctx.Err() != nil`
+	// below would otherwise swallow deadline-exceeded panics and silently drop the block.
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return connect.NewError(connect.CodeDeadlineExceeded, fmt.Errorf("execution timed out at block %s: %w", blockRef, recoveredErr))
+	}
+
 	// If recovering from context cancel, simply return the execution error as-is
 	if ctx.Err() != nil || errors.Is(recoveredErr, context.Canceled) {
 		return executionError
-	}
-
-	// If the context deadline was exceeded, return a deadline exceeded error RPC error
-	if ctx.Err() == context.DeadlineExceeded {
-		return connect.NewError(connect.CodeDeadlineExceeded, fmt.Errorf("execution timed out at block %s: %w", blockRef, recoveredErr))
 	}
 
 	// Otherwise, log the panic and return a generic error
@@ -721,8 +723,10 @@ func (p *Pipeline) execute(ctx context.Context, executor exec.ModuleExecutor, ex
 				return
 			}
 
-			// Move the panic up so it's handled at a higher level by those who call execute()
-			panic(fmt.Errorf("unknown error: %s", r))
+			// Move the panic up so it's handled at a higher level by those who call execute().
+			// Wrap with %w (not %s) to preserve the error chain so that callers can
+			// errors.Is(err, context.DeadlineExceeded) on the result.
+			panic(fmt.Errorf("unknown error: %w", recoveredErr))
 		}
 	}()
 

--- a/pipeline/process_block_recover_test.go
+++ b/pipeline/process_block_recover_test.go
@@ -1,0 +1,99 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/streamingfast/bstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecoverExecutionPanic_DeadlineExceeded is the regression test for the
+// silent-swallow bug: when a WASM host-function panic coincides with the
+// per-block execution deadline, recoverExecutionPanic must return a
+// CodeDeadlineExceeded connect error — not nil — so the stream terminates
+// instead of skipping the block.
+func TestRecoverExecutionPanic_DeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	// Wait for the deadline to fire.
+	<-ctx.Done()
+	require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+
+	blockRef := bstream.NewBlockRef("blk-id", 42)
+	recovered := fmt.Errorf("running wasm extension %q: %w", "eth::eth_call",
+		fmt.Errorf("timeout while doing eth_call: %w", context.DeadlineExceeded))
+
+	got := recoverExecutionPanic(ctx, nil, recovered, blockRef)
+
+	require.NotNil(t, got, "deadline-exceeded panic must not be silently swallowed")
+
+	var ce *connect.Error
+	require.ErrorAs(t, got, &ce, "result must be a connect.Error")
+	assert.Equal(t, connect.CodeDeadlineExceeded, ce.Code())
+
+	// The original error chain must be preserved so callers can introspect.
+	assert.ErrorIs(t, got, context.DeadlineExceeded)
+	assert.Contains(t, got.Error(), "blk-id")
+}
+
+// TestRecoverExecutionPanic_ContextCanceled covers the non-deadline cancel
+// path: the recover must return the caller's executionError as-is (we don't
+// invent a new error when the request was cancelled).
+func TestRecoverExecutionPanic_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+
+	blockRef := bstream.NewBlockRef("blk-id", 42)
+	executionErr := errors.New("some prior error")
+
+	got := recoverExecutionPanic(ctx, executionErr, errors.New("panicked"), blockRef)
+	assert.Same(t, executionErr, got, "canceled ctx should return executionError unchanged")
+}
+
+// TestRecoverExecutionPanic_RecoveredIsCanceled covers the case where ctx
+// itself is alive but the panic value contains context.Canceled (e.g.
+// propagated through wrapping).
+func TestRecoverExecutionPanic_RecoveredIsCanceled(t *testing.T) {
+	ctx := context.Background()
+	blockRef := bstream.NewBlockRef("blk-id", 42)
+	executionErr := errors.New("some prior error")
+
+	recovered := fmt.Errorf("wrapped: %w", context.Canceled)
+	got := recoverExecutionPanic(ctx, executionErr, recovered, blockRef)
+	assert.Same(t, executionErr, got)
+}
+
+// TestRecoverExecutionPanic_GenericPanic verifies the fallback path: a real
+// runtime panic with a live ctx should yield a "panic at block ..." error
+// that wraps the recovered value.
+func TestRecoverExecutionPanic_GenericPanic(t *testing.T) {
+	ctx := context.Background()
+	blockRef := bstream.NewBlockRef("blk-id", 42)
+
+	recovered := errors.New("nil pointer dereference")
+	got := recoverExecutionPanic(ctx, nil, recovered, blockRef)
+
+	require.NotNil(t, got)
+	assert.ErrorIs(t, got, recovered)
+	assert.Contains(t, got.Error(), "blk-id")
+}
+
+// TestRecoverExecutionPanic_NonErrorRecovered handles the case where the
+// panic value isn't an `error` (e.g. a plain string panic from somewhere).
+func TestRecoverExecutionPanic_NonErrorRecovered(t *testing.T) {
+	ctx := context.Background()
+	blockRef := bstream.NewBlockRef("blk-id", 42)
+
+	got := recoverExecutionPanic(ctx, nil, "something broke", blockRef)
+
+	require.NotNil(t, got)
+	assert.Contains(t, got.Error(), "something broke")
+	assert.Contains(t, got.Error(), "blk-id")
+}


### PR DESCRIPTION
## Summary
Since https://github.com/streamingfast/substreams/commit/5b3f59b2 if block execution times out (like with non-deterministic `eth_call` call loop), the substreams engine quietly swallows that timeout error and skips the block as if it doesn't have any output. 
This PR should fix it. 

## Symptom

Running in development mode against tier1 node with `--substreams-block-execution-timeout=90s`:
```
❯ substreams run https://github.com/pinax-network/substreams-evm/releases/download/evm-balances-v0.3.3/evm-clickhouse-balances-v0.3.3.spkg db_out -e hyperevm.substreams.pinax.network:443 -s 35129899 -t +2 --limit-processed-blocks 0 --noop-mode
2026-05-27T16:43:48.966-0400 WARN (substreams) noop-mode used without production-mode: server will execute in development mode without sending the data, this is probably not what you want
Connecting...


----------- BLOCK #35,129,899 (8c85da1b36f703305b32e4d5128b7582c749c3b22decac5b4e4359ddde13d8df) age=307h6m26.769813s ---------------
----------- BLOCK #35,129,900 (7fe17e72c0412fb100795cfc9de4567949755e085c635354ee3d873a758cff1d) age=307h8m1.02479s ---------------
📊 Usage Report
 • Egress Bytes (uncompressed): 638 B
 • Processed Blocks: 1 blocks
 • Received Blocks: 2 blocks
Completed successfully

```

- Tier1 logs flood with `retrying RPCCall on non-deterministic RPC call error` for ~90s on a stuck `eth_call`.
- After 90s, `INFO (rpc-cache) stopping rpc calls here, context is canceled` fires (`rpccalls.go:467`) — proving the per-block ctx hit its deadline.
- 1 second later, the request successfully ends with `substreams request stats ... "error": ""`. The client sees `Completed successfully`. Egress stats show `Processed Blocks: 1, Received Blocks: 2` — one block silently dropped.

## Root cause

Two combined bugs in `pipeline/process_block.go`:

**1. Dead code in `recoverExecutionPanic`**:
```go
// If recovering from context cancel, simply return the execution error as-is
if ctx.Err() != nil || errors.Is(recoveredErr, context.Canceled) {
    return executionError
}

// If the context deadline was exceeded, return a deadline exceeded error RPC error
if ctx.Err() == context.DeadlineExceeded {            // ← unreachable
    return connect.NewError(connect.CodeDeadlineExceeded, ...)
}
```
The catch-all `ctx.Err() != nil` matches `DeadlineExceeded`, so the deadline-specific branch never fires. Function returns `executionError` (typically nil) → `executeModules` returns nil → block silently skipped.

**2. Broken error chain in `Pipeline.execute`'s re-panic**:
```go
panic(fmt.Errorf("unknown error: %s", r))
```
Uses `%s` instead of `%w`, severing the wrap chain. Even if the dead code were fixed, downstream callers couldn't `errors.Is(err, context.DeadlineExceeded)` on the result.

## Path through the code (for wasmtime)

1. Per-block ctx fires at 90s.
2. `rpccalls.go:476` returns `"timeout while doing eth_call ... cause: %w"` wrapping `context.DeadlineExceeded`.
3. `wasm/wasmtime/instance.go:49` `panic(fmt.Errorf("running wasm extension ...: %w", err))`.
4. wasmtime propagates the panic as a Go panic through `entrypoint.Call()` (no recover in `wasm/wasmtime/module.go`).
5. Propagates through `wasmCall` → `mapexec.run` → `RunModule` to `Pipeline.execute`'s deferred recover.
6. Doesn't match `ErrWasmDeterministicExec` / `ErrFoundationalStoreCanceled` → re-panic with broken `%s` wrap.
7. Caught by `executeModules`'s deferred recover → `recoverExecutionPanic(ctx, nil, ...)`.
8. `ctx.Err() != nil` (DeadlineExceeded) → returns `nil`.
9. Pipeline marches on. Once `block.Number > stopBlockNum`, `handleStepNew` returns `io.EOF` → stream "succeeds".

Wazero is unaffected: it converts host-function panics to error returns at `f.Call()`, so the recover path isn't entered.

## Fix

- `recoverExecutionPanic`: check `errors.Is(ctx.Err(), context.DeadlineExceeded)` **before** the catch-all so deadline-exceeded gets the intended `CodeDeadlineExceeded` connect error.
- `Pipeline.execute`'s re-panic: wrap with `%w` so the chain is preserved for any callers that inspect it.

## Bug introduced

Commit 5b3f59b2 (2025-10-21, "Improved panic handling and make clearer the intent when throwing errors in the WASM handlers") added `ctx.Err() != nil ||` to a previously-correct condition. Present in v1.17.0 and every release since.

## Test plan

- [x] `go vet ./pipeline/...` clean
- [x] `go test -short ./pipeline/...` passes
- [ ] Manual repro: stuck `eth_call` on a non-deterministic error (e.g. Reth `StackUnderflow`) with `--substreams-block-execution-timeout=90s`. Before this PR: client sees `Completed successfully` with `Processed: N-1 / Received: N`. After: client sees `DeadlineExceeded` gRPC error with `execution timed out at block ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)