### PR TITLE
docs: fix unclosed backtick breaking deltas mode note rendering

### DIFF
--- a/docs/references/substreams-components/modules/types.md
+++ b/docs/references/substreams-components/modules/types.md
@@ -128,7 +128,7 @@ let store = StoreUSDPrice {
 - `store.get_last() == "1.65"`: you get the _NewValue_ of the last delta which is the state at end of Block #1000.
 - `store.get_at(1) == "1.54"`: you get the _NewValue_ of the delta with _Ord == 1_, or the closest ordinal if _Ord == 1_ does not exist.
 
-The `store.get_at(1) is executed as follows:
+The `store.get_at(1)` is executed as follows:
 - Start with value = get_last() (1.65)
 - Iterate ord 4, value = delta.OldValue (1.47)
 - Iterate ord 3, value = delta.OldValue (<nil>)


### PR DESCRIPTION
## Summary

- Fix an unclosed backtick in the `store.get_at(1)` example inside `types.md`
- The missing closing backtick caused Markdown parsers to treat everything from that line down to the backtick before `` `set_sum` `` in the `deltas mode` section as one giant inline code span
- This garbled both hint-block notes in the `deltas mode` section — the first rendered raw and the second had its content split and merged incorrectly

## Test plan

- [ ] View `docs/references/substreams-components/modules/types.md` on GitBook and confirm the two info boxes in `deltas mode` render as proper styled callouts with correct text