### PR TITLE
Prevent mmap store file leaks and canceled-load data loss

### DIFF
--- a/orchestrator/stage/modstate.go
+++ b/orchestrator/stage/modstate.go
@@ -71,7 +71,9 @@ func (s *StoreModuleState) getStore(ctx context.Context, exclusiveEndBlock uint6
 		fullKVFile := store.NewCompleteFileInfo(s.name, moduleInitBlock, exclusiveEndBlock)
 		err := loadStore.Load(ctx, fullKVFile)
 		if err != nil {
-			if errors.Is(err, store.ErrInvalidFullKVFile) {
+			// Only a live context means real corruption: a canceled load also
+			// surfaces as ErrInvalidFullKVFile and must not delete a valid file.
+			if errors.Is(err, store.ErrInvalidFullKVFile) && ctx.Err() == nil {
 				s.logger.Warn("found a corrupted fullKV store, deleting it", zap.Error(err), zap.String("store_name", loadStore.Name()), zap.String("store_hash", loadStore.ModuleHash()), zap.String("filename", fullKVFile.Filename))
 				if err := loadStore.Delete(ctx, fullKVFile); err != nil {
 					s.logger.Error("cannot delete corrupted fullKV store", zap.Error(err), zap.String("store_name", loadStore.Name()), zap.String("store_hash", loadStore.ModuleHash()), zap.String("filename", fullKVFile.Filename))
@@ -112,7 +114,9 @@ func (s *StoreModuleState) tryLoadFullKV(ctx context.Context, exclusiveEndBlock 
 	kv := s.storeConfig.NewFullKV(s.logger)
 	fullKVFile := store.NewCompleteFileInfo(s.name, moduleInitBlock, exclusiveEndBlock)
 	if err := kv.Load(ctx, fullKVFile); err != nil {
-		if errors.Is(err, store.ErrInvalidFullKVFile) {
+		// A canceled load also surfaces as ErrInvalidFullKVFile; only delete
+		// when the context is still live so we never drop a valid store file.
+		if errors.Is(err, store.ErrInvalidFullKVFile) && ctx.Err() == nil {
 			s.logger.Warn("found a corrupted fullKV store, deleting it", zap.Error(err), zap.String("store_name", kv.Name()), zap.String("store_hash", kv.ModuleHash()), zap.String("filename", fullKVFile.Filename))
 			if delErr := kv.Delete(ctx, fullKVFile); delErr != nil {
 				s.logger.Error("cannot delete corrupted fullKV store", zap.Error(delErr), zap.String("store_name", kv.Name()), zap.String("store_hash", kv.ModuleHash()), zap.String("filename", fullKVFile.Filename))

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -498,7 +498,11 @@ func (p *Pipeline) setupSubrequestStores(ctx context.Context) (storeMap store.Ma
 		}
 		egLoad.Go(func() error {
 			if err := loadable.fullKVStore.Load(ctx, loadable.fileInfo); err != nil {
-				if errors.Is(err, store.ErrInvalidFullKVFile) {
+				// A canceled context surfaces as ErrInvalidFullKVFile because the
+				// streaming unmarshal wraps the read error as a string, so only
+				// treat the file as corrupt when the context is still live —
+				// otherwise a canceled request would delete a valid store file.
+				if errors.Is(err, store.ErrInvalidFullKVFile) && ctx.Err() == nil {
 					logger.Warn("found a corrupted fullKV store, deleting it", zap.Error(err), zap.String("store_name", loadable.fullKVStore.Name()), zap.String("store_hash", loadable.fullKVStore.ModuleHash()), zap.String("filename", loadable.fileInfo.Filename))
 					if err := loadable.fullKVStore.Delete(ctx, loadable.fileInfo); err != nil {
 						logger.Error("cannot delete corrupted fullKV store", zap.Error(err), zap.String("store_name", loadable.fullKVStore.Name()), zap.String("store_hash", loadable.fullKVStore.ModuleHash()), zap.String("filename", loadable.fileInfo.Filename))

--- a/storage/store/full_kv.go
+++ b/storage/store/full_kv.go
@@ -129,6 +129,13 @@ func (s *FullKV) Load(ctx context.Context, file *FileInfo) error {
 
 	s.totalSizeBytes, err = unmarshalIterInto(s.kvImpl, s.marshaller, reader, nil)
 	if err != nil {
+		// A canceled/expired context aborts the streaming read and would
+		// otherwise be reported as file corruption, tricking callers into
+		// deleting a perfectly valid store file. Surface the cancellation
+		// instead so it never gets misclassified.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return fmt.Errorf("%w (streaming): %s", ErrInvalidFullKVFile, err.Error())
 	}
 

--- a/storage/store/full_kv_test.go
+++ b/storage/store/full_kv_test.go
@@ -66,6 +66,39 @@ func TestFullKV_Save_Load_Empty_MapNotNil(t *testing.T) {
 	require.NotNilf(t, kvl.kvImpl, "kvl.kvImpl is nil")
 }
 
+// TestFullKV_Load_CanceledContext_NotCorrupt ensures a load aborted by context
+// cancellation reports the cancellation, not ErrInvalidFullKVFile — otherwise
+// callers would delete a perfectly valid remote store file.
+func TestFullKV_Load_CanceledContext_NotCorrupt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store := dstore.NewMockStore(nil)
+	store.OpenObjectFunc = func(context.Context, string) (io.ReadCloser, error) {
+		cancel() // the stream is torn down mid-read
+		return io.NopCloser(&errReaderReadCloser{err: context.Canceled}), nil
+	}
+
+	kv := &FullKV{
+		baseStore: &baseStore{
+			kvImpl:     newMemoryKVImpl(),
+			kvOps:      &pbssinternal.Operations{},
+			logger:     zap.NewNop(),
+			marshaller: marshaller.Default(),
+			Config:     &Config{moduleInitialBlock: 0, objStore: store},
+		},
+	}
+
+	err := kv.Load(ctx, NewCompleteFileInfo("test", 0, 100))
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled, "canceled load must surface cancellation")
+	require.NotErrorIs(t, err, ErrInvalidFullKVFile, "canceled load must not look like corruption")
+}
+
+type errReaderReadCloser struct{ err error }
+
+func (r *errReaderReadCloser) Read([]byte) (int, error) { return 0, r.err }
+func (r *errReaderReadCloser) Close() error             { return nil }
+
 func TestFullKV_QuickSave_QuickLoad_Empty(t *testing.T) {
 	var writtenBytes []byte
 	mockStore := dstore.NewMockStore(func(base string, f io.Reader) (err error) {

--- a/storage/store/kv_impl_integration_test.go
+++ b/storage/store/kv_impl_integration_test.go
@@ -182,20 +182,16 @@ func testLargeDataset(t *testing.T, s *baseStore, baseDir string) {
 		mmapImpl, ok := s.kvImpl.(*mmapKVImpl)
 		require.True(t, ok, "should be mmap implementation")
 
-		// Verify file exists and is in the correct directory
-		assert.FileExists(t, mmapImpl.path)
+		// The path is derived from the configured base dir and store name...
 		assert.Contains(t, mmapImpl.path, baseDir, "mmap file should be in configured base dir")
-
-		// Verify filename contains store name
 		filename := filepath.Base(mmapImpl.path)
 		assert.Contains(t, filename, "test_store", "filename should contain store name")
 
-		// Check file size (should be > 1MB for 1K * 1KB entries)
-		stat, err := os.Stat(mmapImpl.path)
-		require.NoError(t, err)
-		t.Logf("Mmap file size: %d bytes (%.2f MB)", stat.Size(), float64(stat.Size())/(1024*1024))
-		// bbolt allocates in pages, so actual size may vary, but should be substantial
-		assert.Greater(t, stat.Size(), int64(512*1024), "file should be at least 512KB")
+		// ...but the backing file is unlinked at open time, so it is not visible
+		// on disk while the store is live — this is what makes an orphaned bbolt
+		// file impossible no matter how the process dies.
+		_, err := os.Stat(mmapImpl.path)
+		assert.True(t, os.IsNotExist(err), "mmap file should be unlinked after open, stat err=%v", err)
 	}
 
 	// Test iteration over large dataset

--- a/storage/store/kv_impl_mmap.go
+++ b/storage/store/kv_impl_mmap.go
@@ -141,8 +141,18 @@ func newMmapKVImplWithConfig(storeName, moduleHash string, cfg *MmapBackendConfi
 
 	db, err := openMmapDB(path, true, 0) // NoSync: substreams stores are ephemeral and rebuilt from object storage on crash
 	if err != nil {
+		os.Remove(path) // openMmapDB may have left the file behind
 		return nil, fmt.Errorf("failed to open mmap KVImpl for store %q at %q: %w", storeName, path, err)
 	}
+
+	// Unlink the backing file now that it is open. On unix the inode (and its
+	// mmap) stays valid for the lifetime of the open db handle, but the
+	// directory entry is gone — so no matter how this process dies (SIGKILL,
+	// OOM, panic, a Load/Save that outlives a shutdown deadline), it can never
+	// leave an orphan bbolt file behind. Space is reclaimed when Close() drops
+	// the handle. Best-effort: on platforms that refuse to unlink an open file
+	// (e.g. Windows) this is a no-op and Close() falls back to removing by path.
+	os.Remove(path)
 
 	impl, err := newMmapKVImplFromDB(db, path, storeName, true)
 	if err != nil {
@@ -554,20 +564,29 @@ func (b *mmapKVImpl) Close() error {
 	b.snapMu.RLock()
 	defer b.snapMu.RUnlock()
 
+	var closeErr error
 	if b.db != nil {
 		if metrics.StoreMmapFileSizeBytes != nil {
 			if stat, err := os.Stat(b.path); err == nil {
 				metrics.StoreMmapFileSizeBytes.SetFloat64(float64(stat.Size()), b.storeName)
 			}
 		}
-		if err := b.db.Close(); err != nil {
-			return fmt.Errorf("closing mmap db: %w", err)
-		}
+		closeErr = b.db.Close()
 	}
+	// Always attempt removal, even if db.Close failed: the file is usually
+	// already gone (unlinked at open time), but on platforms where the
+	// open-file unlink was a no-op this is what reclaims it. Skipping it on a
+	// db.Close error would leak the file.
 	if b.path != "" {
 		if err := os.Remove(b.path); err != nil && !os.IsNotExist(err) {
+			if closeErr != nil {
+				return fmt.Errorf("closing mmap db: %w (and removing file %s: %v)", closeErr, b.path, err)
+			}
 			return fmt.Errorf("removing mmap db file %s: %w", b.path, err)
 		}
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing mmap db: %w", closeErr)
 	}
 	return nil
 }

--- a/storage/store/kv_impl_mmap_cancel_test.go
+++ b/storage/store/kv_impl_mmap_cancel_test.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errReader yields n good bytes worth of a real serialized stream then fails,
+// mimicking an objStore read that returns context.Canceled mid-load.
+type cancelAfterReader struct {
+	data    []byte
+	pos     int
+	failAt  int
+	failErr error
+}
+
+func (r *cancelAfterReader) Read(p []byte) (int, error) {
+	if r.pos >= r.failAt {
+		return 0, r.failErr
+	}
+	n := copy(p, r.data[r.pos:min(r.failAt, len(r.data))])
+	r.pos += n
+	return n, nil
+}
+
+// TestMmapLoadCancelCleanup reproduces the tier2 scenario: a mmap-backed FullKV
+// is Load()ed, the load fails partway (simulating context cancellation), and
+// then the store is Close()d (as the setupSubrequestStores defer does).
+// The backing bbolt file MUST be gone afterwards.
+func TestMmapLoadCancelCleanup(t *testing.T) {
+	t.Setenv("SUBSTREAMS_STORE_BACKEND", "mmap")
+	scratch := t.TempDir()
+
+	// Build a real serialized snapshot to load from.
+	src := createTestStore(t, "cancel_src", 0, scratch).kvImpl
+	kv := make(map[string][]byte, 50_000)
+	for i := 0; i < 50_000; i++ {
+		kv[fmt.Sprintf("key:%08d", i)] = []byte(fmt.Sprintf("value_%d", i))
+	}
+	require.NoError(t, src.BatchSet(kv))
+	src.Close()
+
+	dst := createTestStore(t, "cancel_dst", 0, scratch)
+	mm := dst.kvImpl.(*mmapKVImpl)
+	path := mm.path
+	// The backing file is unlinked at open time, so no process death can ever
+	// orphan it: it is already absent from the directory while fully usable.
+	_, err := os.Stat(path)
+	require.True(t, os.IsNotExist(err), "dst file should already be unlinked after open, stat err=%v", err)
+
+	// Fail the load partway through.
+	r := &cancelAfterReader{data: []byte("garbage-that-fails-to-parse-immediately"), failAt: 5, failErr: fmt.Errorf("context canceled")}
+	_, loadErr := unmarshalIterInto(dst.kvImpl, dst.marshaller, r, nil)
+	require.Error(t, loadErr, "load should fail")
+	t.Logf("load error: %v", loadErr)
+
+	// setupSubrequestStores defer path:
+	require.NoError(t, dst.Close(), "close should succeed")
+
+	_, statErr := os.Stat(path)
+	require.True(t, os.IsNotExist(statErr), "bbolt file %s must be removed after Close, stat err=%v", path, statErr)
+
+	// sanity: no substreams-store-*.db left in scratch
+	leftovers, _ := filepath.Glob(filepath.Join(scratch, "substreams-store-*.db"))
+	require.Empty(t, leftovers, "no orphan mmap files should remain: %v", leftovers)
+}


### PR DESCRIPTION
## Problem

tier2 leaves orphaned bbolt (mmap) store files on disk after requests get interrupted (see leak observed while draining a flood of multi-minute `map_flood` store loads).

Two distinct bugs:

1. **Orphaned bbolt files.** The graceful cancel path already cleans up (verified by test). The leak is abnormal termination: these store `Load`/`Save` calls take 3–9 min, and when the process is shut down/killed while one is in flight, the deferred `Close()`/`os.Remove` never runs. No defer survives SIGKILL/OOM.

2. **Canceled load misread as corruption → data loss.** `FullKV.Load` wrapped *any* streaming error (including a ctx-canceled read) as `ErrInvalidFullKVFile`. The `%s` wrap flattened `context.Canceled` to a string so `errors.Is` couldn't see it. Callers then **deleted the valid remote `.kv` file** ("found a corrupted fullKV store, deleting it" ... `context canceled`), forcing expensive reprocessing.

## Fix

- **Unlink at open** (`kv_impl_mmap.go`): `os.Remove` the bbolt file immediately after `bbolt.Open`. The inode + mmap stay valid for the handle's lifetime, but the directory entry is gone — no process death can orphan it; space reclaimed on `Close()`. Verified bbolt tolerates unlink-after-open through file growth + mmap remap. `Close()` also reordered to always remove even if `db.Close()` errors.
- **Canceled load** (`full_kv.go`): return `ctx.Err()` when the context is dead instead of the corruption wrap. Delete sites in `pipeline.go` + `modstate.go` (2) additionally guard on `ctx.Err() == nil`.

The existing `sweepOrphanMmapFiles` startup sweep now only matters for the millisecond window between `CreateTemp` and unlink.

## Tests

- `TestMmapLoadCancelCleanup` + updated `TestKVImplBackends`: assert the file is unlinked-while-live.
- `TestFullKV_Load_CanceledContext_NotCorrupt`: canceled load surfaces `context.Canceled`, not `ErrInvalidFullKVFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)