### PR TITLE
Suppress tier2 TLS handshake noise from plain-HTTP probes

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Server: tier2 no longer logs `tls: first record does not look like a TLS handshake` errors from plain-HTTP health probes / load balancers hitting a TLS port (same suppress list as the existing EOF and connection-reset handshake noise).
+
 ## 1.20.3
 
 ### Added

--- a/service/server.go
+++ b/service/server.go
@@ -151,10 +151,12 @@ func ListenTier2(
 			grpc.StatsHandler(otelgrpc.NewServerHandler(otelgrpc.WithTracerProvider(tracerProvider))),
 			grpc.MaxRecvMsgSize(1024*1024*1024),
 		),
-		// we get these errors when the tier1's dns loadbalancer selector checks availability, we want to ignore them.
+		// Health probes / LB selectors often open TCP and speak plain HTTP (or drop mid-handshake)
+		// against a TLS port; Go's http.Server logs those as ERROR. Suppress the known-benign ones.
 		dgrpcserver.WithSuppressHTTPError(
 			regexp.MustCompile(`TLS handshake error.*EOF`),
 			regexp.MustCompile(`TLS handshake error.*connection reset by peer`),
+			regexp.MustCompile(`TLS handshake error.*first record does not look like a TLS handshake`),
 		),
 	}
 	if enforceCompression {


### PR DESCRIPTION
## Summary

- Load balancers and health probes often speak plain HTTP to tier2's TLS port, producing noisy `tls: first record does not look like a TLS handshake` ERROR logs.
- Tier2 already suppressed related handshake noise (`EOF`, `connection reset by peer`); this adds the missing "first record does not look like a TLS handshake" pattern via the existing `WithSuppressHTTPError` list.
- Changelog entry under Unreleased.

## Test plan

- [ ] Deploy/restart a tier2 with TLS listen (or reproduce with plain HTTP against the TLS port)
- [ ] Confirm the `first record does not look like a TLS handshake` lines no longer appear at ERROR
- [ ] Confirm real client TLS/gRPC traffic is unaffected
- [ ] Optionally verify EOF / connection-reset suppress patterns still work as before