### PR TITLE
Send SessionInit before streaming quickload decode

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.20.1
+
+### Fixed
+
+- Server: linear quickload resume now emits `SessionInit` (trace id) and starts keepalives before the store decode streams, instead of after. A large or remote quicksave could previously stream for a long time with zero client output; the quickload-success path also never emitted a `SessionInit` at all.
+
 ## v1.20.0
 
 ### Changed
@@ -20,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Server: new opt-in mmap (bbolt-backed) store backend, selectable via `--substreams-stores-backend=mmap` (default `memory`). It keeps FullKV store data in a memory-mapped file so cold pages are reclaimable by the kernel under memory pressure, instead of pinning everything on the non-reclaimable Go heap — this addresses production OOMs with large or highly concurrent stores. The in-memory backend remains the default and is byte-for-byte unchanged; mmap is validated to produce identical output. **The scratch-space directory holding the bbolt files (`StoresScratchSpace`, OS temp dir if unset) must live on a local NVMe SSD**: the store is continuously read from and written to through the mmap, and the kernel pages it straight to that file, so a slow or network-backed disk turns store operations into an I/O bottleneck and negates the benefit. Do not point it at network/EBS-class storage.
+- Server: new opt-in mmap (bbolt-backed) store backend, selectable via `--substreams-stores-backend=mmap` (default `memory`). It keeps FullKV store data in a memory-mapped file so cold pages are reclaimable by the kernel under memory pressure, instead of pinning everything on the non-reclaimable Go heap — this addresses production OOMs with large or highly concurrent stores. The in-memory backend remains the default and is byte-for-byte unchanged; mmap is validated to produce identical output. **The scratch-space directory holding the bbolt files (`StoresScratchSpace`, default "{sf-data-dir}/substreams/stores-scratch") must live on a local NVMe SSD**: the store is continuously read from and written to through the mmap, and the kernel pages it straight to that file, so a slow or network-backed disk turns store operations into an I/O bottleneck and negates the benefit. Do not point it at network/EBS-class storage.
 
 - Server: cached deterministic errors now expire. Each error file carries a write timestamp in its name (`errors.<block>.<hash>.<unix>`), and on read tier1 discards any error older than `SUBSTREAMS_DETERMINISTIC_ERROR_MAX_AGE` (Go duration, default `1h`), retrying execution. Legacy error files without a timestamp are deleted on read.
 

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -148,6 +148,7 @@ type Pipeline struct {
 	lastCursor            *bstream.Cursor
 	sentBlocks            uint64
 	quickSaved            bool
+	sessionInitSent       bool // ensures a single Response_Session per request; see sendSession
 
 	blockStepMap         map[bstream.StepType]uint64
 	workerPoolFactory    work.WorkerPoolFactory
@@ -261,34 +262,40 @@ func (p *Pipeline) InitTier2Stores(ctx context.Context) (err error) {
 	return nil
 }
 
-func (p *Pipeline) initStoresFromQuickload(ctx context.Context, reqPlan *plan.RequestPlan) (success bool) {
+// openStoresFromQuickload checks whether the request can resume linearly from its
+// cursor by loading store state from the temporary quicksave files, and if so opens
+// (but does NOT yet stream) those files. Returning a primed store map + the cursor
+// block lets the caller emit the client's session/trace-id before the slow streaming
+// decode in finishStoresFromQuickload. On any miss it cleans up and returns false so
+// the caller falls back to a full parallel rebuild.
+func (p *Pipeline) openStoresFromQuickload(ctx context.Context, reqPlan *plan.RequestPlan) (store.Map, bstream.BlockRef, bool) {
 
 	// no stores to init
 	if len(p.stores.configs) == 0 {
-		return false
+		return nil, nil, false
 	}
 
 	if reqPlan.LinearPipeline == nil {
-		return false
+		return nil, nil, false
 	}
 
 	if reqPlan.WriteExecOut != nil || reqPlan.ReadExecOut != nil {
-		return false
+		return nil, nil, false
 	}
 
 	details := reqctx.Details(ctx)
 	if details.ResolvedCursor == "" {
-		return false
+		return nil, nil, false
 	}
 
 	cursor, err := bstream.CursorFromOpaque(details.ResolvedCursor)
 	if err != nil {
 		reqctx.Logger(ctx).Warn("invalid cursor", zap.Error(err))
-		return false
+		return nil, nil, false
 	}
 
 	if !reqPlan.LinearPipeline.Contains(cursor.Block.Num() + 1) {
-		return false
+		return nil, nil, false
 	}
 
 	storeMap := store.NewMap()
@@ -296,27 +303,67 @@ func (p *Pipeline) initStoresFromQuickload(ctx context.Context, reqPlan *plan.Re
 		storeMap[storeConfig.Name()] = storeConfig.NewFullKV(p.stores.logger)
 	}
 
-	if err := storeMap.QuickLoad(ctx, cursor.Block); err != nil {
+	if err := storeMap.QuickLoadOpen(ctx, cursor.Block); err != nil {
 		p.stores.logger.Info("no temporary store files found", zap.Error(err))
-		for _, st := range storeMap.All() {
-			if closer, ok := st.(interface{ Close() error }); ok {
-				if cerr := closer.Close(); cerr != nil {
-					p.stores.logger.Warn("failed to close store after quickload failure", zap.String("store", st.Name()), zap.Error(cerr))
-				}
+		p.closeQuickloadStores(storeMap)
+		return nil, nil, false
+	}
+
+	return storeMap, cursor.Block, true
+}
+
+// finishStoresFromQuickload streams the quicksave files opened by
+// openStoresFromQuickload into the store map and installs it as the active store map.
+func (p *Pipeline) finishStoresFromQuickload(ctx context.Context, storeMap store.Map, atBlock bstream.BlockRef) error {
+	if err := storeMap.QuickLoadFinish(ctx, atBlock); err != nil {
+		return err
+	}
+	reqctx.Logger(ctx).Info("skipping backprocessing, reading from temporary files", zap.Strings("stores", storeMap.Names()), zap.Uint64("block_num", atBlock.Num()), zap.String("block_id", atBlock.ID()))
+	p.stores.StoreMap = storeMap
+	return nil
+}
+
+// closeQuickloadStores releases the KV backends (e.g. the bbolt mmap file) of a
+// quickload store map that will not be used, so a failed/abandoned quickload does
+// not leak open stores.
+func (p *Pipeline) closeQuickloadStores(storeMap store.Map) {
+	for _, st := range storeMap.All() {
+		if closer, ok := st.(interface{ Close() error }); ok {
+			if cerr := closer.Close(); cerr != nil {
+				p.stores.logger.Warn("failed to close store after quickload failure", zap.String("store", st.Name()), zap.Error(cerr))
 			}
 		}
-		return false
 	}
-	reqctx.Logger(ctx).Info("skipping backprocessing, reading from temporary files", zap.Strings("stores", storeMap.Names()), zap.Uint64("block_num", cursor.Block.Num()), zap.String("block_id", cursor.Block.ID()))
-	p.stores.StoreMap = storeMap
-	return true
 }
 
 func (p *Pipeline) InitTier1StoresAndBackprocess(ctx context.Context, reqPlan *plan.RequestPlan, noopMode bool) (bool, error) {
-	success := p.initStoresFromQuickload(ctx, reqPlan)
-	if success {
-		reqctx.Details(ctx).FromQuickload = true
-		return true, nil
+	if storeMap, atBlock, ok := p.openStoresFromQuickload(ctx, reqPlan); ok {
+		// Emit the session (trace id) and start keepalives BEFORE streaming the
+		// quicksave files: that decode can take a long time for a large store on a
+		// cold/remote quicksave store, and it used to run with zero output to the
+		// client, risking a gateway/client idle-timeout before the trace id ever
+		// arrived. The files are already open here, so we're committed to the linear
+		// resume path.
+		if err := p.emitLinearSessionInit(ctx); err != nil {
+			storeMap.QuickLoadClose()
+			p.closeQuickloadStores(storeMap)
+			return false, err
+		}
+
+		// A decode failure here (corrupt/truncated file, or canceled context) falls
+		// through to a full rebuild below, exactly as a missing file would. The already
+		// -emitted linear session is deduped by sendSession, so the rebuild path won't
+		// emit a second, conflicting one. Release the abandoned store map first (open
+		// readers + mmap db/temp file), and leave FromQuickload false so the rebuild is
+		// not mistaken for a genuine quickload resume downstream (live backfiller).
+		if err := p.finishStoresFromQuickload(ctx, storeMap, atBlock); err != nil {
+			p.stores.logger.Warn("quicksave present but failed to decode, falling back to full processing", zap.Error(err))
+			storeMap.QuickLoadClose()
+			p.closeQuickloadStores(storeMap)
+		} else {
+			reqctx.Details(ctx).FromQuickload = true
+			return true, nil
+		}
 	}
 
 	if reqPlan.RequiresParallelProcessing() {
@@ -327,46 +374,67 @@ func (p *Pipeline) InitTier1StoresAndBackprocess(ctx context.Context, reqPlan *p
 		p.stores.SetStoreMap(storeMap) // this is valid even if we don't have stores in the parallelProcessing but only a mapper
 		return false, nil
 	} else {
-
-		reqDetails := reqctx.Details(ctx)
-		var toProcessAfter uint64
-		estimateProcessUpto := reqDetails.StopBlockNum
-		if estimateProcessUpto == 0 && p.getHeadBlockNum != nil {
-			headBlock, err := p.getHeadBlockNum()
-			if err != nil {
-				reqctx.Logger(ctx).Warn("cannot get head block for sessionInit", zap.Error(err))
-			} else {
-				estimateProcessUpto = headBlock
-			}
+		if err := p.emitLinearSessionInit(ctx); err != nil {
+			return false, err
 		}
-
-		if estimateProcessUpto != 0 && estimateProcessUpto > reqDetails.ResolvedStartBlockNum {
-			toProcessAfter = estimateProcessUpto - reqDetails.ResolvedStartBlockNum
-		}
-
-		p.respFunc(&pbsubstreamsrpc.Response{
-			Message: &pbsubstreamsrpc.Response_Session{
-				Session: &pbsubstreamsrpc.SessionInit{
-					TraceId:                                  tracing.GetTraceID(ctx).String(),
-					ResolvedStartBlock:                       reqDetails.ResolvedStartBlockNum,
-					LinearHandoffBlock:                       reqDetails.LinearHandoffBlockNum,
-					MaxParallelWorkers:                       reqDetails.MaxParallelJobs,
-					BlocksToProcessBeforeStartBlock:          0,
-					EffectiveBlocksToProcessBeforeStartBlock: 0,
-					BlocksToProcessAfterStartBlock:           toProcessAfter, // only linear processing
-					EffectiveBlocksToProcessAfterStartBlock:  toProcessAfter, // only linear processing
-				},
-			},
-		})
-
-		if err := reqDetails.AssertProcessedBlocksLimit(0, toProcessAfter); err != nil {
-			return false, connect.NewError(connect.CodeFailedPrecondition, err)
-		}
-
 	}
 
 	p.stores.SetStoreMap(p.setupEmptyStores(ctx))
 	return false, nil
+}
+
+// sendSession emits the request's Response_Session, at most once. Both the linear
+// (emitLinearSessionInit) and parallel (runParallelProcess) paths funnel through
+// here, so a quickload that emits its linear session and then falls back to a full
+// rebuild cannot produce a second, conflicting session. Called only from the request
+// goroutine, so the flag needs no synchronization.
+func (p *Pipeline) sendSession(session *pbsubstreamsrpc.SessionInit) {
+	if p.sessionInitSent {
+		return
+	}
+	p.sessionInitSent = true
+	p.respFunc(&pbsubstreamsrpc.Response{
+		Message: &pbsubstreamsrpc.Response_Session{Session: session},
+	})
+}
+
+// emitLinearSessionInit sends the Response_Session message for a purely linear run
+// (no parallel backprocessing): quickload resume from a cursor, or a start block
+// already inside the linear pipeline. The parallel path emits its own Session message
+// from runParallelProcess.
+func (p *Pipeline) emitLinearSessionInit(ctx context.Context) error {
+	reqDetails := reqctx.Details(ctx)
+	var toProcessAfter uint64
+	estimateProcessUpto := reqDetails.StopBlockNum
+	if estimateProcessUpto == 0 && p.getHeadBlockNum != nil {
+		headBlock, err := p.getHeadBlockNum()
+		if err != nil {
+			reqctx.Logger(ctx).Warn("cannot get head block for sessionInit", zap.Error(err))
+		} else {
+			estimateProcessUpto = headBlock
+		}
+	}
+
+	if estimateProcessUpto != 0 && estimateProcessUpto > reqDetails.ResolvedStartBlockNum {
+		toProcessAfter = estimateProcessUpto - reqDetails.ResolvedStartBlockNum
+	}
+
+	p.sendSession(&pbsubstreamsrpc.SessionInit{
+		TraceId:                                  tracing.GetTraceID(ctx).String(),
+		ResolvedStartBlock:                       reqDetails.ResolvedStartBlockNum,
+		LinearHandoffBlock:                       reqDetails.LinearHandoffBlockNum,
+		MaxParallelWorkers:                       reqDetails.MaxParallelJobs,
+		BlocksToProcessBeforeStartBlock:          0,
+		EffectiveBlocksToProcessBeforeStartBlock: 0,
+		BlocksToProcessAfterStartBlock:           toProcessAfter, // only linear processing
+		EffectiveBlocksToProcessAfterStartBlock:  toProcessAfter, // only linear processing
+	})
+
+	if err := reqDetails.AssertProcessedBlocksLimit(0, toProcessAfter); err != nil {
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+
+	return nil
 }
 
 func (p *Pipeline) GetStoreMap() store.Map {
@@ -589,20 +657,15 @@ func (p *Pipeline) runParallelProcess(ctx context.Context, reqPlan *plan.Request
 	}
 
 	blocksBefore, effectiveBlocksBefore, blocksAfter, effectiveBlocksAfter := parallelProcessor.Stages().BlocksToProcess(headBlockNum)
-	traceId := tracing.GetTraceID(ctx).String()
-	p.respFunc(&pbsubstreamsrpc.Response{
-		Message: &pbsubstreamsrpc.Response_Session{
-			Session: &pbsubstreamsrpc.SessionInit{
-				TraceId:                                  traceId,
-				ResolvedStartBlock:                       reqDetails.ResolvedStartBlockNum,
-				LinearHandoffBlock:                       reqDetails.LinearHandoffBlockNum,
-				MaxParallelWorkers:                       reqDetails.MaxParallelJobs,
-				BlocksToProcessBeforeStartBlock:          blocksBefore,
-				BlocksToProcessAfterStartBlock:           blocksAfter,
-				EffectiveBlocksToProcessBeforeStartBlock: effectiveBlocksBefore,
-				EffectiveBlocksToProcessAfterStartBlock:  effectiveBlocksAfter,
-			},
-		},
+	p.sendSession(&pbsubstreamsrpc.SessionInit{
+		TraceId:                                  tracing.GetTraceID(ctx).String(),
+		ResolvedStartBlock:                       reqDetails.ResolvedStartBlockNum,
+		LinearHandoffBlock:                       reqDetails.LinearHandoffBlockNum,
+		MaxParallelWorkers:                       reqDetails.MaxParallelJobs,
+		BlocksToProcessBeforeStartBlock:          blocksBefore,
+		BlocksToProcessAfterStartBlock:           blocksAfter,
+		EffectiveBlocksToProcessBeforeStartBlock: effectiveBlocksBefore,
+		EffectiveBlocksToProcessAfterStartBlock:  effectiveBlocksAfter,
 	})
 
 	if err := reqDetails.AssertProcessedBlocksLimit(effectiveBlocksBefore, effectiveBlocksAfter); err != nil {

--- a/storage/store/config.go
+++ b/storage/store/config.go
@@ -172,7 +172,7 @@ func (c *Config) ModuleInitialBlock() uint64 {
 }
 
 func (c *Config) NewFullKV(logger *zap.Logger) *FullKV {
-	return &FullKV{c.newBaseStore(logger), "N/A"}
+	return &FullKV{baseStore: c.newBaseStore(logger), loadedFrom: "N/A"}
 }
 
 func (c *Config) ExistsFullKV(ctx context.Context, upTo uint64) (bool, error) {

--- a/storage/store/full_kv.go
+++ b/storage/store/full_kv.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"time"
 
@@ -21,6 +22,12 @@ type FullKV struct {
 	*baseStore
 
 	loadedFrom string
+
+	// quickLoadReader holds the quicksave object opened by QuickLoadOpen until
+	// QuickLoadFinish streams it (or QuickLoadClose discards it). Set/read only
+	// from the request goroutine, so no synchronization is needed.
+	quickLoadReader   io.ReadCloser
+	quickLoadFilename string
 }
 
 func (s *FullKV) Store() dstore.Store {
@@ -48,12 +55,25 @@ func (s *FullKV) DerivePartialStore(initialBlock uint64) *PartialKV {
 
 var ErrNoQuickSaveStore = fmt.Errorf("no quick save store")
 
+// QuickLoad opens and streams the quicksave file in one call. It is equivalent
+// to QuickLoadOpen followed by QuickLoadFinish and exists for callers that don't
+// need to interleave work between the (cheap) open and the (slow) streaming decode.
 func (s *FullKV) QuickLoad(ctx context.Context, atBlock bstream.BlockRef) error {
+	if err := s.QuickLoadOpen(ctx, atBlock); err != nil {
+		return err
+	}
+	return s.QuickLoadFinish(ctx, atBlock)
+}
+
+// QuickLoadOpen opens the quicksave object for atBlock, confirming it exists and
+// is readable, but does not stream it yet. Pairing this with a later QuickLoadFinish
+// lets the caller do work (e.g. send the client its session/trace-id and keepalives)
+// during the potentially slow streaming decode instead of before it.
+func (s *FullKV) QuickLoadOpen(ctx context.Context, atBlock bstream.BlockRef) error {
 	if s.quickSaveStore == nil {
 		return ErrNoQuickSaveStore
 	}
 
-	start := time.Now()
 	filename := atBlock.ID() + ".quicksave"
 	s.logger.Debug("loading full store state from temporary file", zap.String("fileName", filename), zap.String("module_hash", s.moduleHash), zap.Uint64("block_num", atBlock.Num()), zap.String("block_id", atBlock.ID()))
 
@@ -62,8 +82,26 @@ func (s *FullKV) QuickLoad(ctx context.Context, atBlock bstream.BlockRef) error 
 		return fmt.Errorf("opening file %q (in module %q): %w", filename, s.moduleHash, err)
 	}
 
+	s.quickLoadReader = r
+	s.quickLoadFilename = filename
+	return nil
+}
+
+// QuickLoadFinish streams the object opened by QuickLoadOpen into the store and
+// closes it. It must be called after a successful QuickLoadOpen.
+func (s *FullKV) QuickLoadFinish(ctx context.Context, atBlock bstream.BlockRef) error {
+	if s.quickLoadReader == nil {
+		return fmt.Errorf("quickload finish called without a prior successful open for store %q", s.name)
+	}
+
+	r := s.quickLoadReader
+	filename := s.quickLoadFilename
+	s.quickLoadReader = nil
+	s.quickLoadFilename = ""
 	defer r.Close()
 
+	start := time.Now()
+	var err error
 	s.totalSizeBytes, err = unmarshalIterInto(ctx, s.kvImpl, s.marshaller, r, nil)
 	if err != nil {
 		return fmt.Errorf("unmarshal store (streaming): %w", err)
@@ -78,6 +116,17 @@ func (s *FullKV) QuickLoad(ctx context.Context, atBlock bstream.BlockRef) error 
 		zap.Duration("load_duration", time.Since(start)),
 	)
 	return nil
+}
+
+// QuickLoadClose discards a reader opened by QuickLoadOpen without streaming it,
+// used to release resources when a sibling store's open failed and the whole
+// quickload is being abandoned.
+func (s *FullKV) QuickLoadClose() {
+	if s.quickLoadReader != nil {
+		_ = s.quickLoadReader.Close()
+		s.quickLoadReader = nil
+		s.quickLoadFilename = ""
+	}
 }
 
 func (s *FullKV) QuickSave(ctx context.Context, atBlockHash string) error {

--- a/storage/store/interface.go
+++ b/storage/store/interface.go
@@ -57,6 +57,9 @@ type Store interface {
 
 type QuickLoad interface {
 	QuickLoad(ctx context.Context, atBlock bstream.BlockRef) error
+	QuickLoadOpen(ctx context.Context, atBlock bstream.BlockRef) error
+	QuickLoadFinish(ctx context.Context, atBlock bstream.BlockRef) error
+	QuickLoadClose()
 }
 
 type QuickSave interface {

--- a/storage/store/map.go
+++ b/storage/store/map.go
@@ -56,6 +56,17 @@ func (m *Map) QuickSave(ctx context.Context, atBlockHash string) error {
 }
 
 func (m *Map) QuickLoad(ctx context.Context, atBlock bstream.BlockRef) error {
+	if err := m.QuickLoadOpen(ctx, atBlock); err != nil {
+		return err
+	}
+	return m.QuickLoadFinish(ctx, atBlock)
+}
+
+// QuickLoadOpen opens every store's quicksave object (confirming they all exist
+// and are readable) without streaming them. If any open fails, every reader opened
+// so far is released before returning, so a failed open leaves no dangling handles.
+// On success the caller must eventually call QuickLoadFinish (or QuickLoadClose).
+func (m *Map) QuickLoadOpen(ctx context.Context, atBlock bstream.BlockRef) error {
 	eg := llerrgroup.New(quickSaveParallelism)
 	for _, s := range m.All() {
 		loadable, ok := s.(QuickLoad)
@@ -66,10 +77,46 @@ func (m *Map) QuickLoad(ctx context.Context, atBlock bstream.BlockRef) error {
 			break
 		}
 		eg.Go(func() error {
-			return loadable.QuickLoad(ctx, atBlock)
+			return loadable.QuickLoadOpen(ctx, atBlock)
 		})
 	}
 	if err := eg.Wait(); err != nil {
+		m.QuickLoadClose()
+		return err
+	}
+	return nil
+}
+
+// QuickLoadClose releases any readers opened by QuickLoadOpen that were not yet
+// streamed, used to abandon a quickload after a partial open.
+func (m *Map) QuickLoadClose() {
+	for _, s := range m.All() {
+		if loadable, ok := s.(QuickLoad); ok {
+			loadable.QuickLoadClose()
+		}
+	}
+}
+
+// QuickLoadFinish streams every store's previously-opened quicksave object into
+// the store, then does memory accounting. Must follow a successful QuickLoadOpen.
+func (m *Map) QuickLoadFinish(ctx context.Context, atBlock bstream.BlockRef) error {
+	eg := llerrgroup.New(quickSaveParallelism)
+	for _, s := range m.All() {
+		loadable, ok := s.(QuickLoad)
+		if !ok {
+			continue
+		}
+		if eg.Stop() {
+			break
+		}
+		eg.Go(func() error {
+			return loadable.QuickLoadFinish(ctx, atBlock)
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		// A store's Finish failed (or was skipped after eg.Stop): release any
+		// readers opened by QuickLoadOpen that were never streamed.
+		m.QuickLoadClose()
 		return err
 	}
 


### PR DESCRIPTION
## What

Split `QuickLoad` into `QuickLoadOpen` (cheap: confirm quicksave files exist/readable) + `QuickLoadFinish` (slow: stream-decode into stores). The tier1 linear resume path now emits `SessionInit` (trace id) and starts keepalives **between** open and finish.

## Why

A large or cold/remote quicksave store could stream-decode for a long time with zero output to the client, risking a gateway/client idle-timeout before the trace id ever arrived. The old quickload-success path additionally never emitted a `SessionInit` at all.

All `SessionInit` emission now funnels through `sendSession` with a once-guard (`sessionInitSent`), so a quickload that emits its linear session and then falls back to a full rebuild cannot produce a second, conflicting session.

## Notes

- Failure paths release readers (`QuickLoadClose`, idempotent) and bbolt backends (`closeQuickloadStores`); a corrupt/truncated quicksave falls through to a full rebuild exactly as a missing file would.
- Wire format unchanged; quickload remains order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)