### PR TITLE
Speed up mmap store squashing

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Server: mmap store squashing is faster. The bbolt mmap is now pre-sized from the store's configured size limit (`InitialMmapSize`), eliminating the repeated remap stalls bbolt otherwise incurs while a large store is hydrated or grown; and the SET / SET_IF_NOT_EXISTS merge paths now read only prior value *lengths* (`GetManySizes`) instead of copying every previous value off the mmap and onto the heap just to discard it. Both changes are backend-transparent (memory backend behaviour and the on-disk format are unchanged).
 - Server: store quicksave/quickload now run up to 8 stores concurrently instead of one at a time, cutting shutdown/resume latency for pipelines with many stores.
 - Server: quicksave now streams the store lazily and unsorted (one KV entry at a time as the upload consumes it, without sorting keys), instead of buffering the whole serialized store and paying an O(n log n) key sort plus key-slice allocation up front. This lowers both peak memory and save time for large stores (millions of keys). Quickload is order-independent, and the on-disk format is unchanged (byte-compatible protobuf), so no migration is required.
 - Server: tier1 store loading at request start now loads up to 8 stores concurrently (both the size probe and the download/decode), instead of one at a time.

--- a/storage/store/config.go
+++ b/storage/store/config.go
@@ -90,15 +90,46 @@ func (c *Config) newBaseStore(logger *zap.Logger) *baseStore {
 	case "memory":
 		return c.newBaseStoreWithBackend(logger, &MemoryBackendConfig{})
 	case "mmap":
-		return c.newBaseStoreWithBackend(logger, &MmapBackendConfig{ScratchSpace: c.scratchSpace})
+		return c.newBaseStoreWithBackend(logger, c.mmapBackendConfig())
 	default:
 		// fall back to env var when backend is unset, but preserve scratchSpace
 		t := getKVImplTypeFromEnv()
 		if t == KVImplTypeMemory {
 			return c.newBaseStoreWithBackend(logger, &MemoryBackendConfig{})
 		}
-		return c.newBaseStoreWithBackend(logger, &MmapBackendConfig{ScratchSpace: c.scratchSpace})
+		return c.newBaseStoreWithBackend(logger, c.mmapBackendConfig())
 	}
+}
+
+// mmapBackendConfig builds the mmap backend options for this store, pre-sizing
+// the bbolt mmap from the store's own size ceiling so the file can grow to its
+// full extent without a single remap stall.
+func (c *Config) mmapBackendConfig() *MmapBackendConfig {
+	return &MmapBackendConfig{
+		ScratchSpace:    c.scratchSpace,
+		InitialMmapSize: mmapInitialSizeForLimit(c.totalSizeLimit),
+	}
+}
+
+// mmapInitialSizeForLimit turns a store's uncompressed data-size limit into an
+// mmap reservation. It reserves ~1.5x the limit to absorb bbolt's B+tree page
+// overhead so a store never remaps as it approaches its cap, clamped to a
+// [floor, cap] range: the floor keeps tiny stores from remapping during load,
+// the cap keeps a pathologically large limit from reserving absurd address
+// space (a late remap in that rare case is acceptable). The reservation is
+// virtual only — unused pages never become resident.
+func mmapInitialSizeForLimit(totalSizeLimit uint64) int {
+	const floor = defaultInitialMmapSize
+	const maxReservation = 8 << 30 // 8 GiB
+
+	want := totalSizeLimit + totalSizeLimit/2 // ~1.5x
+	if want < floor {
+		want = floor
+	}
+	if want > maxReservation {
+		want = maxReservation
+	}
+	return int(want)
 }
 
 func (c *Config) newBaseStoreWithBackend(logger *zap.Logger, backend KVImplBackendConfig) *baseStore {

--- a/storage/store/kv_impl.go
+++ b/storage/store/kv_impl.go
@@ -62,6 +62,15 @@ type KVImpl interface {
 	// Keys not found are omitted from the result map.
 	GetMany(keys []string) (map[string][]byte, error)
 
+	// GetManySizes retrieves, in a single operation, the byte length of the
+	// value stored at each of the given keys. Keys not found are omitted from
+	// the result map (so the map doubles as a presence test). It is the
+	// value-free counterpart of GetMany: for the mmap backend it reads value
+	// lengths straight out of the bbolt pages without copying the values onto
+	// the heap, which the merge path uses for SET/SET_IF_NOT_EXISTS where only
+	// prior existence and size (for accounting) matter, not the old bytes.
+	GetManySizes(keys []string) (map[string]int, error)
+
 	// KeyCount returns the number of keys currently stored.
 	KeyCount() int
 

--- a/storage/store/kv_impl_config.go
+++ b/storage/store/kv_impl_config.go
@@ -24,6 +24,15 @@ type KVImplBackendConfig interface {
 // MmapBackendConfig holds mmap (bbolt) specific options.
 type MmapBackendConfig struct {
 	ScratchSpace string // base directory for bbolt files; uses OS temp dir if empty
+
+	// InitialMmapSize pre-reserves this many bytes of mmap address space when
+	// the bbolt file is opened. bbolt otherwise grows its mmap by doubling and
+	// remapping, and each remap must wait for all in-flight transactions to
+	// finish and blocks new ones — a stall that recurs O(log size) times while a
+	// large store is hydrated (Load) or grown (Merge/BatchSet). This is a
+	// virtual reservation only (pages are not resident until touched), so a
+	// generous value is cheap on 64-bit. Zero falls back to defaultInitialMmapSize.
+	InitialMmapSize int
 }
 
 // MemoryBackendConfig holds in-memory backend options (none currently).

--- a/storage/store/kv_impl_getmanysizes_test.go
+++ b/storage/store/kv_impl_getmanysizes_test.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestKVImpls returns one instance of every KVImpl backend, each loaded with
+// kv, so a single test body can assert identical behaviour across backends.
+func newTestKVImpls(t *testing.T, kv map[string][]byte) map[string]KVImpl {
+	t.Helper()
+
+	mem := newMemoryKVImpl()
+	_, err := mem.Load(mapToIter(kv))
+	require.NoError(t, err)
+
+	mm, err := newMmapKVImplWithConfig("t", "h", &MmapBackendConfig{ScratchSpace: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { mm.Close() })
+	_, err = mm.Load(mapToIter(kv))
+	require.NoError(t, err)
+
+	return map[string]KVImpl{"memory": mem, "mmap": mm}
+}
+
+// TestGetManySizes_MatchesGetMany pins the core invariant the merge accounting
+// relies on: GetManySizes reports exactly the presence set and value lengths
+// that GetMany would, on every backend. If these ever diverge, SET /
+// SET_IF_NOT_EXISTS merges would mis-account totalSizeBytes or (for SIONE)
+// wrongly overwrite existing keys.
+func TestGetManySizes_MatchesGetMany(t *testing.T) {
+	kv := map[string][]byte{}
+	for i := 0; i < 500; i++ {
+		kv[fmt.Sprintf("key:%04d", i)] = []byte(fmt.Sprintf("value-%d", i))
+	}
+
+	// query a mix of present and absent keys
+	var keys []string
+	for i := 0; i < 500; i += 2 {
+		keys = append(keys, fmt.Sprintf("key:%04d", i)) // present
+	}
+	keys = append(keys, "absent-1", "absent-2", "key:0001")
+
+	for name, impl := range newTestKVImpls(t, kv) {
+		t.Run(name, func(t *testing.T) {
+			values, err := impl.GetMany(keys)
+			require.NoError(t, err)
+
+			sizes, err := impl.GetManySizes(keys)
+			require.NoError(t, err)
+
+			require.Equal(t, len(values), len(sizes), "presence set must match GetMany")
+			for k, v := range values {
+				sz, ok := sizes[k]
+				require.True(t, ok, "key %q present in GetMany but missing in GetManySizes", k)
+				require.Equal(t, len(v), sz, "size mismatch for key %q", k)
+			}
+			for _, absent := range []string{"absent-1", "absent-2"} {
+				_, ok := sizes[absent]
+				require.False(t, ok, "absent key %q must not appear in GetManySizes", absent)
+			}
+		})
+	}
+}

--- a/storage/store/kv_impl_memory.go
+++ b/storage/store/kv_impl_memory.go
@@ -134,6 +134,16 @@ func (m *memoryKVImpl) GetMany(keys []string) (map[string][]byte, error) {
 	return result, nil
 }
 
+func (m *memoryKVImpl) GetManySizes(keys []string) (map[string]int, error) {
+	result := make(map[string]int, len(keys))
+	for _, k := range keys {
+		if v, ok := m.kv[k]; ok {
+			result[k] = len(v)
+		}
+	}
+	return result, nil
+}
+
 func (m *memoryKVImpl) Save() iter.Seq2[marshaller.StoreDataEntry, error] {
 	return func(yield func(marshaller.StoreDataEntry, error) bool) {
 		keys := make([]string, 0, len(m.kv))

--- a/storage/store/kv_impl_mmap.go
+++ b/storage/store/kv_impl_mmap.go
@@ -24,6 +24,12 @@ var (
 // during bulk operations (Load, BatchSet).
 const mmapBatchSize = 10_000
 
+// defaultInitialMmapSize is the mmap address space pre-reserved when a store is
+// opened without an explicit InitialMmapSize hint. It is a virtual reservation
+// (not resident RAM) that lets small/medium stores hydrate and grow without the
+// remap stalls bbolt incurs when it doubles its mmap.
+const defaultInitialMmapSize = 128 << 20 // 128 MiB
+
 // snapshotBatchMaxKeys and snapshotBatchMaxBytes bound how many entries a
 // snapshot iterator copies into heap per refill transaction.
 const (
@@ -139,7 +145,12 @@ func newMmapKVImplWithConfig(storeName, moduleHash string, cfg *MmapBackendConfi
 	path := f.Name()
 	f.Close()
 
-	db, err := openMmapDB(path, true, 0) // NoSync: substreams stores are ephemeral and rebuilt from object storage on crash
+	initialMmapSize := cfg.InitialMmapSize
+	if initialMmapSize <= 0 {
+		initialMmapSize = defaultInitialMmapSize
+	}
+
+	db, err := openMmapDB(path, true, initialMmapSize) // NoSync: substreams stores are ephemeral and rebuilt from object storage on crash
 	if err != nil {
 		os.Remove(path) // openMmapDB may have left the file behind
 		return nil, fmt.Errorf("failed to open mmap KVImpl for store %q at %q: %w", storeName, path, err)
@@ -293,6 +304,30 @@ func (b *mmapKVImpl) GetMany(keys []string) (map[string][]byte, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("mmap GetMany: %w", err)
+	}
+	return result, nil
+}
+
+// GetManySizes reads the value length of each key in a single read transaction
+// without copying the values out of the mmap. Keys not present are omitted.
+func (b *mmapKVImpl) GetManySizes(keys []string) (map[string]int, error) {
+	result := make(map[string]int, len(keys))
+	err := b.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(defaultBucket)
+		if bucket == nil {
+			return nil
+		}
+		for _, k := range keys {
+			// bucket.Get returns an mmap-backed slice; we only read its length
+			// and never retain it, so no copy is needed.
+			if v := bucket.Get([]byte(k)); v != nil {
+				result[k] = len(v)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mmap GetManySizes: %w", err)
 	}
 	return result, nil
 }

--- a/storage/store/kv_impl_mmap_initialsize_test.go
+++ b/storage/store/kv_impl_mmap_initialsize_test.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMmapInitialSizeForLimit(t *testing.T) {
+	const floor = defaultInitialMmapSize
+	const maxReservation = 8 << 30
+
+	cases := []struct {
+		name  string
+		limit uint64
+		want  int
+	}{
+		{"zero falls to floor", 0, floor},
+		{"tiny limit clamps to floor", 1 << 20, floor},
+		{"one gib reserves 1.5x", 1 << 30, int(1<<30 + (1<<30)/2)},
+		{"huge limit clamps to cap", 100 << 30, maxReservation},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, mmapInitialSizeForLimit(c.limit))
+		})
+	}
+}
+
+// TestMmapPreSizedStoreGrowsBeyondReservation guards the correctness side of the
+// InitialMmapSize optimisation: pre-reserving mmap space is a perf hint only, so
+// a store opened with a deliberately tiny reservation must still grow past it
+// (forcing bbolt to remap) without losing or corrupting any data.
+func TestMmapPreSizedStoreGrowsBeyondReservation(t *testing.T) {
+	impl, err := newMmapKVImplWithConfig("grow", "h", &MmapBackendConfig{
+		ScratchSpace:    t.TempDir(),
+		InitialMmapSize: 64 << 10, // 64 KiB — far below the data we load
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { impl.Close() })
+
+	kv := map[string][]byte{}
+	for i := 0; i < 5000; i++ {
+		kv[fmt.Sprintf("key:%06d", i)] = []byte(fmt.Sprintf("value-payload-%d-padding-padding-padding", i))
+	}
+
+	_, err = impl.Load(mapToIter(kv))
+	require.NoError(t, err)
+	require.Equal(t, len(kv), impl.KeyCount())
+
+	for k, want := range kv {
+		got, found := impl.Get(k)
+		require.True(t, found, "key %q missing after growth", k)
+		require.Equal(t, want, got, "value corrupted for key %q", k)
+	}
+}

--- a/storage/store/merge.go
+++ b/storage/store/merge.go
@@ -95,16 +95,44 @@ func (b *baseStore) mergeBatched(kvPartialStore *PartialKV) error {
 		return fmt.Errorf("iterating partial store: %w", err)
 	}
 
-	// Step 2: Read existing FullKV values for all partial keys in a single transaction.
-	// All policies need this for totalSizeBytes accounting (knowing if a key existed and
-	// its old size). Policies other than SET also need the values to compute the merge result.
+	// Step 2: Read what we need about the existing FullKV values for all partial
+	// keys, in a single transaction.
+	//
+	// SET and SET_IF_NOT_EXISTS never fold the previous value into the result —
+	// they only need to know whether a key already existed (SET_IF_NOT_EXISTS)
+	// and its former size (for the totalSizeBytes accounting below). For those we
+	// fetch value *lengths* only via GetManySizes, which on the mmap backend
+	// reads the sizes straight out of the bbolt pages without copying every
+	// previous value onto the heap — a full random-read sweep whose bytes would
+	// otherwise be allocated, copied, and immediately discarded. All other
+	// policies fold the previous value into the merge and need the bytes, so they
+	// fetch via GetMany. Either way existingSizes ends up populated for every
+	// present key so the accounting path stays backend- and policy-agnostic.
 	keys := make([]string, len(partialEntries))
 	for i, e := range partialEntries {
 		keys[i] = e.key
 	}
-	existingKV, err := b.kvImpl.GetMany(keys)
-	if err != nil {
-		return fmt.Errorf("reading existing keys from full store: %w", err)
+	var (
+		existingKV    map[string][]byte // populated only for value-consuming policies
+		existingSizes map[string]int    // always populated: present key -> old value length
+		err           error
+	)
+	switch b.updatePolicy {
+	case pbsubstreams.Module_KindStore_UPDATE_POLICY_SET,
+		pbsubstreams.Module_KindStore_UPDATE_POLICY_SET_IF_NOT_EXISTS:
+		existingSizes, err = b.kvImpl.GetManySizes(keys)
+		if err != nil {
+			return fmt.Errorf("reading existing key sizes from full store: %w", err)
+		}
+	default:
+		existingKV, err = b.kvImpl.GetMany(keys)
+		if err != nil {
+			return fmt.Errorf("reading existing keys from full store: %w", err)
+		}
+		existingSizes = make(map[string]int, len(existingKV))
+		for k, v := range existingKV {
+			existingSizes[k] = len(v)
+		}
 	}
 
 	// Step 3: Compute merged results in memory.
@@ -117,9 +145,9 @@ func (b *baseStore) mergeBatched(kvPartialStore *PartialKV) error {
 		}
 
 	case pbsubstreams.Module_KindStore_UPDATE_POLICY_SET_IF_NOT_EXISTS:
-		// existingKV populated above — only write keys not already present
+		// existingSizes populated above — only write keys not already present
 		for _, e := range partialEntries {
-			if _, found := existingKV[e.key]; !found {
+			if _, found := existingSizes[e.key]; !found {
 				results[e.key] = e.val
 			}
 		}
@@ -394,8 +422,8 @@ func (b *baseStore) mergeBatched(kvPartialStore *PartialKV) error {
 	// For each key we're writing: subtract old value size (if existed), add new value size.
 	// For new keys: also add the key size.
 	for k, newVal := range results {
-		if oldVal, existed := existingKV[k]; existed {
-			b.totalSizeBytes -= uint64(len(oldVal))
+		if oldLen, existed := existingSizes[k]; existed {
+			b.totalSizeBytes -= uint64(oldLen)
 		} else {
 			b.totalSizeBytes += uint64(len(k))
 		}

--- a/storage/store/merge_setaccounting_test.go
+++ b/storage/store/merge_setaccounting_test.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"testing"
+
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// fullForPolicy builds an empty FullKV on the named backend for size-accounting
+// tests. Both backends run the exact same accounting code; asserting the
+// absolute totalSizeBytes (not just memory-vs-mmap parity) pins the arithmetic
+// of the GetManySizes path used by SET / SET_IF_NOT_EXISTS.
+func fullForPolicy(t *testing.T, backend string, kv map[string][]byte, up pbsubstreams.Module_KindStore_UpdatePolicy, vt string) *FullKV {
+	t.Helper()
+	switch backend {
+	case "memory":
+		return newStore(cloneKV(kv), up, vt)
+	case "mmap":
+		return mmapFull(t, cloneKV(kv), up, vt)
+	default:
+		t.Fatalf("unknown backend %q", backend)
+		return nil
+	}
+}
+
+func backends() []string { return []string{"memory", "mmap"} }
+
+// TestMergeSet_SizeAccounting exercises the SET merge path, which now reads only
+// value lengths (GetManySizes) instead of the full previous values (GetMany).
+// It checks that new-key and overwrite accounting both stay exact.
+func TestMergeSet_SizeAccounting(t *testing.T) {
+	up := pbsubstreams.Module_KindStore_UPDATE_POLICY_SET
+	vt := "string"
+
+	for _, backend := range backends() {
+		t.Run(backend, func(t *testing.T) {
+			full := fullForPolicy(t, backend, map[string][]byte{}, up, vt)
+
+			// First merge: two brand-new keys.
+			// size = (len("aa")+len("1")) + (len("bb")+len("22")) = 3 + 4 = 7
+			require.NoError(t, full.Merge(newPartialStore(map[string][]byte{
+				"aa": []byte("1"),
+				"bb": []byte("22"),
+			}, up, vt, nil)))
+			require.Equal(t, uint64(7), full.SizeBytes(), "size after inserting two new keys")
+
+			// Second merge: overwrite "aa" (old len 1 -> new len 3, delta +2) and
+			// insert new key "cc" (len("cc")+len("3") = 3). total = 7 + 2 + 3 = 12
+			require.NoError(t, full.Merge(newPartialStore(map[string][]byte{
+				"aa": []byte("999"),
+				"cc": []byte("3"),
+			}, up, vt, nil)))
+			require.Equal(t, uint64(12), full.SizeBytes(), "size after overwrite + new key")
+
+			assertGet(t, full, "aa", "999")
+			assertGet(t, full, "bb", "22")
+			assertGet(t, full, "cc", "3")
+			require.Equal(t, 3, full.kvImpl.KeyCount())
+		})
+	}
+}
+
+// TestMergeSetIfNotExists checks the SET_IF_NOT_EXISTS path: existing keys keep
+// their value and are NOT re-accounted, only genuinely new keys are written.
+// Correct behaviour hinges on GetManySizes reporting prior existence.
+func TestMergeSetIfNotExists(t *testing.T) {
+	up := pbsubstreams.Module_KindStore_UPDATE_POLICY_SET_IF_NOT_EXISTS
+	vt := "string"
+
+	for _, backend := range backends() {
+		t.Run(backend, func(t *testing.T) {
+			full := fullForPolicy(t, backend, map[string][]byte{"exist": []byte("old")}, up, vt)
+			// helper does not seed totalSizeBytes from the pre-loaded key, so the
+			// counter starts at 0 and we assert only the merge-induced delta.
+
+			require.NoError(t, full.Merge(newPartialStore(map[string][]byte{
+				"exist": []byte("NEW-should-be-ignored"),
+				"fresh": []byte("x"),
+			}, up, vt, nil)))
+
+			// "exist" is untouched; only "fresh" is written and accounted:
+			// size delta = len("fresh") + len("x") = 6
+			assertGet(t, full, "exist", "old")
+			assertGet(t, full, "fresh", "x")
+			require.Equal(t, uint64(6), full.SizeBytes(), "only the new key should be accounted")
+			require.Equal(t, 2, full.kvImpl.KeyCount())
+		})
+	}
+}
+
+func assertGet(t *testing.T, s *FullKV, key, want string) {
+	t.Helper()
+	v, found := s.kvImpl.Get(key)
+	require.True(t, found, "key %q must exist", key)
+	require.Equal(t, want, string(v), "value for key %q", key)
+}


### PR DESCRIPTION
Stacked on top of #828 (base = `feature/mmap-store-backend`). Two contained, backend-transparent optimizations to make squashing faster on the mmap backend, following the review discussion on #828.

## 1. Pre-size the bbolt mmap (`InitialMmapSize`)
`newMmapKVImplWithConfig` opened bbolt with `InitialMmapSize=0`. bbolt then grows its mmap by **doubling + remapping**, and every remap must wait for all in-flight transactions and blocks new ones — a stall that recurs `O(log size)` times while a large store is hydrated (`Load`) or grown (`Merge`/`BatchSet`).

Now the mmap is pre-reserved from the store's own configured size ceiling (`totalSizeLimit`, ~1.5× to absorb B+tree page overhead, clamped to `[128 MiB, 8 GiB]`). It's a **virtual** reservation — unused pages never become resident — so it's cheap on 64-bit and lets a store reach its full size without a single remap.

## 2. Skip value copies for SET / SET_IF_NOT_EXISTS merges (`GetManySizes`)
`mergeBatched` unconditionally called `GetMany`, copying **every** previous value for all partial keys off the mmap and onto the heap. But `SET` and `SET_IF_NOT_EXISTS` never fold the old value into the result — they need only prior *existence* (SIONE) and prior *size* (for `totalSizeBytes` accounting).

New `GetManySizes` reads value lengths straight out of the bbolt pages without copying. Those two policies use it; value-consuming policies (`ADD`/`SET_SUM`/`MIN`/`MAX`/`APPEND`) still use `GetMany`. Size accounting is unchanged and stays exact.

## Not changed
Memory-backend behaviour, the on-disk store format (byte-compatible protobuf), and merge results are all unchanged. No migration.

## Tests
- `TestGetManySizes_MatchesGetMany` — `GetManySizes` reports exactly the presence set and value lengths `GetMany` would, on both backends (the invariant the accounting relies on).
- `TestMergeSet_SizeAccounting` / `TestMergeSetIfNotExists` — new-key + overwrite accounting pinned to exact byte totals; SIONE leaves existing keys untouched and un-accounted.
- `TestMmapInitialSizeForLimit` — floor/1.5×/cap math.
- `TestMmapPreSizedStoreGrowsBeyondReservation` — a deliberately tiny reservation still grows past itself (forcing a remap) with no data loss/corruption.

`go test ./storage/store/ -race` green.

## Note
Not addressed here (ops-level, from the #828 review): mmap perf is bounded by page-fault latency, so **scratch space must be on local NVMe** — a network-backed scratch dir will dominate any code-level win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
