### PR TITLE
Warn and count undo signals sent to clients

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Server: new `substreams_undo_signal_counter` prometheus metric, counting the `BlockUndoSignal` messages sent to clients, labeled by `source` (`reorg` when a fork is seen while streaming, `cursor_resolution` when the cursor of an incoming request points to a block that was reorged out). Undo signals reverting more than 5 blocks are also logged as a warning with `trace_id`, `head`, `revert_up_to`, `distance` and, on the `cursor_resolution` path, the client `cursor`.
+- Server: new `substreams_undo_signal_distance_blocks` prometheus histogram, observing how many blocks each `BlockUndoSignal` sent to clients reverts, labeled by `source` (`reorg` when a fork is seen while streaming, `cursor_resolution` when the cursor of an incoming request points to a block that was reorged out). Its `_count` gives the total number of undo signals sent; subtracting the `le="5"` bucket from it gives the number of large ones. Undo signals reverting more than 5 blocks are also logged as a warning with `trace_id`, `head`, `revert_up_to`, `distance` and, on the `cursor_resolution` path, the client `cursor`.
 
 ### Changed
 

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- Server: new `substreams_undo_signal_counter` prometheus metric, counting the `BlockUndoSignal` messages sent to clients, labeled by `source` (`reorg` when a fork is seen while streaming, `cursor_resolution` when the cursor of an incoming request points to a block that was reorged out). Undo signals reverting more than 5 blocks are also logged as a warning with `trace_id`, `head`, `revert_up_to`, `distance` and, on the `cursor_resolution` path, the client `cursor`.
+
 ### Changed
 
 - Sink: **Breaking** the `handleSessionInit` callback passed to `sink.NewSinkerFullHandlers` and `sink.NewSinkerFullHandlersWithPartial` now receives a `*pbsubstreamsrpcv3.Request` instead of a `*pbsubstreamsrpc.Request` (`rpc/v2`), matching both the `SinkerSessionInitHandler` interface and the request the sinker actually sends. The two disagreed, so the sinker's type assertion never matched and the callback was never invoked — no behavior can depend on it today.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -37,6 +37,11 @@ var BlockEndProcess = MetricSet.NewCounter("substreams_block_process_end_counter
 var ExecutedWasmModules = MetricSet.NewCounter("substreams_executed_wasm_modules", "Counter for total WASM executions for each module on each block")
 var SkippedCachedWasmModules = MetricSet.NewCounter("substreams_skipped_cached_wasm_modules", "Counter for total WASM skipped executions for each module on each block due to the shared cache")
 
+// UndoSignalCounter counts the BlockUndoSignal messages sent to clients, by source:
+// "reorg" when a fork is detected while streaming, "cursor_resolution" when the cursor
+// of an incoming request points to a block that is no longer part of the canonical chain.
+var UndoSignalCounter = MetricSet.NewCounterVec("substreams_undo_signal_counter", []string{"source"}, "Counter for undo signals sent to clients, by source")
+
 var Tier1OutputHeadBlockRelativeTime *dmetrics.HeadBlockRelativeTime
 
 // Store backend metrics

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -37,10 +37,17 @@ var BlockEndProcess = MetricSet.NewCounter("substreams_block_process_end_counter
 var ExecutedWasmModules = MetricSet.NewCounter("substreams_executed_wasm_modules", "Counter for total WASM executions for each module on each block")
 var SkippedCachedWasmModules = MetricSet.NewCounter("substreams_skipped_cached_wasm_modules", "Counter for total WASM skipped executions for each module on each block due to the shared cache")
 
-// UndoSignalCounter counts the BlockUndoSignal messages sent to clients, by source:
+// UndoSignalDistance observes how many blocks each BlockUndoSignal sent to clients reverts, by source:
 // "reorg" when a fork is detected while streaming, "cursor_resolution" when the cursor
 // of an incoming request points to a block that is no longer part of the canonical chain.
-var UndoSignalCounter = MetricSet.NewCounterVec("substreams_undo_signal_counter", []string{"source"}, "Counter for undo signals sent to clients, by source")
+// The '_count' gives the total number of undo signals sent, subtracting the 'le="5"' bucket
+// from it gives the number of undo signals reverting more than 5 blocks.
+var UndoSignalDistance = MetricSet.NewHistogramVecCustomBuckets(
+	"substreams_undo_signal_distance_blocks",
+	[]string{"source"},
+	[]float64{1, 2, 5, 10, 25, 100},
+	"Distribution of the number of blocks reverted by the undo signals sent to clients, by source",
+)
 
 var Tier1OutputHeadBlockRelativeTime *dmetrics.HeadBlockRelativeTime
 

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -251,13 +251,17 @@ func (p *Pipeline) undoPartialStates() error {
 // undoWarnThreshold is the number of reverted blocks above which an undo signal is logged as a warning.
 const undoWarnThreshold = 5
 
-// reportUndoSignal counts an undo signal sent to the user and warns when it reverts more than
-// 'undoWarnThreshold' blocks. The 'requestCursor' is only set when the undo signal is caused by
-// the cursor of an incoming request pointing to a block that was reorged out.
+// reportUndoSignal observes the distance of an undo signal sent to the user and warns when it
+// reverts more than 'undoWarnThreshold' blocks. The 'requestCursor' is only set when the undo
+// signal is caused by the cursor of an incoming request pointing to a block that was reorged out.
 func reportUndoSignal(ctx context.Context, source string, headBlockNum, lastValidBlockNum uint64, requestCursor string) {
-	metrics.UndoSignalCounter.Inc(source)
+	var distance uint64
+	if headBlockNum > lastValidBlockNum {
+		distance = headBlockNum - lastValidBlockNum
+	}
+	metrics.UndoSignalDistance.ObserveFloat64(float64(distance), source)
 
-	if headBlockNum <= lastValidBlockNum+undoWarnThreshold {
+	if distance <= undoWarnThreshold {
 		return
 	}
 
@@ -266,7 +270,7 @@ func reportUndoSignal(ctx context.Context, source string, headBlockNum, lastVali
 		zap.String("source", source),
 		zap.Uint64("head", headBlockNum),
 		zap.Uint64("revert_up_to", lastValidBlockNum),
-		zap.Uint64("distance", headBlockNum-lastValidBlockNum),
+		zap.Uint64("distance", distance),
 	}
 	if requestCursor != "" {
 		fields = append(fields, zap.String("cursor", requestCursor))

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -251,6 +251,8 @@ func (p *Pipeline) undoPartialStates() error {
 // undoWarnThreshold is the number of reverted blocks above which an undo signal is logged as a warning.
 const undoWarnThreshold = 5
 
+var undoWarnMessage = fmt.Sprintf("sending undo signal reverting more than %d blocks", undoWarnThreshold)
+
 // reportUndoSignal observes the distance of an undo signal sent to the user and warns when it
 // reverts more than 'undoWarnThreshold' blocks. The 'requestCursor' is only set when the undo
 // signal is caused by the cursor of an incoming request pointing to a block that was reorged out.
@@ -276,7 +278,7 @@ func reportUndoSignal(ctx context.Context, source string, headBlockNum, lastVali
 		fields = append(fields, zap.String("cursor", requestCursor))
 	}
 
-	reqctx.Logger(ctx).Warn("sending undo signal reverting more than 5 blocks", fields...)
+	reqctx.Logger(ctx).Warn(undoWarnMessage, fields...)
 }
 
 // handleUndo reverts a block's outputs and sends an undo signal to the user.

--- a/pipeline/process_block.go
+++ b/pipeline/process_block.go
@@ -15,6 +15,7 @@ import (
 	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
 	"github.com/streamingfast/dmetering"
 	"github.com/streamingfast/logging"
+	tracing "github.com/streamingfast/sf-tracing"
 	"github.com/streamingfast/substreams/metering"
 	"github.com/streamingfast/substreams/metrics"
 	pbssinternal "github.com/streamingfast/substreams/pb/sf/substreams/intern/v2"
@@ -155,14 +156,14 @@ func (p *Pipeline) processBlock(
 	case bstream.StepUndoPartial:
 		if reqctx.PartialBlocks(ctx) {
 			p.blockStepMap[bstream.StepUndoPartial]++
-			if err := p.handleStepUndoPartial(cursor); err != nil {
+			if err := p.handleStepUndoPartial(ctx, cursor); err != nil {
 				return err
 			}
 		}
 
 	case bstream.StepUndo:
 		p.blockStepMap[bstream.StepUndo]++
-		if err := p.handleStepUndo(clock, cursor, reorgJunctionBlock); err != nil {
+		if err := p.handleStepUndo(ctx, clock, cursor, reorgJunctionBlock); err != nil {
 			return fmt.Errorf("step undo: %w", err)
 		}
 	case bstream.StepStalled:
@@ -247,8 +248,35 @@ func (p *Pipeline) undoPartialStates() error {
 	return nil
 }
 
+// undoWarnThreshold is the number of reverted blocks above which an undo signal is logged as a warning.
+const undoWarnThreshold = 5
+
+// reportUndoSignal counts an undo signal sent to the user and warns when it reverts more than
+// 'undoWarnThreshold' blocks. The 'requestCursor' is only set when the undo signal is caused by
+// the cursor of an incoming request pointing to a block that was reorged out.
+func reportUndoSignal(ctx context.Context, source string, headBlockNum, lastValidBlockNum uint64, requestCursor string) {
+	metrics.UndoSignalCounter.Inc(source)
+
+	if headBlockNum <= lastValidBlockNum+undoWarnThreshold {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("trace_id", tracing.GetTraceID(ctx).String()),
+		zap.String("source", source),
+		zap.Uint64("head", headBlockNum),
+		zap.Uint64("revert_up_to", lastValidBlockNum),
+		zap.Uint64("distance", headBlockNum-lastValidBlockNum),
+	}
+	if requestCursor != "" {
+		fields = append(fields, zap.String("cursor", requestCursor))
+	}
+
+	reqctx.Logger(ctx).Warn("sending undo signal reverting more than 5 blocks", fields...)
+}
+
 // handleUndo reverts a block's outputs and sends an undo signal to the user.
-func (p *Pipeline) handleUndo(clock *pbsubstreams.Clock, cursor *bstream.Cursor, reorgJunctionBlock bstream.BlockRef) error {
+func (p *Pipeline) handleUndo(ctx context.Context, clock *pbsubstreams.Clock, cursor *bstream.Cursor, reorgJunctionBlock bstream.BlockRef) error {
 	if err := p.forkHandler.handleUndo(clock); err != nil {
 		return fmt.Errorf("reverting outputs: %w", err)
 	}
@@ -269,6 +297,9 @@ func (p *Pipeline) handleUndo(clock *pbsubstreams.Clock, cursor *bstream.Cursor,
 
 	p.lastProcessedBlockRef = reorgJunctionBlock
 	p.lastCursor = targetCursor
+
+	reportUndoSignal(ctx, "reorg", clock.Number, reorgJunctionBlock.Num(), "")
+
 	return p.respFunc(
 		&pbsubstreamsrpc.Response{
 			Message: &pbsubstreamsrpc.Response_BlockUndoSignal{
@@ -282,7 +313,7 @@ func (p *Pipeline) handleUndo(clock *pbsubstreams.Clock, cursor *bstream.Cursor,
 
 // handleStepUndo handles a regular undo step: undoes any pending partial states,
 // then reverts the block and sends an undo signal to the user.
-func (p *Pipeline) handleStepUndo(clock *pbsubstreams.Clock, cursor *bstream.Cursor, reorgJunctionBlock bstream.BlockRef) error {
+func (p *Pipeline) handleStepUndo(ctx context.Context, clock *pbsubstreams.Clock, cursor *bstream.Cursor, reorgJunctionBlock bstream.BlockRef) error {
 
 	if p.previousLastPartialBlock != nil && p.previousLastPartialBlock.Num() > reorgJunctionBlock.Num() {
 		p.previousLastPartialBlock = nil // remove assumptions about an 'undone' previous partial block
@@ -290,12 +321,12 @@ func (p *Pipeline) handleStepUndo(clock *pbsubstreams.Clock, cursor *bstream.Cur
 	if err := p.undoPartialStates(); err != nil {
 		return err
 	}
-	return p.handleUndo(clock, cursor, reorgJunctionBlock)
+	return p.handleUndo(ctx, clock, cursor, reorgJunctionBlock)
 }
 
 // handleStepUndoPartial handles an undo specifically for partial blocks.
 // It undoes partial states and sends an undo signal to the user.
-func (p *Pipeline) handleStepUndoPartial(cursor *bstream.Cursor) error {
+func (p *Pipeline) handleStepUndoPartial(ctx context.Context, cursor *bstream.Cursor) error {
 	if p.partialProcessingState == nil {
 		return nil
 	}
@@ -318,7 +349,7 @@ func (p *Pipeline) handleStepUndoPartial(cursor *bstream.Cursor) error {
 		return err
 	}
 
-	return p.handleUndo(clock, targetCursor, reorgJunctionBlock)
+	return p.handleUndo(ctx, clock, targetCursor, reorgJunctionBlock)
 }
 
 func (p *Pipeline) handleStepFinal(clock *pbsubstreams.Clock) error {
@@ -346,7 +377,7 @@ func (p *Pipeline) handleStepPartial(ctx context.Context, clock *pbsubstreams.Cl
 			p.partialProcessingState.highestIndex = idx
 		} else {
 			reqctx.Logger(ctx).Warn("received partial after another non-last partial with different block numbers (without step_Undo) -- this should not happen unless you are running a chain with partial blocks AND skipped blocks", zap.Uint64("received", clock.Number), zap.Uint64("expected", p.partialProcessingState.num))
-			if err := p.handleStepUndoPartial(cursor); err != nil {
+			if err := p.handleStepUndoPartial(ctx, cursor); err != nil {
 				return err
 			}
 			// partialProcessingState is now nil, a new sequence starts below
@@ -373,7 +404,7 @@ func (p *Pipeline) handleStepPartial(ctx context.Context, clock *pbsubstreams.Cl
 		// it is a different version of the block (a reorg happening inside partial blocks).
 		// Undo the partials sent so far.
 		parentRef := p.partialProcessingState.previousBlockRef // same block number: same parent
-		if err := p.handleStepUndoPartial(cursor); err != nil {
+		if err := p.handleStepUndoPartial(ctx, cursor); err != nil {
 			return err
 		}
 		if !isLast {
@@ -583,7 +614,7 @@ func (p *Pipeline) handleStepNew(ctx context.Context, clock *pbsubstreams.Clock,
 			}
 			logger.Info("receiving new block with an active partial state, but previousLastPartialBlock is not the same as the current block. Undoing partial state",
 				zap.String("previous last partial", prevLastPartial), zap.Stringer("current new block", clock))
-			if err := p.handleStepUndoPartial(cursor); err != nil {
+			if err := p.handleStepUndoPartial(ctx, cursor); err != nil {
 				return fmt.Errorf("failed to undo partial states: %w", err)
 			}
 		}

--- a/pipeline/process_block_test.go
+++ b/pipeline/process_block_test.go
@@ -400,7 +400,7 @@ func TestHandleStepPartial(t *testing.T) {
 				case bstream.StepPartial, bstream.StepNewPartial: // we always have partial blocks active here
 					err = pipe.handleStepPartial(ctx, clock, testCursor(blk.blk, blk.step), execOutput, blk.blk.PreviousRef(), blk.blk.PartialIndex, blk.blk.LastPartial)
 				case bstream.StepUndo, bstream.StepUndoPartial:
-					err = pipe.handleStepUndo(clock, testCursor(blk.blk, blk.step), blk.junction)
+					err = pipe.handleStepUndo(ctx, clock, testCursor(blk.blk, blk.step), blk.junction)
 				}
 				require.NoError(t, err)
 			}

--- a/pipeline/resolve.go
+++ b/pipeline/resolve.go
@@ -205,6 +205,7 @@ func resolveStartBlockNum(ctx context.Context, req *pbsubstreamsrpc.Request, res
 	}
 
 	var undoSignal *pbsubstreamsrpc.BlockUndoSignal
+	requestBlockNum := cursor.Block.Num() // block the client was on, kept for reporting since 'cursor' may be replaced below
 
 	if cursor.Step == bstream.StepPartial && cursor.HeadBlock.Num() < cursor.Block.Num() {
 		// cursors with StepPartial hide the 'parent block' in the 'head block' field
@@ -231,6 +232,9 @@ func resolveStartBlockNum(ctx context.Context, req *pbsubstreamsrpc.Request, res
 
 	if cursor.IsOnFinalBlock() {
 		nextBlock := cursor.Block.Num() + 1
+		if undoSignal != nil {
+			reportUndoSignal(ctx, "cursor_resolution", requestBlockNum, undoSignal.LastValidBlock.Number, req.StartCursor)
+		}
 		return nextBlock, cursor.ToOpaque(), undoSignal, nil
 	}
 
@@ -268,6 +272,10 @@ func resolveStartBlockNum(ctx context.Context, req *pbsubstreamsrpc.Request, res
 		resolvedStartBlockNum = resolvedCursor.Block.Num() + 1
 	case resolvedCursor.Step.Matches(bstream.StepUndo):
 		resolvedStartBlockNum = resolvedCursor.Block.Num()
+	}
+
+	if undoSignal != nil {
+		reportUndoSignal(ctx, "cursor_resolution", requestBlockNum, undoSignal.LastValidBlock.Number, req.StartCursor)
 	}
 
 	return resolvedStartBlockNum, normalizedOpaqueCursor(*resolvedCursor), undoSignal, nil


### PR DESCRIPTION
## What

Undo signals sent to clients are currently invisible in both metrics and logs, so a service sending deep reverts (bad cursor resolution, long reorg) leaves no trace.

- New prometheus histogram `substreams_undo_signal_distance_blocks{source}`, observing how many blocks each `BlockUndoSignal` sent to clients reverts. Buckets: `1, 2, 5, 10, 25, 100`. `source` is `reorg` (fork seen while streaming) or `cursor_resolution` (the cursor of an incoming request points to a block that was reorged out).
- `zlog.Warn` when an undo reverts more than 5 blocks, with `trace_id`, `source`, `head`, `revert_up_to`, `distance`, and — only on the `cursor_resolution` path — the client `cursor`.

A histogram rather than a counter: it answers both "how many" and "how deep", and keeps the large-undo threshold out of the binary.

- total undo signals: `rate(substreams_undo_signal_distance_blocks_count[5m])`
- large ones (>5 blocks, matching the log threshold): `rate(..._count[5m]) - rate(..._bucket{le="5"}[5m])`
- depth: `histogram_quantile(0.99, ...)`

## Where

- `reportUndoSignal()` in `pipeline/process_block.go`, called from `handleUndo()` (covers `StepUndo` and `StepUndoPartial`) and from `resolveStartBlockNum()` in `pipeline/resolve.go`.
- `ctx` is threaded through `handleUndo` / `handleStepUndo` / `handleStepUndoPartial` to reach the request logger and trace ID.
- The metric is a package-level var (like `BlockBeginProcess`), so it is registered even on tier2 where `DeclareTier1Metrics` is not called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)