### PR TITLE
fix: stats leak degrading long-lived live streams

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Manifest: environment variable expansion in `imports` and `protobuf.importPaths` now errors out when a referenced variable is undefined, instead of silently substituting an empty string.
+
+### Fixed
+
+- Server: fixed a per-request stats leak causing long-lived live streams to progressively burn more CPU per block and eventually fall behind the chain until reconnect.
+
 ## v1.20.1
 
 ### Fixed

--- a/pipeline/exec/module_executor.go
+++ b/pipeline/exec/module_executor.go
@@ -106,7 +106,9 @@ func RunModule(ctx context.Context, executor ModuleExecutor, execOutput execout.
 		return moduleOutput, outputBytes, nil, false, skippableOutput, nil
 	}
 
-	uid := reqctx.ReqStats(ctx).RecordModuleWasmBlockBegin(modName)
+	stats := reqctx.ReqStats(ctx)
+	uid := stats.RecordModuleWasmBlockBegin(modName)
+	defer stats.RecordModuleWasmBlockEnd(modName, uid)
 
 	outputBytes, outputForFiles, moduleOutput, err := executor.run(ctx, execOutput, cachable)
 	switch {
@@ -126,8 +128,6 @@ func RunModule(ctx context.Context, executor ModuleExecutor, execOutput execout.
 	case err != nil:
 		return nil, nil, nil, false, skippableOutput, fmt.Errorf("execute: %w", err)
 	}
-
-	reqctx.ReqStats(ctx).RecordModuleWasmBlockEnd(modName, uid)
 
 	fillModuleOutputMetadata(executor, moduleOutput)
 


### PR DESCRIPTION
## Problem

Long-lived tier1 live streams degrade over the life of a single connection: tier1 CPU climbs steadily from the moment the stream connects, and once the per-block serial path exceeds the chain's block interval the client starts drifting and never recovers until it reconnects Reconnecting instantly resets CPU to baseline. 
Affects any spkg with modules that skip blocks (`ErrNoInput`), on any chain — the more skipping modules and the faster the chain, the sooner it bites. 


## Root cause

`RunModule` records a wasm-execution `Begin` stats entry, but the `ErrNoInput` early return (module skipped because all its inputs are empty — every block, for modules whose upstream produces no data on that block) returns without the matching `End`. Each skip leaks one entry in the per-module `inprocessSince` map, millions per day on a fast chain with several such modules.

`updateDurations()` iterates **all** of those entries (a `time.Since` per entry) under the stats lock, and it runs on every progress message, serially in the block-processing path (`handleStepNew` → deferred `returnRPCModuleProgressOutputs` → `AggregatedModulesStats`). Per-block cost therefore grows linearly with connection age.

## Fix

Pair `RecordModuleWasmBlockEnd` with `Begin` on every `RunModule` return path (defer), so skipped/errored executions no longer leak.

## Results

Blue - fixed tier1 deployment, CPU stays flat

<img width="1263" height="393" alt="image" src="https://github.com/user-attachments/assets/219aaacb-0e03-4b9c-a179-1157eb18e36e" />


🤖 Generated with the help of [Claude Code](https://claude.com/claude-code)
