### PR TITLE
Skip secret-dependent CI steps for dependabot PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -78,7 +78,7 @@ jobs:
         with:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -90,7 +90,7 @@ jobs:
 
       - name: Docker Scout
         id: docker-scout
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
         uses: docker/scout-action@v1
         with:
           dockerhub-user: ${{ secrets.DOCKER_SCOUT_USER }}

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Secret Scanning Review
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
         uses: advanced-security/secret-scanning-review-action@v2.2.4
         with:
           token: ${{ secrets.SECRETS_ALERTS }}


### PR DESCRIPTION
## Problem

`check-secrets` and `docker-build` are required checks but fail on **every** dependabot PR. Dependabot runs workflows with a restricted token where `secrets.*` resolve to empty:

- `secret-scanning.yml` → `secrets.SECRETS_ALERTS` empty → `401 Unauthorized`
- `docker.yml` Docker Scout → `secrets.DOCKER_SCOUT_*` / `PR_COMMENTER` empty → `Parameter token or opts.auth is required`

Both steps were already skipped for **fork** PRs via `head.repo.full_name == github.repository`, but dependabot branches live in this repo, so that guard passes and the steps run without secrets.

## Fix

Extend the existing fork guard to also exclude the `dependabot[bot]` actor on the secret-dependent steps:

- `check-secrets` step skips → job green.
- docker: login + push + Scout skip; the image still **builds** (amd64+arm64, `push: false`) so the Dockerfile is still validated → job green.

Full secret-scanning and Scout coverage still runs on push to `develop`.

Result: dependabot PRs go green on required checks without an admin bypass.