### PR TITLE
hotfix: wire StoreSizeLimit into tier1 linear pipeline

### DIFF
--- a/app/tier1.go
+++ b/app/tier1.go
@@ -277,6 +277,9 @@ func (a *Tier1App) Run() error {
 	if a.config.StoresBackend != "" {
 		opts = append(opts, service.WithStoresBackend(a.config.StoresBackend))
 	}
+	if a.config.StoreSizeLimit != 0 {
+		opts = append(opts, service.WithStoreSizeLimit(a.config.StoreSizeLimit))
+	}
 
 	if a.config.TmpDir != "" {
 		wazero.SetTempDir(a.config.TmpDir)

--- a/service/config/runtimeconfig.go
+++ b/service/config/runtimeconfig.go
@@ -20,6 +20,7 @@ type RuntimeConfig struct {
 	DefaultCacheTag        string // appended to BaseObjectStore unless overridden by auth layer
 	StoresScratchSpace     string // local directory for ephemeral store files (e.g. bbolt); uses OS temp dir if empty
 	StoresBackend          string // store KV backend: "memory" (default) or "mmap"; empty falls back to SUBSTREAMS_STORE_BACKEND env var (also memory-default)
+	StoreSizeLimit         uint64 // if non-zero, overrides the default per-store size limit (in bytes)
 	ClientFactory          client.InternalClientFactory
 	WorkerPoolFactory      work.WorkerPoolFactory
 	ModuleExecutionTracing bool

--- a/service/options.go
+++ b/service/options.go
@@ -119,6 +119,16 @@ func deleteLeftoverStoreFilesAtStartup(dir string) {
 	}
 }
 
+// WithStoreSizeLimit sets the per-store size limit on tier1's own (linear)
+// pipeline. Tier2 receives this limit per-request via ProcessRangeRequest.
+func WithStoreSizeLimit(limit uint64) Option {
+	return func(a anyTierService) {
+		if s, ok := a.(*Tier1Service); ok {
+			s.runtimeConfig.StoreSizeLimit = limit
+		}
+	}
+}
+
 func WithStoresBackend(backend string) Option {
 	return func(a anyTierService) {
 		switch s := a.(type) {

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -763,7 +763,7 @@ func (s *Tier1Service) blocks(
 		return fmt.Errorf("new config map: %w", err)
 	}
 
-	storeConfigs, err := store.NewConfigMap(cacheStore, quickSaveStore, execGraph.Stores(), execGraph.ModuleHashes(), chainFirstStreamableBlock, 0, s.runtimeConfig.StoresScratchSpace, s.runtimeConfig.StoresBackend)
+	storeConfigs, err := store.NewConfigMap(cacheStore, quickSaveStore, execGraph.Stores(), execGraph.ModuleHashes(), chainFirstStreamableBlock, s.runtimeConfig.StoreSizeLimit, s.runtimeConfig.StoresScratchSpace, s.runtimeConfig.StoresBackend)
 	if err != nil {
 		return fmt.Errorf("configuring stores: %w", err)
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -182,6 +182,29 @@ func TestForkHandling(t *testing.T) {
 	}
 }
 
+// TestStoreSizeLimit guards the tier1 linear-pipeline wiring of the configured
+// per-store size limit (RuntimeConfig.StoreSizeLimit). Regression: tier1 used to
+// hardcode 0 when building its store ConfigMap, so it always applied the default
+// store size limit and ignored the operator-configured value. With a tiny limit
+// set here, tier1's own linear processing must trip ErrStoreAboveMaxSize; if the
+// limit is silently dropped again, the store grows unbounded and this test fails.
+func TestStoreSizeLimit(t *testing.T) {
+	manifest.TestUseSimpleHash = true
+	bstream.GetProtocolFirstStreamableBlock = 0
+
+	defaultSPKG := "./testdata/simple_substreams/substreams-test-v0.1.0.spkg"
+
+	run := newTestRun(t, 25, 25, 29, 0, "assert_test_store_add_i64", defaultSPKG)
+	run.ProductionMode = false
+	run.ParallelSubrequests = 1
+	run.StoreSizeLimit = 1 // 1 byte: any store content trips the limit on tier1
+
+	err := run.Run(t, "store_size_limit")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "became too big")
+	assert.Contains(t, err.Error(), "maximum size: 1")
+}
+
 func TestOneStoreOneMap(t *testing.T) {
 	testStoreAddI64Hash := hex.EncodeToString([]byte("setup_test_store_add_i64"))
 	assertTestStoreAddI64Hash := hex.EncodeToString([]byte("assert_test_store_add_i64"))

--- a/test/runnable_test.go
+++ b/test/runnable_test.go
@@ -51,6 +51,7 @@ type testRun struct {
 	JobCallback            func(stage.Unit)
 	LinearHandoffBlockNum  uint64 // defaults to the request's StopBlock, so no linear handoff, only backprocessing
 	FirstStreamableBlock   uint64
+	StoreSizeLimit         uint64 // per-store size limit for tier1's linear pipeline; 0 uses the store default
 	ProductionMode         bool
 	// PreWork can be done to perform tier2 work in advance, to simulate when
 	// pre-existing data is available in different conditions
@@ -177,7 +178,7 @@ func (f *testRun) run(t *testing.T, testName string) error {
 		f.PreWork(t, f, workerPoolFactory)
 	}
 
-	if err := processRequest(t, ctx, request, workerPoolFactory, newBlockGenerator, responseCollector, false, f.BlockProcessedCallback, f.TempDir, f.ParallelSubrequests, f.LinearHandoffBlockNum); err != nil {
+	if err := processRequest(t, ctx, request, workerPoolFactory, newBlockGenerator, responseCollector, false, f.BlockProcessedCallback, f.TempDir, f.ParallelSubrequests, f.LinearHandoffBlockNum, f.StoreSizeLimit); err != nil {
 		return fmt.Errorf("running test: %w", err)
 	}
 
@@ -337,6 +338,7 @@ func processRequest(
 	testTempDir string,
 	parallelSubrequests uint64,
 	linearHandoffBlockNum uint64,
+	storeSizeLimit uint64,
 ) error {
 	t.Helper()
 
@@ -360,6 +362,7 @@ func processRequest(
 		DefaultCacheTag:            "tag",
 		MaxJobsAhead:               10,
 		WorkerPoolFactory:          workerPoolFactory,
+		StoreSizeLimit:             storeSizeLimit,
 	}
 
 	svc := service.TestNewService(runtimeConfig, linearHandoffBlockNum, tr.StreamFactory)

--- a/tests_e2e/mmap_test.go
+++ b/tests_e2e/mmap_test.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/streamingfast/substreams/manifest"
 	pbsubstreamsrpcv3 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v3"
@@ -14,6 +17,73 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 )
+
+// mmapDBFilePoller watches dir for *.db files while a request runs. The mmap
+// backend creates a temp .db file per store and removes it on Close (see
+// storage/store/kv_impl_mmap.go), so the files only exist transiently during
+// processing and are gone by the time a request returns. Poll fast to observe
+// the peak count instead of checking the dir after the fact.
+type mmapDBFilePoller struct {
+	dir     string
+	maxDB   int64
+	maxSize int64
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+func startMmapDBFilePoller(dir string) *mmapDBFilePoller {
+	p := &mmapDBFilePoller{
+		dir:  dir,
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+	go func() {
+		defer close(p.done)
+		ticker := time.NewTicker(5 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			p.sample()
+			select {
+			case <-p.stop:
+				p.sample() // final sample to catch anything created just before stop
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return p
+}
+
+func (p *mmapDBFilePoller) sample() {
+	entries, err := os.ReadDir(p.dir)
+	if err != nil {
+		return
+	}
+	var count, size int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".db") {
+			continue
+		}
+		count++
+		if info, err := e.Info(); err == nil {
+			size += info.Size()
+		}
+	}
+	if count > atomic.LoadInt64(&p.maxDB) {
+		atomic.StoreInt64(&p.maxDB, count)
+	}
+	if size > atomic.LoadInt64(&p.maxSize) {
+		atomic.StoreInt64(&p.maxSize, size)
+	}
+}
+
+// Stop halts polling and returns the peak .db file count and total size seen.
+func (p *mmapDBFilePoller) Stop() (maxDBFiles int, maxTotalSize int64) {
+	var once sync.Once
+	once.Do(func() { close(p.stop) })
+	<-p.done
+	return int(atomic.LoadInt64(&p.maxDB)), atomic.LoadInt64(&p.maxSize)
+}
 
 // TestMmapBackendE2E validates that mmap backend works in full e2e scenario.
 // mmap is the default backend, so no SUBSTREAMS_STORE_BACKEND env var is set here.
@@ -104,6 +174,10 @@ func TestMmapBackendE2E(t *testing.T) {
 				Package:         pkg.Package,
 			}
 
+			// Watch for the transient mmap .db files while the request runs;
+			// the backend removes them on Close, so they won't exist afterward.
+			poller := startMmapDBFilePoller(mmapDir)
+
 			// Run the request
 			blockScopedDataSlice, session, err := RunRequest(t, request, substreamsEndpoint)
 			if err != nil && err != io.EOF {
@@ -117,26 +191,15 @@ func TestMmapBackendE2E(t *testing.T) {
 				t.Fatalf("Unexpected error: %s", err.Error())
 			}
 
+			maxDBFiles, maxTotalSize := poller.Stop()
+
 			require.NotNil(t, session, "Should have received at least one session")
 			assert.Equal(t, tc.expectedLen, len(blockScopedDataSlice), "Should have received all expected blocks")
 			require.Greater(t, len(blockScopedDataSlice), 0)
 			assert.Equal(t, tc.expectedClock, uint64(blockScopedDataSlice[len(blockScopedDataSlice)-1].Clock.Number), "Should end on expected block")
 
-			filesAfter, err := os.ReadDir(mmapDir)
-			require.NoError(t, err)
-			t.Logf("Mmap files after test: %d", len(filesAfter))
-
-			dbFiles := 0
-			for _, file := range filesAfter {
-				if !file.IsDir() && strings.HasSuffix(file.Name(), ".db") {
-					dbFiles++
-					info, err := file.Info()
-					if err == nil {
-						t.Logf("  - %s: %d bytes (%.2f MB)", file.Name(), info.Size(), float64(info.Size())/(1024*1024))
-					}
-				}
-			}
-			assert.Greater(t, dbFiles, 0, "mmap backend must leave visible .db files in the scratch dir")
+			t.Logf("Peak mmap .db files during test: %d (%.2f MB)", maxDBFiles, float64(maxTotalSize)/(1024*1024))
+			assert.Greater(t, maxDBFiles, 0, "mmap backend must create .db files in the scratch dir while running")
 
 			t.Logf("Test completed successfully with mmap backend")
 		})
@@ -261,6 +324,11 @@ func TestMmapVsMemoryComparison(t *testing.T) {
 				Package:         pkg.Package,
 			}
 
+			var poller *mmapDBFilePoller
+			if tc.backend == "mmap" {
+				poller = startMmapDBFilePoller(mmapDir)
+			}
+
 			blockScopedDataSlice, session, err := RunRequest(t, request, substreamsEndpoint)
 			if err != nil && err != io.EOF {
 				t.Fatalf("Unexpected error: %s", err.Error())
@@ -278,22 +346,12 @@ func TestMmapVsMemoryComparison(t *testing.T) {
 				finalClock: finalClock,
 			}
 
-			// Check for mmap files
+			// The mmap backend removes each store's .db file on Close, so
+			// sample the peak seen during the run instead of after it.
 			if tc.backend == "mmap" {
-				files, err := os.ReadDir(mmapDir)
-				require.NoError(t, err)
-				result.mmapFilesCount = len(files)
-
-				totalSize := int64(0)
-				for _, file := range files {
-					if !file.IsDir() {
-						info, err := file.Info()
-						if err == nil {
-							totalSize += info.Size()
-						}
-					}
-				}
-				result.totalMmapSizeMB = float64(totalSize) / (1024 * 1024)
+				maxDBFiles, maxTotalSize := poller.Stop()
+				result.mmapFilesCount = maxDBFiles
+				result.totalMmapSizeMB = float64(maxTotalSize) / (1024 * 1024)
 			}
 
 			results = append(results, result)


### PR DESCRIPTION
## Problem

Operators set `StoreSizeLimit` (e.g. 3.5GiB) but tier1's own linear (dev-mode) pipeline still tripped at the 1GiB default:

```
store "uniswap_v4:store_pools" became too big at 1579123284, maximum size: 1073741824
```

`service/tier1.go` hardcoded `0` when building its store `ConfigMap`, so it always fell back to `DefaultStoreSizeLimit`. Tier2 subrequests received the limit correctly via `ProcessRangeRequest`; only tier1's linear path ignored it.

## Fix

- Add `StoreSizeLimit` to `RuntimeConfig` (next to `StoresScratchSpace`/`StoresBackend`) + `WithStoreSizeLimit` option, wired from the tier1 app config.
- tier1 store `ConfigMap` now passes `runtimeConfig.StoreSizeLimit` instead of `0`.

## Test

`TestStoreSizeLimit` sets a 1-byte limit on the tier1 linear pipeline and asserts `ErrStoreAboveMaxSize`. Verified it fails if the wiring regresses (limit dropped back to `0`).

## Additional e2e tests fixes

* mmap test was failing because the assertion for 'db files exist' was in a race condition with the deletion step. Now polls during the test to validate that files exist.