### PR TITLE
Log the worker counts of an incoming tier1 request

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -11,6 +11,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- Server: tier1 request logs now explain how many parallel workers a request actually got, and why. A client asking for 300 workers and getting 15 previously left no trace of the negotiation anywhere in the logs.
+
+  The `incoming Substreams Blocks request` entry gained a `parallelism` object (`requested_workers` as asked by the client, `granted_workers` as allowed by the authentication layer, the effective `workers`, `workers_source` telling which of the two applied, plus `plan_tier` and `stage_layer_executors`), along with `parallel_segment_count` and `stage_count` — a request with fewer segments than workers can never use them all.
+
+  The `substreams request stats` entry gained a `workers` object (`requested`, `granted`, `effective`, `peak`, `pool_exhausted_count`, `pool_rampup_deferred_count`), reported on tier1 only. A high `pool_exhausted_count` with a `peak` well below `effective` means the shared worker pool ran dry, a case that was previously only visible at debug level.
+
 ### Fixed
 
 - Server: `substreams-tier1` now restarts when its block hub can no longer link incoming live blocks, instead of hanging every request at a frozen head indefinitely. A live-source gap whose one-block files were already merged away can never be linked, and the head-block metrics keep tracking the live source, so the process looked healthy throughout.

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
   The `substreams request stats` entry gained a `workers` object (`requested`, `granted`, `effective`, `peak`, `pool_exhausted_count`, `pool_rampup_deferred_count`), reported on tier1 only. A high `pool_exhausted_count` with a `peak` well below `effective` means the shared worker pool ran dry, a case that was previously only visible at debug level.
 
+  The periodic `substreams request progress` entry gained its own `workers` object (`requested`, `granted`, `effective`, `running`, `idle`, and `pool_exhausted_5m` when jobs failed to get a worker over the window), so the same question can be answered while the request is still running rather than only once it ends. When jobs repeatedly find no free worker while the request still has idle capacity, a hint now says so and names the three ceilings that can cause it — the tier2 fleet being full, the organization's worker quota, or the server's per-session worker cap — since the pool reports a single error for all three.
+
 ### Fixed
 
 - Server: `substreams-tier1` now restarts when its block hub can no longer link incoming live blocks, instead of hanging every request at a frozen head indefinitely. A live-source gap whose one-block files were already merged away can never be linked, and the head-block metrics keep tracking the live source, so the process looked healthy throughout.

--- a/metrics/progress_log.go
+++ b/metrics/progress_log.go
@@ -256,13 +256,6 @@ func (s *Stats) RecordJobSchedulingBlocked(blocked bool) {
 	s.schedulingBlockedSince = time.Time{}
 }
 
-// RecordMaxParallelJobs records how many jobs this request may run at once.
-func (s *Stats) RecordMaxParallelJobs(count uint64) {
-	s.Lock()
-	defer s.Unlock()
-	s.maxParallelJobs = count
-}
-
 // throttledOverWindow is how long scheduling was held back over the window, including the
 // interval still open.
 //

--- a/metrics/progress_log.go
+++ b/metrics/progress_log.go
@@ -93,6 +93,10 @@ const (
 	// the second threshold.
 	squashingBehindSegments = 5
 	squashingBehindFor      = 2 * time.Minute
+	// Failed worker borrows over the window before the shared pool is called out. A couple of
+	// misses is normal — the pool is shared and workers come back quickly — so what matters is
+	// missing repeatedly while this request still has room to run more.
+	workerPoolExhaustedToReport = 5
 )
 
 // StageProgress is a point-in-time view of one stage of the parallel phase: what it executes,
@@ -256,6 +260,51 @@ func (s *Stats) RecordJobSchedulingBlocked(blocked bool) {
 	s.schedulingBlockedSince = time.Time{}
 }
 
+// workerReport is the live view of this request's workers, as opposed to the end-of-request
+// summary carried by workerStats: how many workers the request may use, how many it is using
+// right now, and whether the shared pool is what stands between the two.
+type workerReport struct {
+	requested uint64
+	granted   uint64
+	effective uint64
+	running   uint64
+	// idle is how many of the allowed workers have no job. It is not a symptom on its own: a
+	// request whose stages all depend on one another has nothing to hand out, and a throttled
+	// one is idle by design.
+	idle uint64
+	// poolExhausted counts, over the window, the jobs that were ready to run but found the
+	// shared pool empty. This is the one that separates "this request has nothing to schedule"
+	// from "the fleet has nothing to give it".
+	poolExhausted uint64
+}
+
+func (w *workerReport) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddUint64("requested", w.requested)
+	encoder.AddUint64("granted", w.granted)
+	encoder.AddUint64("effective", w.effective)
+	encoder.AddUint64("running", w.running)
+	encoder.AddUint64("idle", w.idle)
+	if w.poolExhausted != 0 {
+		encoder.AddUint64("pool_exhausted_5m", w.poolExhausted)
+	}
+	return nil
+}
+
+// workerReport should be called while locked
+func (s *Stats) workerReport(now time.Time) *workerReport {
+	report := &workerReport{
+		requested:     s.workers.requested.Load(),
+		granted:       s.workers.granted.Load(),
+		effective:     s.workers.effective.Load(),
+		running:       uint64(len(s.runningJobs)),
+		poolExhausted: s.windowPoolExhausted.sum(now),
+	}
+	if report.effective > report.running {
+		report.idle = report.effective - report.running
+	}
+	return report
+}
+
 // throttledOverWindow is how long scheduling was held back over the window, including the
 // interval still open.
 //
@@ -356,6 +405,7 @@ func (s *Stats) progressFields() []zap.Field {
 	linearBlocksInWindow := s.windowLocalBlocks.sum(now)
 	stages := s.stageJobReport(now)
 	calls := s.externalCallReport(now, measured)
+	workers := s.workerReport(now)
 
 	// How much output is sitting in the cache that the consumer has not taken yet. Measured
 	// from where the consumer actually is, which before the first block is the start of the
@@ -384,6 +434,7 @@ func (s *Stats) progressFields() []zap.Field {
 		zap.Float64("linear_blocks_processed_per_sec_5m", perSecond(linearBlocksInWindow, measured)),
 		zap.Uint64("blocks_sent", s.blocksSent),
 		zap.Object("blocks_sent_5m", sendStats),
+		zap.Object("workers", workers),
 		zap.Objects("stages", stages),
 		zap.Objects("external_calls", calls),
 	}
@@ -405,7 +456,7 @@ func (s *Stats) progressFields() []zap.Field {
 		}))
 	}
 
-	fields = append(fields, zap.Strings("hints", s.progressHints(stages, calls, sendStats, cachedAhead, linearPhase, measured, jobErrorsInWindow, now)))
+	fields = append(fields, zap.Strings("hints", s.progressHints(stages, calls, sendStats, workers, cachedAhead, linearPhase, measured, jobErrorsInWindow, now)))
 
 	return fields
 }
@@ -864,6 +915,7 @@ func (s *Stats) progressHints(
 	stages []*stageJobReport,
 	calls []*externalCallReport,
 	sendStats durationStats,
+	workers *workerReport,
 	cachedAhead uint64,
 	linearPhase bool,
 	measured time.Duration,
@@ -1001,6 +1053,20 @@ func (s *Stats) progressHints(
 				"%d job error(s) over the last %s, last one on stage %d: %s",
 				jobErrorsInWindow, humanDuration(measured), s.lastJobErrorStage, s.lastJobError))
 		}
+	}
+
+	// 3c. Jobs were ready to run and there was no worker to run them on, while this request was
+	// still allowed more. Worth stating on its own: every hint above reads as "the work is
+	// slow", this one says the work never started.
+	//
+	// The pool reports a single "limit exceeded" for three different ceilings — the fleet-wide
+	// worker count, the per-organization one, and a server-side per-session cap that can sit
+	// below what this request negotiated — so the hint reports what was observed and names the
+	// candidates instead of picking one.
+	if workers.poolExhausted >= workerPoolExhaustedToReport && workers.idle != 0 {
+		hints = append(hints, fmt.Sprintf(
+			"%d job(s) over the last %s were ready to run but no worker was free, while this request is running %d of the %d workers it was granted: something below its own limit is capping it — the tier2 fleet being full, this organization's worker quota, or the server's per-session worker cap",
+			workers.poolExhausted, humanDuration(measured), workers.running, workers.effective))
 	}
 
 	// 4. Jobs produced the partials but squashing them into the full stores lags behind.

--- a/metrics/progress_log_test.go
+++ b/metrics/progress_log_test.go
@@ -424,7 +424,7 @@ func TestProgressHints(t *testing.T) {
 		// limit and stays there: being throttled for the whole window is the healthy state of
 		// a production request, whatever the consumer is doing.
 		stats.startTime = time.Now().Add(-30 * time.Minute)
-		stats.RecordMaxParallelJobs(10)
+		stats.SetWorkerCounts(0, 10, 10)
 		stats.windowThrottled.add(time.Now(), ProgressWindow)
 		logger.logProgress()
 

--- a/metrics/stats.go
+++ b/metrics/stats.go
@@ -100,6 +100,10 @@ type Stats struct {
 	// above is a momentary state that flips on every scheduling attempt, so it says nothing on
 	// its own about whether the throttle cost anything.
 	windowThrottled windowedDuration
+	// windowPoolExhausted counts the borrow failures of workers.poolExhaustedCount over the
+	// window. The cumulative count says the pool ran dry at some point in the request; only the
+	// windowed one says it is dry now.
+	windowPoolExhausted windowedCounter
 	// stageJobs holds job accounting per stage, indexed by stage number.
 	stageJobs []*stageJobStats
 	// lastJobError keeps the most recent tier2 job error of the request. Failure counts tell
@@ -287,6 +291,13 @@ func (s *Stats) SetWorkerCounts(requested, granted, effective uint64) {
 // had no worker left to give, which happens when the pool is shared with other requests.
 func (s *Stats) RecordWorkerPoolExhausted() {
 	s.workers.poolExhaustedCount.Inc()
+
+	// The windowed count is what the periodic progress log reports, so it has to go through the
+	// mutex the rest of that machinery uses. The scheduler backs off for seconds after a failed
+	// borrow, so this cannot turn into a hot lock.
+	s.Lock()
+	defer s.Unlock()
+	s.windowPoolExhausted.add(time.Now(), 1)
 }
 
 // RecordWorkerPoolRampUpDeferred should be called when a job was held back because the worker

--- a/metrics/stats.go
+++ b/metrics/stats.go
@@ -63,6 +63,8 @@ type Stats struct {
 	// counter is used to get the next jobIdx
 	counter uint64
 
+	workers workerStats
+
 	clientReadTime *dmetrics.AvgDurationCounter
 	error          error
 	logger         *zap.Logger
@@ -230,6 +232,67 @@ func NewReqStats(config *Config, stores []*pbsubstreams.Module, moduleHashes map
 
 func (s *Stats) SetError(err error) {
 	s.error = err
+}
+
+// workerStats gathers what is known about the tier2 workers of a tier1 request: how many the
+// client asked for, how many it was granted, and how many it managed to use at runtime. Only
+// tier1 schedules jobs, so this stays zeroed on tier2.
+//
+// Its fields are atomic rather than guarded by the Stats mutex: they are written from the
+// scheduler loop, which must not contend with the block-processing path for a counter bump.
+type workerStats struct {
+	// requested is the worker count the client asked for through the untrusted header, 0 when
+	// it asked for nothing.
+	requested atomic.Uint64
+
+	// granted is the worker count the authentication layer allowed for this request.
+	granted atomic.Uint64
+
+	// effective is the worker count this request may actually use, the min of the two above.
+	effective atomic.Uint64
+
+	// peak is the highest number of jobs that ran concurrently during this request. Well below
+	// effective means something else than the negotiated limit was in the way.
+	peak atomic.Uint64
+
+	// poolExhaustedCount counts how many times a job was ready to be scheduled but the worker
+	// pool, shared with the other requests of the session, had no worker left to give.
+	poolExhaustedCount atomic.Uint64
+
+	// poolRampUpDeferredCount counts how many times a job was held back by the worker pool
+	// ramp-up period, which only spans the first seconds of a request.
+	poolRampUpDeferredCount atomic.Uint64
+}
+
+func (w *workerStats) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddUint64("requested", w.requested.Load())
+	encoder.AddUint64("granted", w.granted.Load())
+	encoder.AddUint64("effective", w.effective.Load())
+	encoder.AddUint64("peak", w.peak.Load())
+	encoder.AddUint64("pool_exhausted_count", w.poolExhaustedCount.Load())
+	encoder.AddUint64("pool_rampup_deferred_count", w.poolRampUpDeferredCount.Load())
+	return nil
+}
+
+// SetWorkerCounts records the outcome of the worker count negotiation for this request. It is
+// called once the trusted and client headers have been resolved, which happens after the stats
+// object is created.
+func (s *Stats) SetWorkerCounts(requested, granted, effective uint64) {
+	s.workers.requested.Store(requested)
+	s.workers.granted.Store(granted)
+	s.workers.effective.Store(effective)
+}
+
+// RecordWorkerPoolExhausted should be called when a job was ready to run but the worker pool
+// had no worker left to give, which happens when the pool is shared with other requests.
+func (s *Stats) RecordWorkerPoolExhausted() {
+	s.workers.poolExhaustedCount.Inc()
+}
+
+// RecordWorkerPoolRampUpDeferred should be called when a job was held back because the worker
+// pool is still ramping up, which only happens in the first seconds of a request.
+func (s *Stats) RecordWorkerPoolRampUpDeferred() {
+	s.workers.poolRampUpDeferredCount.Inc()
 }
 
 type extendedStats struct {
@@ -405,6 +468,9 @@ func (s *Stats) RecordNewSubrequest(stage uint32, startBlock, stopBlock uint64) 
 
 	s.stageJobStats(int(stage)).scheduled++
 
+	if running := uint64(len(s.runningJobs)); running > s.workers.peak.Load() {
+		s.workers.peak.Store(running)
+	}
 	s.Unlock()
 	return id
 }
@@ -983,6 +1049,13 @@ func (s *Stats) getZapFields(meter dmetering.Meter) []zap.Field {
 	byModule := s.wasmExtensionCallMetricsByModule()
 	out = append(out, zap.Objects("wasm_ext_call_metrics", aggregateWasmExtensionCallMetricsByExtension(byModule)))
 	out = append(out, zap.Objects("wasm_ext_call_metrics_by_module", byModule))
+
+	// Additive only: the worker count is negotiated and capped in several different places, so a
+	// client asking for 300 workers and seeing 15 needs all of these together to tell which one
+	// applied. Only tier1 schedules jobs, so tier2 has nothing to say here.
+	if !s.config.Tier2 {
+		out = append(out, zap.Object("workers", &s.workers))
+	}
 
 	return out
 }

--- a/metrics/stats.go
+++ b/metrics/stats.go
@@ -100,9 +100,6 @@ type Stats struct {
 	// above is a momentary state that flips on every scheduling attempt, so it says nothing on
 	// its own about whether the throttle cost anything.
 	windowThrottled windowedDuration
-	// maxParallelJobs is what the request is allowed to run at once, so an idle worker count
-	// can be derived: a throttle only costs something when it leaves workers with nothing to do.
-	maxParallelJobs uint64
 	// stageJobs holds job accounting per stage, indexed by stage number.
 	stageJobs []*stageJobStats
 	// lastJobError keeps the most recent tier2 job error of the request. Failure counts tell
@@ -249,6 +246,8 @@ type workerStats struct {
 	granted atomic.Uint64
 
 	// effective is the worker count this request may actually use, the min of the two above.
+	// It is also what an idle worker count is derived from, since a throttle only costs
+	// something when it leaves workers with nothing to do.
 	effective atomic.Uint64
 
 	// peak is the highest number of jobs that ran concurrently during this request. Well below
@@ -274,9 +273,10 @@ func (w *workerStats) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	return nil
 }
 
-// SetWorkerCounts records the outcome of the worker count negotiation for this request. It is
-// called once the trusted and client headers have been resolved, which happens after the stats
-// object is created.
+// SetWorkerCounts records the outcome of the worker count negotiation for this request, and is
+// the only place these counts are set. It is called once the trusted and client headers have
+// been resolved, which happens after the stats object is created but before either the periodic
+// progress log or the final stats log can read them.
 func (s *Stats) SetWorkerCounts(requested, granted, effective uint64) {
 	s.workers.requested.Store(requested)
 	s.workers.granted.Store(granted)

--- a/metrics/stats_workers_test.go
+++ b/metrics/stats_workers_test.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"testing"
+
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestStats_PeakWorkersIsAHighWaterMark(t *testing.T) {
+	stats := NewReqStats(&Config{}, nil, nil, zlogTest)
+	stats.RecordStages([]*pbsubstreamsrpc.Stage{{Modules: []string{"mod"}}})
+
+	first := stats.RecordNewSubrequest(0, 0, 100)
+	second := stats.RecordNewSubrequest(0, 100, 200)
+	third := stats.RecordNewSubrequest(0, 200, 300)
+	assert.Equal(t, uint64(3), stats.workers.peak.Load())
+
+	stats.RecordEndSubrequest(first, JobComplete)
+	stats.RecordEndSubrequest(second, JobComplete)
+
+	// The peak must not decay as jobs complete, otherwise the value read at the end of the
+	// request would only reflect the tail of the request instead of its busiest moment.
+	assert.Equal(t, uint64(3), stats.workers.peak.Load())
+
+	fourth := stats.RecordNewSubrequest(0, 300, 400)
+	assert.Equal(t, uint64(3), stats.workers.peak.Load())
+
+	stats.RecordEndSubrequest(third, JobComplete)
+	stats.RecordEndSubrequest(fourth, JobComplete)
+	assert.Equal(t, uint64(3), stats.workers.peak.Load())
+}
+
+func TestStats_WorkersAreLoggedOnTier1(t *testing.T) {
+	stats := NewReqStats(&Config{}, nil, nil, zlogTest)
+	stats.RecordStages([]*pbsubstreamsrpc.Stage{{Modules: []string{"mod"}}})
+
+	// A client asking for 300 workers on a key granted 15 of them: the log must keep both
+	// numbers so the gap is explainable without reproducing the request.
+	stats.SetWorkerCounts(300, 15, 15)
+	stats.RecordNewSubrequest(0, 0, 100)
+	stats.RecordWorkerPoolExhausted()
+	stats.RecordWorkerPoolExhausted()
+	stats.RecordWorkerPoolRampUpDeferred()
+
+	fields := fieldsByKey(zapFieldsOf(stats))
+	require.Contains(t, fields, "workers")
+
+	encoder := zapcore.NewMapObjectEncoder()
+	fields["workers"].AddTo(encoder)
+
+	assert.Equal(t, map[string]any{
+		"requested":                  uint64(300),
+		"granted":                    uint64(15),
+		"effective":                  uint64(15),
+		"peak":                       uint64(1),
+		"pool_exhausted_count":       uint64(2),
+		"pool_rampup_deferred_count": uint64(1),
+	}, encoder.Fields["workers"])
+}
+
+func TestStats_WorkersAreOmittedOnTier2(t *testing.T) {
+	stats := NewReqStats(&Config{Tier2: true}, nil, nil, zlogTest)
+
+	fields := fieldsByKey(zapFieldsOf(stats))
+	assert.NotContains(t, fields, "workers", "tier2 does not schedule jobs, it has no worker of its own to report")
+}
+
+// zapFieldsOf collects the fields the final request stats log would carry. The rate counter is
+// stopped first, exactly like LogAndClose does, otherwise reading its rate races with the
+// background janitor goroutine dmetrics runs.
+func zapFieldsOf(stats *Stats) []zap.Field {
+	stats.blockRate.SyncNow()
+	stats.blockRate.Stop()
+	return stats.getZapFields(nil)
+}
+
+func fieldsByKey(fields []zap.Field) map[string]zap.Field {
+	out := make(map[string]zap.Field, len(fields))
+	for _, field := range fields {
+		out[field.Key] = field
+	}
+	return out
+}

--- a/metrics/stats_workers_test.go
+++ b/metrics/stats_workers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestStats_PeakWorkersIsAHighWaterMark(t *testing.T) {
@@ -76,6 +77,95 @@ func zapFieldsOf(stats *Stats) []zap.Field {
 	stats.blockRate.SyncNow()
 	stats.blockRate.Stop()
 	return stats.getZapFields(nil)
+}
+
+func TestStats_ProgressLogReportsLiveWorkers(t *testing.T) {
+	stats := NewReqStats(&Config{}, nil, nil, zlogTest)
+	stats.RecordStages([]*pbsubstreamsrpc.Stage{{Modules: []string{"mod"}}})
+	stats.SetWorkerCounts(300, 15, 15)
+
+	stats.RecordNewSubrequest(0, 0, 100)
+	stats.RecordNewSubrequest(0, 100, 200)
+	stats.RecordWorkerPoolExhausted()
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	NewProgressLogger(stats, zap.New(core)).logProgress()
+
+	workers := fieldMap(t, logs.All()[0])["workers"].(map[string]any)
+	assert.Equal(t, uint64(300), workers["requested"])
+	assert.Equal(t, uint64(15), workers["granted"])
+	assert.Equal(t, uint64(15), workers["effective"])
+	assert.Equal(t, uint64(2), workers["running"])
+	assert.Equal(t, uint64(13), workers["idle"])
+	assert.Equal(t, uint64(1), workers["pool_exhausted_5m"])
+}
+
+func TestStats_ProgressLogOmitsPoolExhaustedWhenNoneHappened(t *testing.T) {
+	stats := NewReqStats(&Config{}, nil, nil, zlogTest)
+	stats.SetWorkerCounts(0, 8, 8)
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	NewProgressLogger(stats, zap.New(core)).logProgress()
+
+	workers := fieldMap(t, logs.All()[0])["workers"].(map[string]any)
+	assert.NotContains(t, workers, "pool_exhausted_5m", "a healthy request must not carry the field at all")
+	assert.Equal(t, uint64(8), workers["idle"], "no job running means every worker is idle")
+}
+
+func TestProgressHint_WorkerPoolCapsTheRequest(t *testing.T) {
+	stats := NewReqStats(&Config{}, nil, nil, zlogTest)
+	stats.RecordStages([]*pbsubstreamsrpc.Stage{{Modules: []string{"mod"}}})
+
+	// Granted 300, but jobs keep finding the pool empty while only one runs: the ceiling that
+	// applies is below what this request negotiated, which is exactly what cannot be seen from
+	// the request's own numbers.
+	stats.SetWorkerCounts(300, 300, 300)
+	stats.RecordNewSubrequest(0, 0, 100)
+	for range workerPoolExhaustedToReport {
+		stats.RecordWorkerPoolExhausted()
+	}
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	NewProgressLogger(stats, zap.New(core)).logProgress()
+
+	hints := fieldMap(t, logs.All()[0])["hints"].([]any)
+	require.Len(t, hints, 1)
+	assert.Contains(t, hints[0], "no worker was free")
+	assert.Contains(t, hints[0], "running 1 of the 300 workers")
+}
+
+func TestProgressHint_NoWorkerPoolHintWhenRunningAtTheLimit(t *testing.T) {
+	stats := NewReqStats(&Config{}, nil, nil, zlogTest)
+	stats.RecordStages([]*pbsubstreamsrpc.Stage{{Modules: []string{"mod"}}})
+
+	// Borrows failed, but the request is already running everything it is allowed to: the pool
+	// refusing a further job costs it nothing, so this is not a problem to report.
+	stats.SetWorkerCounts(0, 1, 1)
+	stats.RecordNewSubrequest(0, 0, 100)
+	for range workerPoolExhaustedToReport * 2 {
+		stats.RecordWorkerPoolExhausted()
+	}
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	NewProgressLogger(stats, zap.New(core)).logProgress()
+
+	assert.Empty(t, fieldMap(t, logs.All()[0])["hints"])
+}
+
+func TestProgressHint_NoWorkerPoolHintOnAFewMisses(t *testing.T) {
+	stats := NewReqStats(&Config{}, nil, nil, zlogTest)
+	stats.RecordStages([]*pbsubstreamsrpc.Stage{{Modules: []string{"mod"}}})
+
+	stats.SetWorkerCounts(0, 300, 300)
+	stats.RecordNewSubrequest(0, 0, 100)
+	for range workerPoolExhaustedToReport - 1 {
+		stats.RecordWorkerPoolExhausted()
+	}
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	NewProgressLogger(stats, zap.New(core)).logProgress()
+
+	assert.Empty(t, fieldMap(t, logs.All()[0])["hints"], "a couple of misses on a shared pool is normal")
 }
 
 func fieldsByKey(fields []zap.Field) map[string]zap.Field {

--- a/orchestrator/scheduler/scheduler.go
+++ b/orchestrator/scheduler/scheduler.go
@@ -204,6 +204,9 @@ func (s *Scheduler) Update(msg loop.Msg) loop.Cmd {
 			s.Stages.ReleaseJob(workUnit)
 			if errors.Is(err, work.ErrorResourceExhausted) {
 				s.logger.Debug("resource exhausted", zap.Error(err))
+				if stats := reqctx.ReqStatsOrNil(s.ctx); stats != nil {
+					stats.RecordWorkerPoolExhausted()
+				}
 				if s.delayedScheduleNextJob {
 					s.logger.Debug("skipping delayed schedule next job")
 					return nil
@@ -215,6 +218,9 @@ func (s *Scheduler) Update(msg loop.Msg) loop.Cmd {
 				})
 			} else if errors.Is(err, work.ErrorResourceExhaustedRampUp) {
 				s.logger.Debug("resource exhausted ramp up", zap.Error(err))
+				if stats := reqctx.ReqStatsOrNil(s.ctx); stats != nil {
+					stats.RecordWorkerPoolRampUpDeferred()
+				}
 
 				if s.delayedScheduleNextJob {
 					s.logger.Debug("skipping ramp up delayed schedule next job")

--- a/pipeline/resolve.go
+++ b/pipeline/resolve.go
@@ -113,7 +113,7 @@ func BuildRequestDetailsFromSubrequest(ctx context.Context, request *pbssinterna
 	}
 
 	// note: we don't touch the maxParallelJobs here
-	_, req.MaxStageLayerParallelExecutor = reqctx.GetEffectiveHeaderValues(ctx, nil, 0, reqctx.DefaultMaxStageLayerParallelExecutorCount)
+	req.MaxStageLayerParallelExecutor = reqctx.GetEffectiveHeaderValues(ctx, nil, 0, reqctx.DefaultMaxStageLayerParallelExecutorCount).StageLayerExecutors
 
 	return req
 }

--- a/reqctx/context.go
+++ b/reqctx/context.go
@@ -102,6 +102,14 @@ func ReqStats(ctx context.Context) *metrics.Stats {
 	return ctx.Value(reqStatsKey).(*metrics.Stats)
 }
 
+// ReqStatsOrNil returns the request stats attached to the context, or nil when there is none.
+// Use it instead of [ReqStats] from code paths that also run without a request stats object
+// installed, typically tests, since [ReqStats] panics in that case.
+func ReqStatsOrNil(ctx context.Context) *metrics.Stats {
+	stats, _ := ctx.Value(reqStatsKey).(*metrics.Stats)
+	return stats
+}
+
 func WithReqStats(ctx context.Context, stats *metrics.Stats) context.Context {
 	return context.WithValue(ctx, reqStatsKey, stats)
 }

--- a/reqctx/headers.go
+++ b/reqctx/headers.go
@@ -6,37 +6,93 @@ import (
 	"strconv"
 
 	"github.com/streamingfast/dauth"
+	"go.uber.org/zap/zapcore"
 )
 
 const HeaderParallelWorkers = "x-substreams-parallel-workers"
 const legacyHeaderParallelWorkers = "x-sf-substreams-parallel-jobs"
 const HeaderCacheTag = "x-substreams-cache-tag"
 
+// Possible values of EffectiveParallelism.WorkersSource, describing what determined
+// the effective worker count of a request.
+const (
+	WorkersSourceDefault       = "default"
+	WorkersSourceTrustedHeader = "trusted_header"
+	WorkersSourceClientHeader  = "client_header"
+)
+
+// EffectiveParallelism is the outcome of the parallelism negotiation between the
+// server defaults, the trusted headers set by the authentication layer and the
+// headers sent by the client. It keeps each input around (instead of only the final
+// value) so that a request log line is enough to explain why a client asking for N
+// workers ended up with a different number.
+type EffectiveParallelism struct {
+	// GrantedWorkers is the worker count the authentication layer allows for this
+	// request, falling back to the server default when the trusted header is absent.
+	GrantedWorkers uint64
+
+	// RequestedWorkers is the worker count the client asked for through the untrusted
+	// header, 0 when the client did not ask for anything.
+	RequestedWorkers uint64
+
+	// Workers is the effective worker count: min(GrantedWorkers, RequestedWorkers) when
+	// the client asked for less than what it was granted, GrantedWorkers otherwise.
+	Workers uint64
+
+	// StageLayerExecutors is the number of modules that can be executed in parallel
+	// within a single stage layer, derived from the plan tier.
+	StageLayerExecutors uint64
+
+	// PlanTier is the substreams plan tier reported by the authentication layer, empty
+	// when the request is unauthenticated.
+	PlanTier string
+
+	// WorkersSource tells which of the three inputs determined Workers, one of
+	// WorkersSourceDefault, WorkersSourceTrustedHeader or WorkersSourceClientHeader.
+	WorkersSource string
+}
+
+func (p EffectiveParallelism) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+	encoder.AddUint64("requested_workers", p.RequestedWorkers)
+	encoder.AddUint64("granted_workers", p.GrantedWorkers)
+	encoder.AddUint64("workers", p.Workers)
+	encoder.AddString("workers_source", p.WorkersSource)
+	encoder.AddString("plan_tier", p.PlanTier)
+	encoder.AddUint64("stage_layer_executors", p.StageLayerExecutors)
+	return nil
+}
+
 // GetEffectiveHeaderValues compares the request headers to the 'trusted headers' sent by the authentication layer.
 // It contains some business logic:
 //   - prevents overriding the numeric values to lower ones for parallel jobs and stage layer executors
-func GetEffectiveHeaderValues(ctx context.Context, headers http.Header, defaultParallelJobs uint64, defaultParallelExecutors uint64) (parallelJobs uint64, parallelExecutors uint64) {
-
-	parallelJobs = defaultParallelJobs
-	parallelExecutors = defaultParallelExecutors
+func GetEffectiveHeaderValues(ctx context.Context, headers http.Header, defaultParallelJobs uint64, defaultParallelExecutors uint64) EffectiveParallelism {
+	out := EffectiveParallelism{
+		GrantedWorkers:      defaultParallelJobs,
+		Workers:             defaultParallelJobs,
+		StageLayerExecutors: defaultParallelExecutors,
+		WorkersSource:       WorkersSourceDefault,
+	}
 
 	// TrustedHeaders can always override these values
 	if trustedHeaders := dauth.FromContext(ctx); trustedHeaders != nil {
 		if parallelJobsStr := trustedHeaders.Get(HeaderParallelWorkers); parallelJobsStr != "" {
 			if count, err := strconv.ParseUint(parallelJobsStr, 10, 64); err == nil {
-				parallelJobs = count
+				out.GrantedWorkers = count
+				out.Workers = count
+				out.WorkersSource = WorkersSourceTrustedHeader
 			}
 		}
 
-		switch trustedHeaders.SubstreamsPlanTier() {
+		out.PlanTier = trustedHeaders.SubstreamsPlanTier()
+		switch out.PlanTier {
 		case "ENTERPRISE":
-			parallelExecutors = 10
+			out.StageLayerExecutors = 10
 		case "PRO":
-			parallelExecutors = 8
+			out.StageLayerExecutors = 8
 		case "SCALING":
-			parallelExecutors = 5
+			out.StageLayerExecutors = 5
 		default:
-			parallelExecutors = 2
+			out.StageLayerExecutors = 2
 		}
 	}
 
@@ -47,10 +103,13 @@ func GetEffectiveHeaderValues(ctx context.Context, headers http.Header, defaultP
 	}
 	if untrustedParallelWorkers != "" {
 		if count, err := strconv.ParseUint(untrustedParallelWorkers, 10, 64); err == nil {
-			if count < parallelJobs {
-				parallelJobs = count
+			out.RequestedWorkers = count
+			if count < out.Workers {
+				out.Workers = count
+				out.WorkersSource = WorkersSourceClientHeader
 			}
 		}
 	}
-	return
+
+	return out
 }

--- a/reqctx/headers_test.go
+++ b/reqctx/headers_test.go
@@ -11,33 +11,44 @@ import (
 
 func TestGetEffectiveHeaderValues(t *testing.T) {
 	tests := []struct {
-		name                    string
-		trustedHeaders          dauth.TrustedHeaders
-		normalHeaders           http.Header
-		defaultParallelWorkers  uint64
-		defaultStageExecutors   uint64
-		expectedParallelWorkers uint64
-		expectedStageExecutors  uint64
+		name                   string
+		trustedHeaders         dauth.TrustedHeaders
+		normalHeaders          http.Header
+		defaultParallelWorkers uint64
+		defaultStageExecutors  uint64
+		expected               EffectiveParallelism
 	}{
 		{
-			name:                    "uses defaults when no headers provided",
-			trustedHeaders:          nil,
-			normalHeaders:           http.Header{},
-			defaultParallelWorkers:  10,
-			defaultStageExecutors:   5,
-			expectedParallelWorkers: 10,
-			expectedStageExecutors:  5,
+			name:                   "uses defaults when no headers provided",
+			trustedHeaders:         nil,
+			normalHeaders:          http.Header{},
+			defaultParallelWorkers: 10,
+			defaultStageExecutors:  5,
+			expected: EffectiveParallelism{
+				RequestedWorkers:    0,
+				GrantedWorkers:      10,
+				Workers:             10,
+				WorkersSource:       WorkersSourceDefault,
+				PlanTier:            "",
+				StageLayerExecutors: 5,
+			},
 		},
 		{
 			name: "trusted headers override defaults",
 			trustedHeaders: dauth.TrustedHeaders{
 				HeaderParallelWorkers: "20",
 			},
-			normalHeaders:           http.Header{},
-			defaultParallelWorkers:  10,
-			defaultStageExecutors:   5,
-			expectedParallelWorkers: 20,
-			expectedStageExecutors:  2, // default for free
+			normalHeaders:          http.Header{},
+			defaultParallelWorkers: 10,
+			defaultStageExecutors:  5,
+			expected: EffectiveParallelism{
+				RequestedWorkers:    0,
+				GrantedWorkers:      20,
+				Workers:             20,
+				WorkersSource:       WorkersSourceTrustedHeader,
+				PlanTier:            "",
+				StageLayerExecutors: 2, // default for free
+			},
 		},
 		{
 			name:           "normal headers can only lower values",
@@ -45,10 +56,16 @@ func TestGetEffectiveHeaderValues(t *testing.T) {
 			normalHeaders: http.Header{
 				http.CanonicalHeaderKey(HeaderParallelWorkers): []string{"5"}, // lower than default 10
 			},
-			defaultParallelWorkers:  10,
-			defaultStageExecutors:   5,
-			expectedParallelWorkers: 5, // lowered
-			expectedStageExecutors:  5, // unchanged (cannot increase)
+			defaultParallelWorkers: 10,
+			defaultStageExecutors:  5,
+			expected: EffectiveParallelism{
+				RequestedWorkers:    5,
+				GrantedWorkers:      10,
+				Workers:             5, // lowered
+				WorkersSource:       WorkersSourceClientHeader,
+				PlanTier:            "",
+				StageLayerExecutors: 5, // unchanged (cannot increase)
+			},
 		},
 		{
 			name: "normal headers cannot override trusted headers upward",
@@ -59,10 +76,53 @@ func TestGetEffectiveHeaderValues(t *testing.T) {
 			normalHeaders: http.Header{
 				http.CanonicalHeaderKey(HeaderParallelWorkers): []string{"15"}, // lower than trusted 20
 			},
-			defaultParallelWorkers:  10,
-			defaultStageExecutors:   5,
-			expectedParallelWorkers: 15, // lowered from trusted value
-			expectedStageExecutors:  8,  // increased from the "PRO" plan
+			defaultParallelWorkers: 10,
+			defaultStageExecutors:  5,
+			expected: EffectiveParallelism{
+				RequestedWorkers:    15,
+				GrantedWorkers:      20,
+				Workers:             15, // lowered from trusted value
+				WorkersSource:       WorkersSourceClientHeader,
+				PlanTier:            "PRO",
+				StageLayerExecutors: 8, // increased from the "PRO" plan
+			},
+		},
+		{
+			name: "client asking for more than granted keeps the granted count",
+			trustedHeaders: dauth.TrustedHeaders{
+				HeaderParallelWorkers:          "15",
+				dauth.HeaderSubstreamsPlanTier: "SCALING",
+			},
+			normalHeaders: http.Header{
+				http.CanonicalHeaderKey(HeaderParallelWorkers): []string{"300"},
+			},
+			defaultParallelWorkers: 10,
+			defaultStageExecutors:  5,
+			expected: EffectiveParallelism{
+				RequestedWorkers:    300,
+				GrantedWorkers:      15,
+				Workers:             15,
+				WorkersSource:       WorkersSourceTrustedHeader,
+				PlanTier:            "SCALING",
+				StageLayerExecutors: 5,
+			},
+		},
+		{
+			name:           "legacy client header is still honored",
+			trustedHeaders: nil,
+			normalHeaders: http.Header{
+				http.CanonicalHeaderKey(legacyHeaderParallelWorkers): []string{"3"},
+			},
+			defaultParallelWorkers: 10,
+			defaultStageExecutors:  5,
+			expected: EffectiveParallelism{
+				RequestedWorkers:    3,
+				GrantedWorkers:      10,
+				Workers:             3,
+				WorkersSource:       WorkersSourceClientHeader,
+				PlanTier:            "",
+				StageLayerExecutors: 5,
+			},
 		},
 	}
 
@@ -73,15 +133,14 @@ func TestGetEffectiveHeaderValues(t *testing.T) {
 				ctx = dauth.WithTrustedHeaders(ctx, tt.trustedHeaders)
 			}
 
-			parallelJobs, parallelExecutors := GetEffectiveHeaderValues(
+			actual := GetEffectiveHeaderValues(
 				ctx,
 				tt.normalHeaders,
 				tt.defaultParallelWorkers,
 				tt.defaultStageExecutors,
 			)
 
-			assert.Equal(t, tt.expectedParallelWorkers, parallelJobs, "parallel jobs mismatch")
-			assert.Equal(t, tt.expectedStageExecutors, parallelExecutors, "parallel executors mismatch")
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -690,9 +690,11 @@ func (s *Tier1Service) blocks(
 		}
 	}
 
-	parallelJobs, parallelExecutors := reqctx.GetEffectiveHeaderValues(ctx, header, s.runtimeConfig.DefaultParallelSubrequests, reqctx.DefaultMaxStageLayerParallelExecutorCount)
-	requestDetails.MaxParallelJobs = parallelJobs
-	requestDetails.MaxStageLayerParallelExecutor = parallelExecutors
+	parallelism := reqctx.GetEffectiveHeaderValues(ctx, header, s.runtimeConfig.DefaultParallelSubrequests, reqctx.DefaultMaxStageLayerParallelExecutorCount)
+	requestDetails.MaxParallelJobs = parallelism.Workers
+	requestDetails.MaxStageLayerParallelExecutor = parallelism.StageLayerExecutors
+	reqStats.SetWorkerCounts(parallelism.RequestedWorkers, parallelism.GrantedWorkers, parallelism.Workers)
+	logFields = append(logFields, zap.Object("parallelism", parallelism))
 
 	ctx = reqctx.WithRequest(ctx, requestDetails)
 	if s.runtimeConfig.ModuleExecutionTracing {
@@ -845,6 +847,18 @@ func (s *Tier1Service) blocks(
 	if err != nil {
 		return stream.NewErrInvalidArg("%s", err.Error())
 	}
+
+	// The number of segments to backprocess bounds how many workers can ever be busy at
+	// once: asking for 300 workers on a request that only has 12 segments of work left
+	// will never use more than 12 of them.
+	var parallelSegmentCount int
+	if segmenter := reqPlan.BackprocessSegmenter(); segmenter != nil {
+		parallelSegmentCount = segmenter.Count()
+	}
+	logFields = append(logFields,
+		zap.Int("parallel_segment_count", parallelSegmentCount),
+		zap.Int("stage_count", len(execGraph.StagedUsedModules())),
+	)
 
 	if s.sessionPool != nil {
 		auth := dauth.FromContext(ctx)

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -927,7 +927,6 @@ func (s *Tier1Service) blocks(
 	// Periodic snapshot of what this request is doing, so a slow substreams can be
 	// diagnosed from the logs alone, without waiting for the final stats line.
 	reqStats.RecordResolvedStartBlock(requestDetails.ResolvedStartBlockNum)
-	reqStats.RecordMaxParallelJobs(requestDetails.MaxParallelJobs)
 	progressCtx, cancelProgressLog := context.WithCancel(ctx)
 	defer cancelProgressLog()
 	go metrics.NewProgressLogger(reqStats, logger).Run(progressCtx)


### PR DESCRIPTION
## Why

A client asking for 300 parallel workers and getting 15 leaves no trace of the negotiation anywhere in the logs today, so the gap can't be diagnosed after the fact. Three separate things can cap the worker count and none of them are observable:

1. **Plan/auth negotiation** — the trusted header from the authentication layer sets the ceiling, the client header can only lower it. Both inputs collapse into a single number that is never logged.
2. **Worker pool contention** — `SessionWorkerPool.Borrow` can come back empty when the pool is shared with other requests. Only visible at debug level.
3. **Not enough work** — a request with fewer segments than workers can never use them all.

## What changed

**`incoming Substreams Blocks request`** gained a `parallelism` object:

```
parallelism: {requested_workers: 300, granted_workers: 15, workers: 15,
              workers_source: "trusted_header", plan_tier: "SCALING",
              stage_layer_executors: 5}
parallel_segment_count: 4213
stage_count: 3
```

`workers_source` tells which input won, so "granted 15 because of the plan tier" and "lowered to 15 because the client asked for it" are no longer the same log line.

**`substreams request stats`** gained a `workers` object, tier1 only:

```
workers: {requested: 300, granted: 15, effective: 15, peak: 4,
          pool_exhausted_count: 87, pool_rampup_deferred_count: 2}
```

`peak` well below `effective` together with a high `pool_exhausted_count` points at pool contention rather than at the negotiated limit.

**`GetEffectiveHeaderValues`** now returns an `EffectiveParallelism` struct instead of two bare integers — that is what makes the negotiation inputs available for logging. The arithmetic is unchanged, and the existing behavior is still covered by the table test plus new cases for the client-asks-for-more and legacy-header paths.

## Notes

- No proto change, nothing new sent to clients — `SessionInit.MaxParallelWorkers` already carries the effective count.
- The six worker counters are atomic rather than guarded by the `Stats` mutex, so the scheduler loop doesn't contend with the block-processing path for a counter bump.
- The scheduler reads the stats through a new nil-safe `reqctx.ReqStatsOrNil`, since `reqctx.ReqStats` panics where no stats object is installed.

## Testing

`go test ./...` passes, and `go test -race ./metrics/...` is clean.