### PR TITLE
Don't log user cancellation as fatal error in execout walker

### DIFF
--- a/orchestrator/execout/execout_walker.go
+++ b/orchestrator/execout/execout_walker.go
@@ -157,6 +157,15 @@ func (r *Walker) CmdDownloadCurrentSegment(waitBefore time.Duration) loop.Cmd {
 				return MsgFileReadTransientError{NextWait: computeNewWait(waitBefore, r.fileWalker.IsLocal), Error: err}
 			}
 
+			// Request cancelled by the user (or context cancelled): not a fatal error
+			if errors.Is(err, context.Canceled) || r.ctx.Err() != nil {
+				r.logger.Info("context cancelled during download",
+					zap.Int("segment", current),
+					zap.Error(err),
+				)
+				return loop.NewQuitMsg(err)
+			}
+
 			// Fatal error - fail the request
 			r.logger.Error("fatal error loading file",
 				zap.Int("segment", current),


### PR DESCRIPTION
A `context canceled` error while loading an execout file means the client canceled the request. It was falling through to the fatal-error branch and logged at `ERROR` severity, e.g.:

```
"severity":"ERROR" ... "message":"fatal error loading file" ... "error":"...: context canceled"
```

Now caught before the fatal branch (via `errors.Is(err, context.Canceled) || r.ctx.Err() != nil`) and logged at `INFO`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)