### PR TITLE
Fail fast on fatal foundational store errors

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Server: `tier1` calls to hosted foundational stores now forward the `x-organization-id` identity header (alongside the existing trusted headers), so a store's internal trust-based listener can authorize the request without an end-user JWT. This fixes `Unauthenticated: required authorization token not found` errors when reading from hosted foundational stores resolved via the control-plane registry.
+- Server: foundational store calls that fail with authentication errors, organization id mismatch, or prolonged unreachability now bubble up to the user as a non-deterministic (uncached) error instead of retrying until the global deadline. Transient unavailability is still retried (~30s) to absorb blips and rolling restarts.
 
 ## v1.19.0
 

--- a/orchestrator/work/worker_foundational_store_test.go
+++ b/orchestrator/work/worker_foundational_store_test.go
@@ -1,0 +1,127 @@
+package work
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/streamingfast/substreams"
+	"github.com/streamingfast/substreams/client"
+	"github.com/streamingfast/substreams/metrics"
+	"github.com/streamingfast/substreams/orchestrator/response"
+	"github.com/streamingfast/substreams/orchestrator/stage"
+	pbssinternal "github.com/streamingfast/substreams/pb/sf/substreams/intern/v2"
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
+	"github.com/streamingfast/substreams/reqctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestMain(m *testing.M) {
+	// work() touches tier1 worker metrics (e.g. Tier1ActiveWorkerRequest), which
+	// are nil until declared.
+	metrics.DeclareTier1Metrics(zap.NewNop())
+	os.Exit(m.Run())
+}
+
+// fakeProcessRangeStream is a grpc.ServerStreamingClient that yields a single
+// error on the first Recv (mimicking a tier2 worker that fails immediately, e.g.
+// because a foundational store call returned an auth / org-mismatch error).
+type fakeProcessRangeStream struct {
+	err error
+}
+
+func (s *fakeProcessRangeStream) Recv() (*pbssinternal.ProcessRangeResponse, error) {
+	return nil, s.err
+}
+func (s *fakeProcessRangeStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+func (s *fakeProcessRangeStream) Trailer() metadata.MD         { return nil }
+func (s *fakeProcessRangeStream) CloseSend() error             { return nil }
+func (s *fakeProcessRangeStream) Context() context.Context     { return context.Background() }
+func (s *fakeProcessRangeStream) SendMsg(any) error            { return nil }
+func (s *fakeProcessRangeStream) RecvMsg(any) error            { return nil }
+
+// fakeSubstreamsClient counts ProcessRange calls and returns a stream that fails
+// with the configured error.
+type fakeSubstreamsClient struct {
+	err   error
+	calls int
+}
+
+func (c *fakeSubstreamsClient) ProcessRange(ctx context.Context, in *pbssinternal.ProcessRangeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[pbssinternal.ProcessRangeResponse], error) {
+	c.calls++
+	return &fakeProcessRangeStream{err: c.err}, nil
+}
+
+func testWorkerCtx() context.Context {
+	ctx := context.Background()
+	ctx = reqctx.WithRequest(ctx, &reqctx.RequestDetails{OutputModule: "m", Modules: &pbsubstreams.Modules{}})
+	ctx = reqctx.WithTier2RequestParameters(ctx, reqctx.Tier2RequestParameters{StateBundleSize: 10})
+
+	stats := metrics.NewReqStats(&metrics.Config{}, nil, nil, zap.NewNop())
+	stats.RecordStages([]*pbsubstreamsrpc.Stage{{Modules: []string{"m"}}})
+	ctx = reqctx.WithReqStats(ctx, stats)
+	return ctx
+}
+
+func newFakeWorker(streamErr error) (*RemoteWorker, *fakeSubstreamsClient) {
+	fake := &fakeSubstreamsClient{err: streamErr}
+	factory := func() (pbssinternal.SubstreamsClient, func() error, []grpc.CallOption, client.Headers, error) {
+		return fake, func() error { return nil }, nil, client.Headers{}, nil
+	}
+	return NewRemoteWorker(factory, "test-worker", zap.NewNop()), fake
+}
+
+// TestWork_FoundationalStoreFatalIsRetryable validates how tier1 classifies the
+// gRPC error that a foundational store fatal failure arrives as. Tier2 emits it
+// as codes.Internal (see service.toGRPCError), and tier1 treats codes.Internal
+// as retryable, while a deterministic codes.InvalidArgument is non-retryable.
+func TestWork_FoundationalStoreFatalIsRetryable(t *testing.T) {
+	upstream := response.New(func(substreams.ResponseFromAnyTier) error { return nil })
+	request := &pbssinternal.ProcessRangeRequest{SegmentNumber: 0, SegmentSize: 10}
+
+	t.Run("internal (foundational store fatal) is retryable", func(t *testing.T) {
+		w, _ := newFakeWorker(status.Error(codes.Internal, "module \"m\": foundational store request failed: store unreachable: connection refused"))
+		res := w.work(testWorkerCtx(), request, nil, upstream, 0)
+
+		var retryable *RetryableErr
+		require.True(t, errors.As(res.Error, &retryable), "codes.Internal must be retryable, got: %v", res.Error)
+	})
+
+	t.Run("invalid argument (deterministic) is not retryable", func(t *testing.T) {
+		w, _ := newFakeWorker(status.Error(codes.InvalidArgument, "module \"m\": boom (deterministic error)"))
+		res := w.work(testWorkerCtx(), request, nil, upstream, 0)
+
+		var retryable *RetryableErr
+		require.False(t, errors.As(res.Error, &retryable), "codes.InvalidArgument must NOT be retryable, got: %v", res.Error)
+		require.Error(t, res.Error)
+	})
+}
+
+// TestWork_RetriesThenBubblesUp validates that a foundational store fatal error
+// (arriving as codes.Internal) is retried exactly workerMaxRetries times before
+// it gives up and bubbles up to the user as a failed job. workerMaxRetries is
+// lowered here to keep the test fast (the real default is 5).
+func TestWork_RetriesThenBubblesUp(t *testing.T) {
+	prev := workerMaxRetries
+	workerMaxRetries = 2
+	defer func() { workerMaxRetries = prev }()
+
+	w, fake := newFakeWorker(status.Error(codes.Internal, "module \"m\": foundational store request failed: organization id mismatch"))
+
+	cmd := w.Work(testWorkerCtx(), stage.Unit{Stage: 0, Segment: 0}, 0, []string{"m"}, response.New(func(substreams.ResponseFromAnyTier) error { return nil }), false)
+	msg := cmd()
+
+	failed, ok := msg.(MsgJobFailed)
+	require.True(t, ok, "expected MsgJobFailed, got %T", msg)
+	require.Error(t, failed.Error)
+	assert.Contains(t, failed.Error.Error(), "giving up", "error should indicate retries were exhausted")
+	assert.Equal(t, workerMaxRetries, fake.calls, "segment must be attempted exactly workerMaxRetries times")
+}

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -751,7 +751,7 @@ func (p *Pipeline) execute(ctx context.Context, executor exec.ModuleExecutor, ex
 			}
 
 			// Those are not deterministic errors, just propagate them up for now, but the context is probably cancelled at this point
-			if errors.Is(recoveredErr, wasm.ErrFoundationalStoreCanceled) {
+			if errors.Is(recoveredErr, wasm.ErrFoundationalStoreCanceled) || errors.Is(recoveredErr, wasm.ErrFoundationalStoreFatal) {
 				out.err = recoveredErr
 				return
 			}

--- a/service/tier2_foundational_store_error_test.go
+++ b/service/tier2_foundational_store_error_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/streamingfast/substreams/wasm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestToGRPCError_FoundationalStoreFatalIsInternal documents how a foundational
+// store fatal error (auth failure, org id mismatch, prolonged unreachability)
+// crosses the tier2 -> tier1 boundary.
+//
+// Unlike a deterministic wasm error (codes.InvalidArgument, which tier1 treats
+// as non-retryable), a foundational store fatal error is non-deterministic and
+// is emitted as codes.Internal. tier1's RemoteWorker.work treats codes.Internal
+// as retryable, so the segment is retried up to workerMaxRetries (5) times
+// before the error bubbles up to the user, uncached.
+func TestToGRPCError_FoundationalStoreFatalIsInternal(t *testing.T) {
+	ctx := context.Background()
+
+	// Mirrors how the error reaches tier2's toGRPCError: wrapped a few times as
+	// it unwinds from the wasm host call through process_block.
+	fatal := fmt.Errorf("running executor %q: %w", "mymodule",
+		fmt.Errorf("execute module: %w",
+			fmt.Errorf("module %q: %w", "mymodule",
+				fmt.Errorf("%w: store unreachable: %s", wasm.ErrFoundationalStoreFatal, "connection refused"))))
+
+	grpcErr := toGRPCError(ctx, fatal)
+	require.Error(t, grpcErr)
+
+	st, ok := status.FromError(grpcErr)
+	require.True(t, ok, "expected a gRPC status error")
+	assert.Equal(t, codes.Internal, st.Code(),
+		"foundational store fatal errors must be Internal (non-deterministic, retried by tier1 then bubbled up), not InvalidArgument")
+}
+
+// TestToGRPCError_DeterministicIsInvalidArgument is the contrast case: a
+// deterministic wasm error is emitted as InvalidArgument and is NOT retried by
+// tier1 (and is cached on tier2).
+func TestToGRPCError_DeterministicIsInvalidArgument(t *testing.T) {
+	ctx := context.Background()
+
+	det := fmt.Errorf("module %q: %w", "mymodule", wasm.ErrWasmDeterministicExec)
+
+	grpcErr := toGRPCError(ctx, det)
+	require.Error(t, grpcErr)
+
+	st, ok := status.FromError(grpcErr)
+	require.True(t, ok, "expected a gRPC status error")
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}

--- a/wasm/call.go
+++ b/wasm/call.go
@@ -20,16 +20,31 @@ import (
 	"github.com/streamingfast/substreams/reqctx"
 	"github.com/streamingfast/substreams/storage/store"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 var ErrWasmDeterministicExec = errors.New("wasm execution failed deterministically")
 var ErrFoundationalStoreCanceled = errors.New("foundational store request canceled")
 
+// ErrFoundationalStoreFatal indicates a foundational store call failed in a way
+// that retrying will not fix (authentication failure, organization id mismatch,
+// or the store being unreachable). It is non-deterministic so it bubbles up to
+// the user without being cached.
+var ErrFoundationalStoreFatal = errors.New("foundational store request failed")
+
 // Foundational store retry configuration constants
 const (
 	foundationalStoreRetryDelay  = 100 * time.Millisecond
 	foundationalStoreMaxWaitTime = 30 * time.Second
+
+	// foundationalStoreMaxUnreachableRetries bounds how many consecutive
+	// "unreachable" (codes.Unavailable) responses we tolerate before giving up,
+	// so a transient blip or rolling restart is absorbed but a truly down or
+	// misconfigured endpoint fails fast instead of retrying until the global
+	// deadline. At foundationalStoreRetryDelay each, this is ~30s of budget.
+	foundationalStoreMaxUnreachableRetries = 300
 )
 
 type Call struct {
@@ -377,6 +392,7 @@ func (c *Call) DoFoundationalStoreGet(index uint32, keys *pbmodel.Keys) *pbmodel
 	logger := reqctx.Logger(c.ctx).With(zap.Uint32("foundational_store_index", index))
 	logger = logger.Named("DoFoundationalStoreGet")
 
+	unreachableRetries := 0
 	for {
 		callCtx := foundationalStoreOutgoingContext(c.ctx, logger)
 		ctx, cancel := context.WithTimeoutCause(callCtx, foundationalStoreMaxWaitTime, fmt.Errorf("foundational store get_all timeout after %s", foundationalStoreMaxWaitTime))
@@ -401,6 +417,10 @@ func (c *Call) DoFoundationalStoreGet(index uint32, keys *pbmodel.Keys) *pbmodel
 				c.PanicNonDeterministicError(ErrFoundationalStoreCanceled)
 			}
 
+			// Fatal errors (auth, org id mismatch, prolonged unreachability) bubble
+			// up as non-deterministic instead of retrying until the global deadline.
+			c.handleFoundationalStoreError(err, &unreachableRetries)
+
 			logger.Warn("failed to call foundational store", zap.Error(err))
 			time.Sleep(foundationalStoreRetryDelay)
 			continue
@@ -418,6 +438,7 @@ func (c *Call) DoFoundationalStoreGetFirst(index uint32, keys *pbmodel.Keys) *pb
 
 	logger := reqctx.Logger(c.ctx).With(zap.Uint32("foundational_store_index", index))
 
+	unreachableRetries := 0
 	for {
 		callCtx := foundationalStoreOutgoingContext(c.ctx, logger)
 		ctx, cancel := context.WithTimeoutCause(callCtx, foundationalStoreMaxWaitTime, fmt.Errorf("foundational store get_all timeout after %s", foundationalStoreMaxWaitTime))
@@ -442,6 +463,10 @@ func (c *Call) DoFoundationalStoreGetFirst(index uint32, keys *pbmodel.Keys) *pb
 				c.PanicNonDeterministicError(ErrFoundationalStoreCanceled)
 			}
 
+			// Fatal errors (auth, org id mismatch, prolonged unreachability) bubble
+			// up as non-deterministic instead of retrying until the global deadline.
+			c.handleFoundationalStoreError(err, &unreachableRetries)
+
 			logger.Warn("failed to call foundational store", zap.Error(err))
 			time.Sleep(foundationalStoreRetryDelay)
 			continue
@@ -452,6 +477,25 @@ func (c *Call) DoFoundationalStoreGetFirst(index uint32, keys *pbmodel.Keys) *pb
 		}
 
 		time.Sleep(foundationalStoreRetryDelay)
+	}
+}
+
+// handleFoundationalStoreError classifies a gRPC error returned by a foundational
+// store call. Fatal errors that retrying cannot fix (authentication failure,
+// organization id mismatch, or the store being unreachable for too long) panic
+// with a non-deterministic error so they bubble up to the user uncached. Other
+// errors return so the caller keeps retrying (e.g. a local request timeout, or
+// the store not having reached the requested block yet). unreachableRetries
+// accumulates consecutive codes.Unavailable responses across the retry loop.
+func (c *Call) handleFoundationalStoreError(err error, unreachableRetries *int) {
+	switch status.Code(err) {
+	case codes.Unauthenticated, codes.PermissionDenied:
+		c.PanicNonDeterministicError(fmt.Errorf("%w: %s", ErrFoundationalStoreFatal, err))
+	case codes.Unavailable:
+		*unreachableRetries++
+		if *unreachableRetries > foundationalStoreMaxUnreachableRetries {
+			c.PanicNonDeterministicError(fmt.Errorf("%w: store unreachable after %d attempts: %s", ErrFoundationalStoreFatal, *unreachableRetries, err))
+		}
 	}
 }
 

--- a/wasm/call.go
+++ b/wasm/call.go
@@ -38,14 +38,15 @@ var ErrFoundationalStoreFatal = errors.New("foundational store request failed")
 const (
 	foundationalStoreRetryDelay  = 100 * time.Millisecond
 	foundationalStoreMaxWaitTime = 30 * time.Second
-
-	// foundationalStoreMaxUnreachableRetries bounds how many consecutive
-	// "unreachable" (codes.Unavailable) responses we tolerate before giving up,
-	// so a transient blip or rolling restart is absorbed but a truly down or
-	// misconfigured endpoint fails fast instead of retrying until the global
-	// deadline. At foundationalStoreRetryDelay each, this is ~30s of budget.
-	foundationalStoreMaxUnreachableRetries = 300
 )
+
+// foundationalStoreMaxUnreachableRetries bounds how many consecutive
+// "unreachable" (codes.Unavailable) responses we tolerate before giving up, so a
+// transient blip or rolling restart is absorbed but a truly down or
+// misconfigured endpoint fails fast instead of retrying until the global
+// deadline. At foundationalStoreRetryDelay each, this is ~30s of budget. It is a
+// var (not a const) so tests can lower it.
+var foundationalStoreMaxUnreachableRetries = 300
 
 type Call struct {
 	ctx        context.Context

--- a/wasm/foundational_store_test.go
+++ b/wasm/foundational_store_test.go
@@ -1,0 +1,166 @@
+package wasm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pbmodel "github.com/streamingfast/substreams/pb/sf/substreams/foundational-store/model/v2"
+	pbservice "github.com/streamingfast/substreams/pb/sf/substreams/foundational-store/service/v2"
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// step is one scripted response from the fake foundational store.
+type step struct {
+	resp *pbservice.GetResponse
+	err  error
+}
+
+// fakeStoreClient returns the scripted steps in order, repeating the last one
+// once exhausted (so "always Unavailable" scripts can be a single step).
+type fakeStoreClient struct {
+	steps []step
+	calls int
+}
+
+func (f *fakeStoreClient) next() (*pbservice.GetResponse, error) {
+	i := f.calls
+	f.calls++
+	if i >= len(f.steps) {
+		i = len(f.steps) - 1
+	}
+	return f.steps[i].resp, f.steps[i].err
+}
+
+func (f *fakeStoreClient) Get(ctx context.Context, in *pbservice.GetRequest, opts ...grpc.CallOption) (*pbservice.GetResponse, error) {
+	return f.next()
+}
+
+func (f *fakeStoreClient) GetFirst(ctx context.Context, in *pbservice.GetRequest, opts ...grpc.CallOption) (*pbservice.GetResponse, error) {
+	return f.next()
+}
+
+// runFoundationalGet drives DoFoundationalStoreGet / DoFoundationalStoreGetFirst
+// the same way pipeline.execute() does: any panic from the wasm host function is
+// recovered into an error. That recovered error is exactly what
+// process_block.go inspects with errors.Is to decide whether to cache it.
+func runFoundationalGet(client pbservice.StoreClient, useFirst bool) (entries *pbmodel.QueriedEntries, recovered error) {
+	call := NewCall(
+		context.Background(),
+		&pbsubstreams.Clock{Number: 100},
+		"test_module",
+		"entrypoint",
+		nil,
+		nil,
+		false,
+		[]pbservice.StoreClient{client},
+	)
+
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok {
+				recovered = err
+			} else {
+				recovered = errors.New("non-error panic")
+			}
+		}
+	}()
+
+	keys := &pbmodel.Keys{Keys: []*pbmodel.Key{{Bytes: []byte("some-key")}}}
+	if useFirst {
+		entries = call.DoFoundationalStoreGetFirst(0, keys)
+	} else {
+		entries = call.DoFoundationalStoreGet(0, keys)
+	}
+	return
+}
+
+// assertFatalNonDeterministic asserts the recovered error bubbles up to the user
+// uncached: it must be a foundational-store fatal error and must NOT be a
+// deterministic error (which would be written to the cache by process_block.go).
+func assertFatalNonDeterministic(t *testing.T, recovered error) {
+	t.Helper()
+	require.Error(t, recovered)
+	assert.True(t, errors.Is(recovered, ErrFoundationalStoreFatal), "must be a foundational store fatal error, got: %v", recovered)
+	assert.False(t, errors.Is(recovered, ErrWasmDeterministicExec), "must NOT be deterministic (would be cached), got: %v", recovered)
+	assert.False(t, errors.Is(recovered, ErrFoundationalStoreCanceled), "must not be the upstream-cancel error, got: %v", recovered)
+}
+
+func TestFoundationalStore_FatalErrorsBubbleUp(t *testing.T) {
+	// auth failures and org id mismatches must fail fast instead of retrying
+	// until the global deadline.
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"unauthenticated", status.Error(codes.Unauthenticated, "missing authenticated context")},
+		{"permission_denied", status.Error(codes.PermissionDenied, "organization id mismatch")},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name+"/get", func(t *testing.T) {
+			client := &fakeStoreClient{steps: []step{{err: c.err}}}
+			entries, recovered := runFoundationalGet(client, false)
+			assert.Nil(t, entries)
+			assertFatalNonDeterministic(t, recovered)
+			assert.Equal(t, 1, client.calls, "fatal error must not be retried")
+		})
+		t.Run(c.name+"/get_first", func(t *testing.T) {
+			client := &fakeStoreClient{steps: []step{{err: c.err}}}
+			entries, recovered := runFoundationalGet(client, true)
+			assert.Nil(t, entries)
+			assertFatalNonDeterministic(t, recovered)
+			assert.Equal(t, 1, client.calls, "fatal error must not be retried")
+		})
+	}
+}
+
+func TestFoundationalStore_UnreachableRetriesThenBubblesUp(t *testing.T) {
+	prev := foundationalStoreMaxUnreachableRetries
+	foundationalStoreMaxUnreachableRetries = 2
+	defer func() { foundationalStoreMaxUnreachableRetries = prev }()
+
+	// Unavailable (unreachable) is retried up to the cap, then bubbles up as a
+	// fatal non-deterministic error.
+	client := &fakeStoreClient{steps: []step{{err: status.Error(codes.Unavailable, "connection refused")}}}
+	entries, recovered := runFoundationalGet(client, false)
+	assert.Nil(t, entries)
+	assertFatalNonDeterministic(t, recovered)
+	assert.Greater(t, client.calls, foundationalStoreMaxUnreachableRetries, "should have retried before giving up")
+}
+
+func TestFoundationalStore_TransientUnavailableIsAbsorbed(t *testing.T) {
+	// A single Unavailable blip followed by success must NOT bubble up: the call
+	// retries and returns the entries.
+	wantEntries := &pbmodel.QueriedEntries{}
+	client := &fakeStoreClient{steps: []step{
+		{err: status.Error(codes.Unavailable, "rolling restart")},
+		{resp: &pbservice.GetResponse{BlockReached: true, Entries: wantEntries}},
+	}}
+
+	entries, recovered := runFoundationalGet(client, false)
+	require.NoError(t, recovered)
+	assert.Same(t, wantEntries, entries)
+	assert.Equal(t, 2, client.calls)
+}
+
+func TestFoundationalStore_BlockNotReachedRetries(t *testing.T) {
+	// A non-error response that hasn't reached the block yet keeps retrying
+	// (store catching up) and is not treated as fatal.
+	wantEntries := &pbmodel.QueriedEntries{}
+	client := &fakeStoreClient{steps: []step{
+		{resp: &pbservice.GetResponse{BlockReached: false}},
+		{resp: &pbservice.GetResponse{BlockReached: false}},
+		{resp: &pbservice.GetResponse{BlockReached: true, Entries: wantEntries}},
+	}}
+
+	entries, recovered := runFoundationalGet(client, false)
+	require.NoError(t, recovered)
+	assert.Same(t, wantEntries, entries)
+	assert.Equal(t, 3, client.calls)
+}


### PR DESCRIPTION
## Problem

Foundational store calls that fail with authentication errors, organization id mismatch, or unreachability retried forever until the global context deadline. These never recover on retry, so the user just saw a deadline timeout instead of the real cause, and the timeout could get cached.

## Change

Classify gRPC errors from foundational store `Get`/`GetFirst` calls:

- `codes.Unauthenticated` (auth) and `codes.PermissionDenied` (org id mismatch) → bubble up immediately as a non-deterministic (uncached) error.
- `codes.Unavailable` (unreachable) → retried up to ~30s (`foundationalStoreMaxUnreachableRetries = 300` at 100ms delay) to absorb transient blips and rolling restarts, then bubbles up.
- Local request timeout (`DeadlineExceeded`) and "store hasn't reached block yet" (`!BlockReached`) → retry forever, unchanged.

`ErrFoundationalStoreFatal` propagates as a non-deterministic error via the same path as the existing `ErrFoundationalStoreCanceled`, so it is not cached.

Upstream-cancel check still runs first, so it wins over fatal classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)