### PR TITLE
fix: forward x-organization-id to hosted foundational stores

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Server: `tier1` calls to hosted foundational stores now forward the `x-organization-id` identity header (alongside the existing trusted headers), so a store's internal trust-based listener can authorize the request without an end-user JWT. This fixes `Unauthenticated: required authorization token not found` errors when reading from hosted foundational stores resolved via the control-plane registry.
+
 ## v1.19.0
 
 ### Sink

--- a/wasm/call.go
+++ b/wasm/call.go
@@ -339,6 +339,38 @@ func (c *Call) DoHasLast(storeIndex int, key string) (found bool) {
 	return readStore.HasLast(key)
 }
 
+// foundationalStoreOutgoingContext builds the outgoing gRPC context used to call
+// a (possibly hosted) foundational store.
+//
+// It forwards the trusted identity headers resolved for this request (via dauth)
+// and, explicitly, the x-organization-id header so a hosted store's internal
+// (trust-based) listener can authorize the request without requiring the
+// end-user JWT, which is consumed upstream and never reaches tier1. For hosted
+// stores whose public endpoint still expects the original Bearer token, the raw
+// authorization header is forwarded when present in the incoming context.
+func foundationalStoreOutgoingContext(ctx context.Context, logger *zap.Logger) context.Context {
+	auth := dauth.FromContext(ctx)
+	callCtx := auth.ToOutgoingGRPCContext(ctx)
+
+	if orgID := auth.OrganizationID(); orgID != "" {
+		callCtx = metadata.AppendToOutgoingContext(callCtx, dauth.HeaderNewOrganizationID, orgID)
+	}
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if auths := md.Get("authorization"); len(auths) > 0 {
+			if ce := logger.Check(zap.DebugLevel, "forwarding foundational store authorization header"); ce != nil {
+				ce.Write(
+					zap.Int("token_length", len(auths[0])),
+					zap.String("organization_id", auth.OrganizationID()),
+				)
+			}
+			callCtx = metadata.AppendToOutgoingContext(callCtx, "authorization", auths[0])
+		}
+	}
+
+	return callCtx
+}
+
 func (c *Call) DoFoundationalStoreGet(index uint32, keys *pbmodel.Keys) *pbmodel.QueriedEntries {
 	c.validateFoundationalStoreIndex(int(index), "foundational_store_get_all")
 
@@ -346,20 +378,7 @@ func (c *Call) DoFoundationalStoreGet(index uint32, keys *pbmodel.Keys) *pbmodel
 	logger = logger.Named("DoFoundationalStoreGet")
 
 	for {
-		auth := dauth.FromContext(c.ctx)
-		callCtx := auth.ToOutgoingGRPCContext(c.ctx)
-		// Forward raw authorization header if present (for hosted store auth plugins that expect the original Bearer token)
-		if md, ok := metadata.FromIncomingContext(c.ctx); ok {
-			if auths := md.Get("authorization"); len(auths) > 0 {
-				if ce := logger.Check(zap.DebugLevel, "forwarding foundational store authorization header"); ce != nil {
-					ce.Write(
-						zap.Int("token_length", len(auths[0])),
-						zap.String("organization_id", auth.OrganizationID()),
-					)
-				}
-				callCtx = metadata.AppendToOutgoingContext(callCtx, "authorization", auths[0])
-			}
-		}
+		callCtx := foundationalStoreOutgoingContext(c.ctx, logger)
 		ctx, cancel := context.WithTimeoutCause(callCtx, foundationalStoreMaxWaitTime, fmt.Errorf("foundational store get_all timeout after %s", foundationalStoreMaxWaitTime))
 		defer cancel()
 
@@ -400,20 +419,7 @@ func (c *Call) DoFoundationalStoreGetFirst(index uint32, keys *pbmodel.Keys) *pb
 	logger := reqctx.Logger(c.ctx).With(zap.Uint32("foundational_store_index", index))
 
 	for {
-		auth := dauth.FromContext(c.ctx)
-		callCtx := auth.ToOutgoingGRPCContext(c.ctx)
-		// Forward raw authorization header if present (for hosted store auth plugins that expect the original Bearer token)
-		if md, ok := metadata.FromIncomingContext(c.ctx); ok {
-			if auths := md.Get("authorization"); len(auths) > 0 {
-				if ce := logger.Check(zap.DebugLevel, "forwarding foundational store authorization header"); ce != nil {
-					ce.Write(
-						zap.Int("token_length", len(auths[0])),
-						zap.String("organization_id", auth.OrganizationID()),
-					)
-				}
-				callCtx = metadata.AppendToOutgoingContext(callCtx, "authorization", auths[0])
-			}
-		}
+		callCtx := foundationalStoreOutgoingContext(c.ctx, logger)
 		ctx, cancel := context.WithTimeoutCause(callCtx, foundationalStoreMaxWaitTime, fmt.Errorf("foundational store get_all timeout after %s", foundationalStoreMaxWaitTime))
 		defer cancel()
 


### PR DESCRIPTION
## Problem

tier1 calls to hosted foundational stores were rejected with:

```
Unauthenticated: required authorization token not found. Please provide a valid JWT token via 'authorization' header or an API key via 'x-api-key' header
```

tier1 correctly resolves and dials the registry's internal endpoint (`*.hs-internal.streamingfast.io:9000`), but only forwards trusted identity headers — the end-user JWT is consumed upstream by the gateway and never reaches tier1. The hosted store's auth did not accept those headers.

## Change

When calling a foundational store, tier1 now explicitly forwards the `x-organization-id` identity header (alongside the existing trusted headers via `dauth.ToOutgoingGRPCContext`), so a store's internal trust-based listener can authorize the request without an end-user JWT. The duplicated auth-forwarding logic in `DoFoundationalStoreGet`/`DoFoundationalStoreGetFirst` is extracted into a shared helper.

Pairs with **substreams-foundational-store #14**, which adds the internal trusted listener that accepts these headers. Both must land for the fix to work end to end.

## Test

- `go build ./wasm/...` ✅
- `go test ./wasm/` ✅
- `go vet ./wasm/` ✅