### PR TITLE
Fix 'substreams info <shortname>' by using the package download endpoint

### DIFF
--- a/cmd/substreams/info.go
+++ b/cmd/substreams/info.go
@@ -66,7 +66,7 @@ func runInfo(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := []manifest.Option{
-		manifest.WithRegistryURL(getSubstreamsRegistryEndpoint()),
+		manifest.WithRegistryURL(getSubstreamsDownloadEndpoint()),
 	}
 	if skipPackageValidation {
 		opts = append(opts, manifest.SkipPackageValidationReader())


### PR DESCRIPTION
`substreams info common` failed with:

```
Error: read manifest "common": package does not exist on the Substreams registry
```

Root cause: `info` passed `getSubstreamsRegistryEndpoint()` (`https://substreams.dev`, the registry **API** host) as the package-fetch base URL. Package fetches hit `/v1/packages/<name>/<version>`, which is served by the **download** endpoint `https://spkg.io`. So the request 404'd.

`run`/`gui` work because they resolve against the download endpoint (spkg.io). Fix aligns `info` with them by using `getSubstreamsDownloadEndpoint()`.

Introduced in 883e29fc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)