### PR TITLE
fix(sink,tui): restore session init callback, trace ID was never shown

### DIFF
--- a/cmd/substreams/estimate.go
+++ b/cmd/substreams/estimate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/streamingfast/cli/sflags"
 	"github.com/streamingfast/logging"
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreamsrpcv3 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v3"
 	"github.com/streamingfast/substreams/pipeline/exec"
 	"github.com/streamingfast/substreams/sink"
 	"go.uber.org/zap"
@@ -657,7 +658,7 @@ func runSegment(ctx context.Context, segment ChainSegment, baseConfig *sink.Sink
 		func(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *sink.Cursor) error {
 			return nil
 		},
-		func(ctx context.Context, req *pbsubstreamsrpc.Request, session *pbsubstreamsrpc.SessionInit) error {
+		func(ctx context.Context, req *pbsubstreamsrpcv3.Request, session *pbsubstreamsrpc.SessionInit) error {
 			zlog.Info("started segment",
 				zap.Reflect("session", session),
 				zap.Uint64("sampled_start_block", segment.SampledStartBlock),

--- a/cmd/substreams/run.go
+++ b/cmd/substreams/run.go
@@ -150,7 +150,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		ui.HandleProgress,
 		ui.HandleDebugSnapshotData,
 		ui.HandleDebugSnapshotComplete,
-		nil,
+		ui.HandleError,
 	)
 	ctx, cancelCause := context.WithCancelCause(ctx)
 	go func() {

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,6 +9,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Sink: **Breaking** the `handleSessionInit` callback passed to `sink.NewSinkerFullHandlers` and `sink.NewSinkerFullHandlersWithPartial` now receives a `*pbsubstreamsrpcv3.Request` instead of a `*pbsubstreamsrpc.Request` (`rpc/v2`), matching both the `SinkerSessionInitHandler` interface and the request the sinker actually sends. The two disagreed, so the sinker's type assertion never matched and the callback was never invoked — no behavior can depend on it today.
+
+  Callers passing `nil` are unaffected. Callers passing a callback get a compile error and should switch the parameter type; the only field that moved is `req.Modules`, now reachable as `req.Package.Modules`. Callers implementing `SinkerSessionInitHandler` directly on their own handler type were already writing the `rpc/v3` signature and are unaffected.
+
+- Sink: **Breaking** the `handleError` callback passed to `sink.NewSinkerFullHandlers` and `sink.NewSinkerFullHandlersWithPartial` now receives an `error` instead of a `*pbsubstreamsrpc.Error`, matching the `SinkerErrorHandler` interface. Same as above, the callback was never invoked before this fix. It is called for stream errors the sinker is about to retry, not on `io.EOF` nor on fatal errors.
+
+### Fixed
+
+- CLI: `substreams run` in TUI output mode was stuck on `Connecting...` and never displayed the trace ID. The session-init callback signature had drifted from the `SinkerSessionInitHandler` interface, so the sinker's type assertion failed and the session never reached the UI at all. The per-stage progress section (stage modules, completed ranges and the `m` bar mode) was hidden by the same bug and is displayed again.
+
+- CLI: `substreams run` with a non-TUI output mode (`--output json`, `jsonl`, ...) was not printing the `TraceID:`, `Server HEAD block:` and stage/blocks-to-process summary lines anymore, for the same reason as above.
+
+- CLI: `substreams run` in TUI output mode kept advertising `Connected` with a stale trace ID while the sinker was retrying a severed stream. It now falls back to `Connecting...` and picks up the new trace ID of the re-established session.
+
 ## 1.20.3
 
 ### Added

--- a/sink/types.go
+++ b/sink/types.go
@@ -18,12 +18,23 @@ type sinkerHandlers struct {
 
 type fullSinkerHandlers struct {
 	sinkerHandlers
-	handleSessionInit             func(ctx context.Context, req *pbsubstreamsrpc.Request, session *pbsubstreamsrpc.SessionInit) error
+	handleSessionInit             func(ctx context.Context, req *pbsubstreamsrpcv3.Request, session *pbsubstreamsrpc.SessionInit) error
 	handleProgress                func(ctx context.Context, progress *pbsubstreamsrpc.ModulesProgress)
 	handleInitialSnapshotData     func(ctx context.Context, debug *pbsubstreamsrpc.InitialSnapshotData) error
 	handleInitialSnapshotComplete func(ctx context.Context, debug *pbsubstreamsrpc.InitialSnapshotComplete) error
-	handleError                   func(ctx context.Context, error *pbsubstreamsrpc.Error)
+	handleError                   func(ctx context.Context, err error)
 }
+
+// The optional handler interfaces are reached through a type assertion on the [SinkerHandler]
+// value, so a signature that drifts away from the interface silently turns the corresponding
+// callback into dead code instead of failing to compile.
+var (
+	_ SinkerHandler            = (*fullSinkerHandlers)(nil)
+	_ SinkerProgressHandler    = (*fullSinkerHandlers)(nil)
+	_ SinkerSessionInitHandler = (*fullSinkerHandlers)(nil)
+	_ SinkerErrorHandler       = (*fullSinkerHandlers)(nil)
+	_ SinkerSnapshotHandler    = (*fullSinkerHandlers)(nil)
+)
 
 var ErrHandlerNotImplemented = errors.New("handler not implemented")
 
@@ -41,13 +52,13 @@ func (h fullSinkerHandlers) HandleProgress(ctx context.Context, progress *pbsubs
 	}
 }
 
-func (h fullSinkerHandlers) HandleError(ctx context.Context, error *pbsubstreamsrpc.Error) {
+func (h fullSinkerHandlers) HandleError(ctx context.Context, err error) {
 	if h.handleError != nil {
-		h.handleError(ctx, error)
+		h.handleError(ctx, err)
 	}
 }
 
-func (h fullSinkerHandlers) HandleSessionInit(ctx context.Context, req *pbsubstreamsrpc.Request, sessionInit *pbsubstreamsrpc.SessionInit) error {
+func (h fullSinkerHandlers) HandleSessionInit(ctx context.Context, req *pbsubstreamsrpcv3.Request, sessionInit *pbsubstreamsrpc.SessionInit) error {
 	if h.handleSessionInit != nil {
 		return h.handleSessionInit(ctx, req, sessionInit)
 	}
@@ -83,11 +94,11 @@ func NewSinkerHandlers(
 func NewSinkerFullHandlers(
 	handleBlockScopedData func(ctx context.Context, data *pbsubstreamsrpc.BlockScopedData, isLive *bool, cursor *Cursor) error,
 	handleBlockUndoSignal func(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *Cursor) error,
-	handleSessionInit func(ctx context.Context, req *pbsubstreamsrpc.Request, session *pbsubstreamsrpc.SessionInit) error,
+	handleSessionInit func(ctx context.Context, req *pbsubstreamsrpcv3.Request, session *pbsubstreamsrpc.SessionInit) error,
 	handleProgress func(ctx context.Context, progress *pbsubstreamsrpc.ModulesProgress),
 	handleInitialSnapshotData func(ctx context.Context, debug *pbsubstreamsrpc.InitialSnapshotData) error,
 	handleInitialSnapshotComplete func(ctx context.Context, complete *pbsubstreamsrpc.InitialSnapshotComplete) error,
-	handleError func(ctx context.Context, error *pbsubstreamsrpc.Error),
+	handleError func(ctx context.Context, err error),
 ) SinkerHandler {
 	return &fullSinkerHandlers{
 		sinkerHandlers: sinkerHandlers{
@@ -106,11 +117,11 @@ func NewSinkerFullHandlers(
 func NewSinkerFullHandlersWithPartial(
 	handleBlockScopedData func(ctx context.Context, data *pbsubstreamsrpc.BlockScopedData, isLive *bool, cursor *Cursor) error,
 	handleBlockUndoSignal func(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *Cursor) error,
-	handleSessionInit func(ctx context.Context, req *pbsubstreamsrpc.Request, session *pbsubstreamsrpc.SessionInit) error,
+	handleSessionInit func(ctx context.Context, req *pbsubstreamsrpcv3.Request, session *pbsubstreamsrpc.SessionInit) error,
 	handleProgress func(ctx context.Context, progress *pbsubstreamsrpc.ModulesProgress),
 	handleInitialSnapshotData func(ctx context.Context, debug *pbsubstreamsrpc.InitialSnapshotData) error,
 	handleInitialSnapshotComplete func(ctx context.Context, complete *pbsubstreamsrpc.InitialSnapshotComplete) error,
-	handleError func(ctx context.Context, error *pbsubstreamsrpc.Error),
+	handleError func(ctx context.Context, err error),
 ) SinkerHandler {
 	return &fullSinkerHandlers{
 		sinkerHandlers: sinkerHandlers{
@@ -200,7 +211,12 @@ type SinkerErrorHandler interface {
 	//
 	// The handler receives the following arguments:
 	// - `ctx` is the context runtime, your handler should be minimal, so normally you shouldn't use this.
-	// - `error` is simply the error received from the Substreams API.
+	// - `err` is simply the error received from the Substreams API.
+	//
+	// It is called only for errors that the [Sinker] is about to retry, the stream is severed at that
+	// point and a new one, with a new session and a new trace ID, is established. Reaching the stop block
+	// (`io.EOF`) and fatal errors (invalid request, authentication failure, quota exceeded) do not go
+	// through this callback.
 	//
 	// The [HandleError] is optional and can be nil.
 	HandleError(ctx context.Context, err error)

--- a/sink/types_test.go
+++ b/sink/types_test.go
@@ -1,0 +1,80 @@
+package sink
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreamsrpcv3 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v3"
+)
+
+// The sinker reaches the optional callbacks through a type assertion on the `SinkerHandler` value,
+// so a handler whose signature drifted from the interface is silently never called. Assert on the
+// value actually returned by the constructors, the compile-time assertions in types.go only cover
+// the concrete type.
+func TestNewSinkerFullHandlers_SatisfiesOptionalInterfaces(t *testing.T) {
+	noopData := func(ctx context.Context, data *pbsubstreamsrpc.BlockScopedData, isLive *bool, cursor *Cursor) error {
+		return nil
+	}
+	noopUndo := func(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *Cursor) error {
+		return nil
+	}
+
+	for name, handler := range map[string]SinkerHandler{
+		"NewSinkerFullHandlers":            NewSinkerFullHandlers(noopData, noopUndo, nil, nil, nil, nil, nil),
+		"NewSinkerFullHandlersWithPartial": NewSinkerFullHandlersWithPartial(noopData, noopUndo, nil, nil, nil, nil, nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, ok := handler.(SinkerSessionInitHandler)
+			assert.True(t, ok, "must implement SinkerSessionInitHandler, otherwise the session (and its trace ID) never reaches the caller")
+
+			_, ok = handler.(SinkerErrorHandler)
+			assert.True(t, ok, "must implement SinkerErrorHandler, otherwise retried stream errors never reach the caller")
+
+			_, ok = handler.(SinkerProgressHandler)
+			assert.True(t, ok, "must implement SinkerProgressHandler")
+
+			_, ok = handler.(SinkerSnapshotHandler)
+			assert.True(t, ok, "must implement SinkerSnapshotHandler")
+		})
+	}
+}
+
+// The callbacks must effectively be forwarded, not just declared with the right signature.
+func TestFullSinkerHandlers_ForwardsSessionInitAndError(t *testing.T) {
+	var gotSession *pbsubstreamsrpc.SessionInit
+	var gotErr error
+
+	handler := NewSinkerFullHandlers(
+		func(ctx context.Context, data *pbsubstreamsrpc.BlockScopedData, isLive *bool, cursor *Cursor) error {
+			return nil
+		},
+		func(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *Cursor) error {
+			return nil
+		},
+		func(ctx context.Context, req *pbsubstreamsrpcv3.Request, session *pbsubstreamsrpc.SessionInit) error {
+			gotSession = session
+			return nil
+		},
+		nil,
+		nil,
+		nil,
+		func(ctx context.Context, err error) {
+			gotErr = err
+		},
+	)
+
+	session := &pbsubstreamsrpc.SessionInit{TraceId: "0123456789abcdef"}
+
+	sessionHandler, ok := handler.(SinkerSessionInitHandler)
+	assert.True(t, ok)
+	assert.NoError(t, sessionHandler.HandleSessionInit(context.Background(), &pbsubstreamsrpcv3.Request{}, session))
+	assert.Same(t, session, gotSession)
+
+	errHandler, ok := handler.(SinkerErrorHandler)
+	assert.True(t, ok)
+	errHandler.HandleError(context.Background(), assert.AnError)
+	assert.Same(t, assert.AnError, gotErr)
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/streamingfast/shutter"
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreamsrpcv3 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v3"
 	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 )
 
@@ -216,7 +217,7 @@ func (ui *TUI) HandleDebugSnapshotComplete(ctx context.Context, complete *pbsubs
 	return nil
 }
 
-func (ui *TUI) HandleSession(ctx context.Context, req *pbsubstreamsrpc.Request, session *pbsubstreamsrpc.SessionInit) error {
+func (ui *TUI) HandleSession(ctx context.Context, req *pbsubstreamsrpcv3.Request, session *pbsubstreamsrpc.SessionInit) error {
 	if session.BlocksToProcessAfterStartBlock != 0 {
 		ui.RequiredProcessedBlocks = session.EffectiveBlocksToProcessBeforeStartBlock + session.EffectiveBlocksToProcessAfterStartBlock
 	}
@@ -226,7 +227,7 @@ func (ui *TUI) HandleSession(ctx context.Context, req *pbsubstreamsrpc.Request, 
 		ui.ensureTerminalLocked()
 		ui.prog.Send(session)
 	} else {
-		execGraph, err := exec.NewOutputModuleGraph(req.OutputModule, req.ProductionMode, req.Modules, bstream.GetProtocolFirstStreamableBlock)
+		execGraph, err := exec.NewOutputModuleGraph(req.OutputModule, req.ProductionMode, req.Package.GetModules(), bstream.GetProtocolFirstStreamableBlock)
 		if err != nil {
 			return fmt.Errorf("cannot handle module graph: %w", err)
 		}
@@ -255,6 +256,18 @@ func (ui *TUI) HandleSession(ctx context.Context, req *pbsubstreamsrpc.Request, 
 		}
 	}
 	return nil
+}
+
+// HandleError is called by the sinker when the stream is severed and about to be retried. The
+// session that follows carries a brand new trace ID, so the UI must stop advertising the previous
+// one until we are effectively re-connected.
+func (ui *TUI) HandleError(ctx context.Context, err error) {
+	_ = ctx
+	_ = err
+
+	if ui.outputMode == OutputModeTUI {
+		ui.Connecting()
+	}
 }
 
 func (ui *TUI) ensureTerminalUnlocked() {

--- a/tui/updates.go
+++ b/tui/updates.go
@@ -17,7 +17,10 @@ func (m model) Init() tea.Cmd { return nil }
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg {
 	case Connecting:
+		// Can be received again after the initial connection when the sinker retries a severed
+		// stream, the trace ID of the previous session does not apply anymore.
 		m.Connected = false
+		m.TraceID = ""
 	case Connected:
 		m.Connected = true
 	}
@@ -53,9 +56,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.BackprocessingCompleteAtBlock = uint64(m.Request.StartBlockNum)
 		}
 		return m, nil
-	case *pbsubstreamsrpc.Response_Session:
-		m.TraceID = msg.Session.TraceId
-		m.BackprocessingCompleteAtBlock = msg.Session.ResolvedStartBlock
+	case *pbsubstreamsrpc.SessionInit:
+		// Receiving the session init message means the connection to the server is
+		// established, the trace ID is only known at that point.
+		m.Connected = true
+		m.TraceID = msg.TraceId
+		m.BackprocessingCompleteAtBlock = msg.ResolvedStartBlock
 
 	case *pbsubstreamsrpc.ModulesProgress:
 		m.Updates += 1

--- a/tui/updates_test.go
+++ b/tui/updates_test.go
@@ -1,0 +1,88 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+)
+
+func TestModelUpdate_SessionInit(t *testing.T) {
+	m := model{StagesProgress: updatedRanges{}}
+
+	// The `SessionInit` message is sent as-is through `tea.Program.Send`, it must be
+	// handled by the model, otherwise the trace ID is never displayed.
+	out, _ := m.Update(&pbsubstreamsrpc.SessionInit{
+		TraceId:            "0123456789abcdef",
+		ResolvedStartBlock: 1000,
+	})
+
+	updated, ok := out.(model)
+	require.True(t, ok)
+
+	assert.True(t, updated.Connected)
+	assert.Equal(t, "0123456789abcdef", updated.TraceID)
+	assert.Equal(t, uint64(1000), updated.BackprocessingCompleteAtBlock)
+
+	assert.True(t, strings.Contains(updated.View(), "Connected (trace ID 0123456789abcdef)"), "view should show the trace ID, got:\n%s", updated.View())
+}
+
+func TestModelUpdate_ReconnectRefreshesTraceID(t *testing.T) {
+	m := model{StagesProgress: updatedRanges{}}
+
+	out, _ := m.Update(&pbsubstreamsrpc.SessionInit{TraceId: "first"})
+	require.True(t, out.(model).Connected)
+
+	// The sinker severed the stream and is about to retry, the previous trace ID is stale.
+	out, _ = out.(model).Update(Connecting)
+	assert.False(t, out.(model).Connected)
+	assert.Empty(t, out.(model).TraceID)
+	assert.True(t, strings.Contains(out.(model).View(), "Connecting..."))
+
+	out, _ = out.(model).Update(&pbsubstreamsrpc.SessionInit{TraceId: "second"})
+	assert.True(t, out.(model).Connected)
+	assert.Equal(t, "second", out.(model).TraceID)
+	assert.True(t, strings.Contains(out.(model).View(), "Connected (trace ID second)"))
+}
+
+// Rendering the connected view enables the stage progress section, and with it the bar
+// mode, which was never reached before. Make sure neither can blow up the UI.
+func TestModelView_ConnectedBarModeEdgeCases(t *testing.T) {
+	progress := &pbsubstreamsrpc.ModulesProgress{
+		Stages: []*pbsubstreamsrpc.Stage{
+			{
+				Modules:         []string{"map_token_balances"},
+				CompletedRanges: []*pbsubstreamsrpc.BlockRange{{StartBlock: 25000000, EndBlock: 25652000}},
+			},
+		},
+		RunningJobs: []*pbsubstreamsrpc.Job{
+			{Stage: 0, StartBlock: 25652000, StopBlock: 25653000, DurationMs: 68000},
+		},
+	}
+
+	cases := []struct {
+		name               string
+		barSize            uint64
+		resolvedStartBlock uint64
+	}{
+		{"no window size message received yet", 0, 25652000},
+		{"completed ranges past the backprocessing target", 40, 24000000},
+		{"nominal", 40, 25652000},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := model{StagesProgress: updatedRanges{}, BarSize: c.barSize, BarMode: true}
+
+			out, _ := m.Update(&pbsubstreamsrpc.SessionInit{TraceId: "abc", ResolvedStartBlock: c.resolvedStartBlock})
+			out, _ = out.(model).Update(progress)
+
+			view := out.(model).View()
+			assert.True(t, strings.Contains(view, "Connected (trace ID abc)"), "got:\n%s", view)
+			assert.False(t, strings.Contains(view, "failed rendering template"), "got:\n%s", view)
+		})
+	}
+}

--- a/tui/view.go
+++ b/tui/view.go
@@ -42,9 +42,17 @@ var tpl = template.Must(template.New("main_view.txt.gotmpl").Funcs(template.Func
 func barmode(in ranges, backprocessingCompleteAtBlock, width uint64) string {
 	lo := in.Lo()
 	hi := backprocessingCompleteAtBlock
+
+	// The width is 0 until the first `tea.WindowSizeMsg` is received and the completed
+	// ranges can sit past the backprocessing target, both would make the bin computation
+	// below divide by zero or underflow.
+	if width == 0 || hi <= lo {
+		return ""
+	}
+
 	binsize := (hi - lo) / width
 	var out []string
-	for i := uint64(0); i < width; i++ {
+	for i := range width {
 		loCheck := binsize*i + lo
 		hiCheck := binsize*(i+1) + lo
 


### PR DESCRIPTION
## Problem

`substreams run` never displayed the Trace ID while backprocessing, sitting on `Connecting...` indefinitely:

```
Connecting...

  Longest-running jobs:
    [Stage: 0, Range: 25652000-25653000, Duration: 68s]
```

## Root cause

Commit 7908100c ("Feature/request v3", #690, first released in **v1.17.0**, 2025-10-21) touched `sink/types.go` in two hunks only: it added the v3 import and retyped the interface method.

```diff
-	HandleSessionInit(ctx context.Context, req *pbsubstreamsrpc.Request, ...)
+	HandleSessionInit(ctx context.Context, req *pbsubstreamsrpcv3.Request, ...)
```

The `fullSinkerHandlers` struct field, its `HandleSessionInit` method and both `NewSinkerFullHandlers*` constructor signatures were left on `rpc/v2` in that same file. The concrete type stopped satisfying its own interface, so the sinker's `handler.(SinkerSessionInitHandler)` assertion silently stopped matching and **the session callback has never been invoked since**. It compiled cleanly the whole time because nothing asserted the two agreed.

Two consequences, one cause:

- **TUI mode** — the template gates the trace ID line and the whole per-stage progress section on `.Connected`; the `Longest-running jobs` block sits *outside* that gate, which is exactly why the reported output showed running jobs under a `Connecting...` header.
- **Non-TUI modes** (`--output json`, `jsonl`, ...) — the `TraceID:`, `Server HEAD block:` and blocks-to-process summary lines silently stopped printing.

A **second, independent bug** sat behind the first: the bubbletea model matched `*rpc.Response_Session` while the UI sends a `*rpc.SessionInit`. Even a firing callback would not have updated the view. Both had to go.

## Changes

- **Align the session-init chain on v3.** The interface is where the API deliberately moved; the constructors are the half left behind. The only field that moved is `req.Modules` → `req.Package.Modules`.
- **Fix the model's message type** so the session actually reaches the view.
- **Fix `SinkerErrorHandler`**, dead for the identical reason (`*rpc.Error` vs `error`). Wired into the TUI so a retried stream falls back to `Connecting...` and picks up the new trace ID, instead of advertising a stale one.
- **Compile-time interface assertions** on `fullSinkerHandlers` for all five optional interfaces. These hooks are reached by type assertion, so signature drift turns them into dead code with no compiler complaint — this is what surfaced the session-init bug within seconds of being added.
- **Guard `barmode` against a divide by zero.** Bar mode (`m`) was unreachable while the connected view never rendered; `BarSize` is 0 until the first `tea.WindowSizeMsg`, so pressing `m` in that window collapsed the entire view into a template error.

## Breaking change

`handleSessionInit` and `handleError` passed to `NewSinkerFullHandlers` / `NewSinkerFullHandlersWithPartial` change type.

Callers passing `nil` are unaffected. Callers passing a callback get a compile error pointing at the exact line — and have had a **silently dead callback since v1.17.0**, so no behavior can depend on it today. Callers implementing `SinkerSessionInitHandler` directly on their own type already wrote the v3 signature and are unaffected; moving the interface back to v2 instead would have broken *those* consumers silently, which is why the fix goes this direction.

I could not verify how the external sinks (`substreams-sink-sql`, `-kv`, `-files`, ...) call these constructors — separate repos. The compile error will surface it at their next bump.

## Verification

`go build ./...` and the full `go test ./...` suite pass. Each fix has a test that was confirmed to fail without it:

- `TestModelUpdate_SessionInit` — reproduces the exact stuck-on-`Connecting...` output.
- `TestModelUpdate_ReconnectRefreshesTraceID` — stale trace ID across a retry.
- `TestModelView_ConnectedBarModeEdgeCases` — confirmed `integer divide by zero` without the guard.
- `TestNewSinkerFullHandlers_SatisfiesOptionalInterfaces` / `TestFullSinkerHandlers_ForwardsSessionInitAndError` — asserts on what the constructors actually return, since the compile-time assertions only cover the concrete type.