### PR TITLE
errors that are cached are now only valid for 1h (or env var SUBSTREAMS_DETERMINISTIC_ERROR_MAX_AGE) after that automatically removed on next attempt

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Server: cached deterministic errors now expire. Each error file carries a write timestamp in its name (`errors.<block>.<hash>.<unix>`), and on read tier1 discards any error older than `SUBSTREAMS_DETERMINISTIC_ERROR_MAX_AGE` (Go duration, default `1h`), retrying execution. Legacy error files without a timestamp are deleted on read.
+
 - Server: new `ProcessRangeRequest.merged_blocks_bundle_size` field (internal tier1→tier2 protocol) carrying the number of blocks per merged-blocks file. `0` (older tier1s) means the historical default of `100`. Tier2 applies the value per-request, so a single tier2 can serve chains with different merged-blocks sizes. **Upgrade all tier2s before setting a non-100 value on any tier1**: older tier2s ignore the field and would read the store with a bundle size of 100 (jobs stall on missing file names).
 - Server: new `Tier1Config.MergedBlocksBundleSize` (default `100`), used by tier1's own merged-blocks reads, cursor resolution, final-block rounding and forwarded to tier2 on every subrequest. The hub's kept final blocks and the live backfiller delay now scale with the bundle size.
 - `substreams tools tier2call`: new `--merged-blocks-bundle-size` flag (default `0` = server default).

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -783,7 +783,7 @@ func (p *Pipeline) execute(ctx context.Context, executor exec.ModuleExecutor, ex
 			}
 
 			if errors.Is(recoveredErr, wasm.ErrWasmDeterministicExec) || errors.Is(recoveredErr, store.ErrStoreAboveMaxSize) {
-				p.execoutStorage.ConfigMap[executorName].WriteDeterministicError(ctx, execOutput.Clock().Number, fmt.Errorf("%w (deterministic error)", recoveredErr))
+				p.execoutStorage.ConfigMap[executorName].WriteDeterministicError(ctx, execOutput.Clock().Number, recoveredErr)
 				out.err = recoveredErr
 				return
 			}

--- a/service/error.go
+++ b/service/error.go
@@ -105,7 +105,7 @@ func toConnectError(ctx context.Context, err error) error {
 	}
 
 	if errors.Is(err, wasm.ErrWasmDeterministicExec) || errors.Is(err, store.ErrStoreAboveMaxSize) {
-		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%w (deterministic error)", err))
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%w (new deterministic error)", err))
 	}
 
 	var errInvalidArg *bsstream.ErrInvalidArg
@@ -216,7 +216,7 @@ func toGrpcTier1Error(ctx context.Context, err error) error {
 	}
 
 	if errors.Is(err, wasm.ErrWasmDeterministicExec) || errors.Is(err, store.ErrStoreAboveMaxSize) {
-		return status.Errorf(codes.InvalidArgument, "%s (deterministic error)", err)
+		return status.Errorf(codes.InvalidArgument, "%s (new deterministic error)", err)
 	}
 
 	var errInvalidArg *bsstream.ErrInvalidArg

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -61,8 +61,17 @@ import (
 var errShuttingDown = errors.New("endpoint is shutting down, please reconnect")
 var fallbackDuration time.Duration
 var useBlockNumberDuration time.Duration
+var deterministicErrorMaxAge = time.Hour
 
 func init() {
+	if v := os.Getenv(EnvDeterministicErrorMaxAge); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			panic(fmt.Errorf("invalid value for env var %s: %w", EnvDeterministicErrorMaxAge, err))
+		}
+		deterministicErrorMaxAge = d
+	}
+
 	envEthCallFallbackToLatestDuration := os.Getenv(EnvEthCallFallbackToLatestDuration)
 	if envEthCallFallbackToLatestDuration != "" {
 		d, err := time.ParseDuration(envEthCallFallbackToLatestDuration)
@@ -1194,23 +1203,36 @@ func (s *Tier1Service) containsDeterministicError(ctx context.Context, startBloc
 	return nil
 }
 
-func parseFilename(in string) (blockNum uint64, moduleExtendedHash string, err error) {
+// parseFilename parses an error filename of the form:
+//
+//	errors.<blockNum:10>.<moduleExtendedHash>.<unixTimestamp>
+//
+// Older formats without a timestamp (or without an extended hash) are still parsed; a
+// zero timestamp signals a legacy error that the caller should discard.
+func parseFilename(in string) (blockNum uint64, moduleExtendedHash string, timestamp time.Time, err error) {
 	in = strings.TrimPrefix(in, "errors.")
 
 	if len(in) < 10 {
-		return 0, "", err
+		return 0, "", time.Time{}, err
 	}
 
 	blockNumStr := in[:10]
 	blockNum, err = strconv.ParseUint(blockNumStr, 10, 64)
 	if err != nil {
-		return 0, "", err
+		return 0, "", time.Time{}, err
 	}
 
 	if len(in) > 10 {
-		moduleExtendedHash = in[11:] // ignore the '.' between blocknum and moduleExtendedHash
+		rest := in[11:] // ignore the '.' between blocknum and the rest
+		parts := strings.Split(rest, ".")
+		moduleExtendedHash = parts[0]
+		if len(parts) > 1 {
+			if sec, parseErr := strconv.ParseInt(parts[1], 10, 64); parseErr == nil {
+				timestamp = time.Unix(sec, 0)
+			}
+		}
 	}
-	return blockNum, moduleExtendedHash, nil
+	return blockNum, moduleExtendedHash, timestamp, nil
 }
 
 func containsDeterministicError(ctx context.Context, moduleStore dstore.Store, moduleName, extendedHash string, startBlock, endBlock uint64, isStore bool, logger *zap.Logger) error {
@@ -1223,7 +1245,7 @@ func containsDeterministicError(ctx context.Context, moduleStore dstore.Store, m
 
 	moduleStore.WalkFrom(ctx, "errors.", startFile, func(filename string) (err error) {
 
-		blockNum, parsedExtendedHash, err := parseFilename(filename)
+		blockNum, parsedExtendedHash, timestamp, err := parseFilename(filename)
 		if err != nil {
 			logger.Warn("checking for errors: invalid filename", zap.String("filename", filename), zap.Error(err))
 			return nil
@@ -1237,6 +1259,19 @@ func containsDeterministicError(ctx context.Context, moduleStore dstore.Store, m
 
 		if parsedExtendedHash != extendedHash {
 			logger.Info("ignoring error on another version of the same module", zap.String("filename", filename), zap.String("parsedExtendedHash", parsedExtendedHash), zap.String("extendedHash", extendedHash))
+			return nil
+		}
+
+		// Errors without a timestamp (legacy format) or older than the configured max age
+		// are discarded so execution is retried.
+		if timestamp.IsZero() {
+			logger.Info("deleting old deterministic error without timestamp", zap.String("filename", filename))
+			moduleStore.DeleteObject(ctx, filename)
+			return nil
+		}
+		if age := time.Since(timestamp); age > deterministicErrorMaxAge {
+			logger.Info("deleting expired deterministic error", zap.String("filename", filename), zap.Duration("age", age), zap.Duration("max_age", deterministicErrorMaxAge))
+			moduleStore.DeleteObject(ctx, filename)
 			return nil
 		}
 

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -1291,7 +1291,7 @@ func containsDeterministicError(ctx context.Context, moduleStore dstore.Store, m
 			return nil
 		}
 
-		lastError = fmt.Errorf("error from block %d in module %s: %s", blockNum, moduleName, string(cnt))
+		lastError = fmt.Errorf("error from block %d in module %s (deterministic error, cached for %d seconds): %s", blockNum, moduleName, int(time.Since(timestamp).Seconds()), string(cnt))
 		return nil
 	})
 

--- a/service/tier2.go
+++ b/service/tier2.go
@@ -812,7 +812,7 @@ func toGRPCError(ctx context.Context, err error) error {
 		return status.Error(codes.DeadlineExceeded, err.Error())
 	}
 	if errors.Is(err, wasm.ErrWasmDeterministicExec) || errors.Is(err, store.ErrStoreAboveMaxSize) {
-		return status.Error(codes.InvalidArgument, fmt.Sprintf("%s (deterministic error)", err.Error()))
+		return status.Error(codes.InvalidArgument, fmt.Sprintf("%s (new deterministic error)", err.Error()))
 	}
 
 	var errInvalidArg *stream.ErrInvalidArg

--- a/service/utils.go
+++ b/service/utils.go
@@ -22,6 +22,11 @@ const EnvEthCallFallbackToLatestDuration = "ETH_CALL_FALLBACK_TO_LATEST_DURATION
 // This is to be used on chains with deterministic behavior but with an archive node that needs the block number to route old queries.
 const EnvEthCallUseBlockNumberDuration = "ETH_CALL_USE_BLOCK_NUMBER_DURATION"
 
+// EnvDeterministicErrorMaxAge is the environment variable name that controls how long a
+// cached deterministic error is honored. Past this duration the error file is discarded
+// (deleted) on read and execution is retried. Defaults to 1h. Value is a Go duration string.
+const EnvDeterministicErrorMaxAge = "SUBSTREAMS_DETERMINISTIC_ERROR_MAX_AGE"
+
 func sortClocksDistributor(clockDistributor map[uint64]*pbsubstreams.Clock) (sortedClockDistributor []*pbsubstreams.Clock) {
 	sortedClockDistributor = make([]*pbsubstreams.Clock, 0, len(clockDistributor))
 	for _, clock := range clockDistributor {

--- a/storage/execout/config.go
+++ b/storage/execout/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/streamingfast/derr"
 	"github.com/streamingfast/dstore"
@@ -62,7 +63,9 @@ func (c *Config) WriteDeterministicError(ctx context.Context, atBlock uint64, er
 	}
 
 	r := strings.NewReader(err.Error())
-	return c.errStore.WriteObject(ctx, fmt.Sprintf("errors.%010d.%s", atBlock, c.extendedModuleHash), r)
+	// The trailing unix timestamp lets the reader expire errors older than a configured
+	// duration; errors without a timestamp are treated as expired and deleted on read.
+	return c.errStore.WriteObject(ctx, fmt.Sprintf("errors.%010d.%s.%d", atBlock, c.extendedModuleHash, time.Now().Unix()), r)
 }
 
 func (c *Config) NewFile(targetRange *block.Range) *File {


### PR DESCRIPTION
we have been caught a few times with deterministic errors that were caused by major incidents like broken blocks.
After fixing the blocks, there were some old errors lingering, and we had to hunt them down.
This simplifies the process, no more manual cleaning of errors after fixing block data in those rare scenarios.
