### PR TITLE
validate more fields in executed partial blocks to detect reorgs even when transaction hashes are the same

### DIFF
--- a/pipeline/partials.go
+++ b/pipeline/partials.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"hash/fnv"
 
 	pbacme "github.com/streamingfast/dummy-blockchain/pb/sf/acme/type/v1"
 	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
@@ -60,10 +61,22 @@ func splitPartialblock(execOutput execout.ExecutionOutput, blockType string, pre
 			}
 
 			var hashMismatch bool
-			hasher := md5.New()
+			// fnv64a is non-cryptographic but fast and allocation-free; we only
+			// need to detect that the partial block matches the previous one, not
+			// to defend against collisions. We hash the transaction hash plus a
+			// deterministic marshalling of the receipt (and all its fields) for
+			// each trace, in order.
+			hasher := fnv.New64a()
+			marshalOpts := proto.MarshalOptions{Deterministic: true}
+			var receiptBuf []byte
 			for i, trx := range block.TransactionTraces {
-				if _, err := hasher.Write([]byte(trx.Hash)); err != nil {
-					return 0, nil, fmt.Errorf("hash transaction: %w", err)
+				hasher.Write(trx.Hash)
+				if trx.Receipt != nil {
+					receiptBuf, err = marshalOpts.MarshalAppend(receiptBuf[:0], trx.Receipt)
+					if err != nil {
+						return 0, nil, fmt.Errorf("hash transaction receipt: %w", err)
+					}
+					hasher.Write(receiptBuf)
 				}
 				if i+1 == prevTrxCount {
 					if !bytes.Equal(hasher.Sum(nil), expectedHash) {

--- a/pipeline/partials.go
+++ b/pipeline/partials.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"bytes"
 	"crypto/md5"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -63,20 +64,39 @@ func splitPartialblock(execOutput execout.ExecutionOutput, blockType string, pre
 			var hashMismatch bool
 			// fnv64a is non-cryptographic but fast and allocation-free; we only
 			// need to detect that the partial block matches the previous one, not
-			// to defend against collisions. We hash the transaction hash plus a
-			// deterministic marshalling of the receipt (and all its fields) for
-			// each trace, in order.
+			// to defend against collisions. For each trace, in order, we write the
+			// transaction hash and the receipt fields (and its logs) directly into
+			// the hasher. Fields are written by hand rather than via proto
+			// marshalling to avoid the reflection cost on this hot path; the
+			// fixed-width integers double as natural separators between records.
 			hasher := fnv.New64a()
-			marshalOpts := proto.MarshalOptions{Deterministic: true}
-			var receiptBuf []byte
+			var scratch [8]byte
+			writeUint64 := func(v uint64) {
+				binary.LittleEndian.PutUint64(scratch[:], v)
+				hasher.Write(scratch[:])
+			}
 			for i, trx := range block.TransactionTraces {
 				hasher.Write(trx.Hash)
-				if trx.Receipt != nil {
-					receiptBuf, err = marshalOpts.MarshalAppend(receiptBuf[:0], trx.Receipt)
-					if err != nil {
-						return 0, nil, fmt.Errorf("hash transaction receipt: %w", err)
+				if r := trx.Receipt; r != nil {
+					hasher.Write(r.StateRoot)
+					writeUint64(r.CumulativeGasUsed)
+					hasher.Write(r.LogsBloom)
+					for _, log := range r.Logs {
+						hasher.Write(log.Address)
+						for _, topic := range log.Topics {
+							hasher.Write(topic)
+						}
+						hasher.Write(log.Data)
+						writeUint64(uint64(log.Index))
+						writeUint64(uint64(log.BlockIndex))
+						writeUint64(log.Ordinal)
 					}
-					hasher.Write(receiptBuf)
+					if r.BlobGasUsed != nil {
+						writeUint64(*r.BlobGasUsed)
+					}
+					if r.BlobGasPrice != nil {
+						hasher.Write(r.BlobGasPrice.Bytes)
+					}
 				}
 				if i+1 == prevTrxCount {
 					if !bytes.Equal(hasher.Sum(nil), expectedHash) {

--- a/pipeline/partials.go
+++ b/pipeline/partials.go
@@ -80,16 +80,12 @@ func splitPartialblock(execOutput execout.ExecutionOutput, blockType string, pre
 				if r := trx.Receipt; r != nil {
 					hasher.Write(r.StateRoot)
 					writeUint64(r.CumulativeGasUsed)
-					hasher.Write(r.LogsBloom)
 					for _, log := range r.Logs {
 						hasher.Write(log.Address)
 						for _, topic := range log.Topics {
 							hasher.Write(topic)
 						}
 						hasher.Write(log.Data)
-						writeUint64(uint64(log.Index))
-						writeUint64(uint64(log.BlockIndex))
-						writeUint64(log.Ordinal)
 					}
 					if r.BlobGasUsed != nil {
 						writeUint64(*r.BlobGasUsed)


### PR DESCRIPTION
Problem:

If the state in reth flash-blocks executor is incorrect, it will only be detected
at the last flash-block, when the block hash is computed with its calculated state-root, 
validated against the next block's parent hash, then the block is recomputed.

Substreams detects that the block was replaced/recomputed base the list of transaction hashes,
it assumes that any change will come with different or disordered transactions.

If it does not (only the state is different, giving room to different events / state changes),
substreams will not detect the incorrect state and will not trigger a reorg.

Solution:

We now check more data on the transaction, including the full transaction receipt.
We changed the hashing algo for fnv which is better for small values (at least 2X, zero allocations, non-cryptographic)
