### PR TITLE
Replace SUBSTREAMS_STORE_SIZE_LIMIT env var with tier1 flag

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -47,13 +47,6 @@ This document lists all environment variables used by the Substreams project, or
 
 ### Performance tuning
 
-#### `SUBSTREAMS_STORE_SIZE_LIMIT`
-**Store size limit**
-- **Purpose**: Set maximum size limit for Substreams stores in bytes
-- **Usage**: Set as unsigned integer (bytes) to limit store memory usage
-- **Default**: 1073741824 (1GiB)
-- **Location**: `service/utils.go`
-
 #### SUBSTREAMS_LOG_TOTAL_STORE_SIZE
 **Log total store size**
 - **Purpose**: Log total store size in bytes

--- a/app/tier1.go
+++ b/app/tier1.go
@@ -99,6 +99,10 @@ type Tier1Config struct {
 	SharedCacheSize  uint64
 	OutputBufferSize uint64 // Used to bundle execout messages within 'BlockScopedDatas' when using protocol V4
 
+	// StoreSizeLimit, if non-zero, overrides the default store size limit (in bytes)
+	// used by tier2 stores. The value is forwarded to tier2 on each request.
+	StoreSizeLimit uint64
+
 	WASMExtensions wasm.WASMExtensioner
 	Tracing        bool
 
@@ -288,6 +292,7 @@ func (a *Tier1App) Run() error {
 		WASMModules:                wasmModules,
 		FoundationalStoreEndpoints: foundationalStoreEndpoints,
 		HostedStoreRegistryAddress: a.config.HostedStoreRegistryAddress,
+		StoreSizeLimit:             a.config.StoreSizeLimit,
 	}
 
 	tier1Service, err := service.NewTier1(

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Server: the store size limit override is now configured by a tier1 flag (`Tier1Config.StoreSizeLimit`, exposed as `--substreams-tier1-store-size-limit`) instead of the `SUBSTREAMS_STORE_SIZE_LIMIT` environment variable, which has been removed. The value is forwarded from tier1 to tier2 on every subrequest via the existing `ProcessRangeRequest.store_size_limit` field, so it no longer needs to be set on tier2. `0` keeps the default of 1GiB.
 - Server: store quicksave/quickload now run up to 8 stores concurrently instead of one at a time, cutting shutdown/resume latency for pipelines with many stores.
 - Server: quicksave now streams the store lazily and unsorted (one KV entry at a time as the upload consumes it, without sorting keys), instead of buffering the whole serialized store and paying an O(n log n) key sort plus key-slice allocation up front. This lowers both peak memory and save time for large stores (millions of keys). Quickload is order-independent, and the on-disk format is unchanged (byte-compatible protobuf), so no migration is required.
 - Server: tier1 store loading at request start now loads up to 8 stores concurrently (both the size probe and the download/decode), instead of one at a time.

--- a/orchestrator/work/worker.go
+++ b/orchestrator/work/worker.go
@@ -23,7 +23,6 @@ import (
 	pbssinternal "github.com/streamingfast/substreams/pb/sf/substreams/intern/v2"
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 	"github.com/streamingfast/substreams/reqctx"
-	"github.com/streamingfast/substreams/storage/store"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelCodes "go.opentelemetry.io/otel/codes"
@@ -92,7 +91,7 @@ func NewRequest(ctx context.Context, req *reqctx.RequestDetails, stageIndex int,
 		FoundationalStoreEndpoints:      tier2ReqParams.FoundationalStoreEndpoints,
 		EthCallFallbackToLatestDuration: int64(reqctx.EthCallFallbackToLatestDuration(ctx)),
 		EthCallFallbackToNumberDuration: int64(reqctx.EthCallUseBlockNumberDuration(ctx)),
-		StoreSizeLimit:                  store.DefaultStoreSizeLimit,
+		StoreSizeLimit:                  tier2ReqParams.StoreSizeLimit,
 	}
 }
 

--- a/reqctx/tier2request.go
+++ b/reqctx/tier2request.go
@@ -17,6 +17,10 @@ type Tier2RequestParameters struct {
 
 	BlockType string
 
+	// StoreSizeLimit, if non-zero, overrides the default store size limit (in bytes)
+	// for stores loaded on tier2. Set from the tier1 store-size-limit flag.
+	StoreSizeLimit uint64
+
 	WASMModules                map[string]string
 	FoundationalStoreEndpoints map[string]string
 	HostedStoreRegistryAddress string

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -215,8 +215,6 @@ func NewTier1(
 		mergedBlocksBundleSize: tier2RequestParameters.MergedBlocksBundleSize,
 	}
 
-	setSubstreamsStoreSizeLimitFromEnv(logger)
-
 	var err error
 	if blockType == "" {
 		blockType, err = getBlockTypeFromStreamFactory(sf)

--- a/service/tier2.go
+++ b/service/tier2.go
@@ -128,8 +128,6 @@ func NewTier2(
 		activeRequests: active_requests.NewActiveRequestsManager(logger),
 	}
 
-	setSubstreamsStoreSizeLimitFromEnv(logger)
-
 	if debugAPIAddress := os.Getenv("SUBSTREAMS_TIER2_DEBUG_API_ADDR"); debugAPIAddress != "" {
 		debugAPI := debugapi.New(
 			debugAPIAddress,

--- a/service/utils.go
+++ b/service/utils.go
@@ -1,14 +1,10 @@
 package service
 
 import (
-	"os"
 	"sort"
-	"strconv"
 
 	"github.com/streamingfast/bstream"
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
-	"github.com/streamingfast/substreams/storage/store"
-	"go.uber.org/zap"
 )
 
 // EnvEthCallFallbackToLatestDuration is the environment variable name that, when set,
@@ -38,16 +34,5 @@ func irreversibleCursorFromClock(clock *pbsubstreams.Clock) *bstream.Cursor {
 		Block:     bstream.NewBlockRef(clock.Id, clock.Number),
 		LIB:       bstream.NewBlockRef(clock.Id, clock.Number),
 		HeadBlock: bstream.NewBlockRef(clock.Id, clock.Number),
-	}
-}
-
-func setSubstreamsStoreSizeLimitFromEnv(logger *zap.Logger) {
-	if limit := os.Getenv("SUBSTREAMS_STORE_SIZE_LIMIT"); limit != "" {
-		if parsed, err := strconv.ParseUint(limit, 10, 64); err == nil {
-			logger.Info("using SUBSTREAMS_STORE_SIZE_LIMIT from env var", zap.Uint64("limit", parsed))
-			store.DefaultStoreSizeLimit = parsed
-		} else {
-			logger.Warn("invalid SUBSTREAMS_STORE_SIZE_LIMIT env var", zap.String("string", limit))
-		}
 	}
 }


### PR DESCRIPTION
## What

The store size limit override was read from the `SUBSTREAMS_STORE_SIZE_LIMIT` environment variable on **both** tier1 and tier2, mutating the global `store.DefaultStoreSizeLimit`. This replaces it with a single tier1 config field (`Tier1Config.StoreSizeLimit`), forwarded to tier2 on every subrequest via the existing `ProcessRangeRequest.store_size_limit` field.

Tier2 no longer needs the env var set — a shared tier2 fleet is configured entirely by the tier1 that dispatches to it. `0` keeps the default of 1GiB.

## Flow

`--substreams-tier1-store-size-limit` (firehose-core) → `Tier1Config.StoreSizeLimit` → `Tier2RequestParameters` → `ProcessRangeRequest.store_size_limit` → tier2 ctx → `store.NewConfigMap` → per-store `totalSizeLimit`.

## Changes

- `reqctx/tier2request.go` — `StoreSizeLimit` added to `Tier2RequestParameters`
- `app/tier1.go` — `Tier1Config.StoreSizeLimit`, wired into the tier2 request params
- `orchestrator/work/worker.go` — subrequest carries `tier2ReqParams.StoreSizeLimit` (was the global default); dropped now-unused `store` import
- `service/utils.go` — removed `setSubstreamsStoreSizeLimitFromEnv` and its dead imports
- `service/tier1.go` / `service/tier2.go` — removed the env-read calls
- `ENVIRONMENT_VARIABLES.md`, `docs/release-notes/change-log.md` — docs

## Follow-up (separate repo)

firehose-core registers the actual cobra flag (`--substreams-tier1-store-size-limit`) + `config.StoreSizeLimit` assignment. That change is staged locally but must land **after** this merges and the substreams dep is bumped, otherwise firehose-core won't compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)