### PR TITLE
Decode blocks on a worker pool in the from-proto sinker

### DIFF
--- a/cmd/substreams/sink_sql_common.go
+++ b/cmd/substreams/sink_sql_common.go
@@ -341,7 +341,6 @@ func runFromProtoSink(cmd *cobra.Command, driver, manifestPath, dsnString string
 		UseConstraints:  useConstraints,
 		UseTransactions: true,
 		BlockBatchSize:  blockBatchSize,
-		Parallel:        false,
 		Encoding:        encoding,
 		Clickhouse:      fromProtoClickhouseOptions(cmd, driver),
 	})

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -21,6 +21,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   The `substreams request stats` entry gained a `workers` object (`requested`, `granted`, `effective`, `peak`, `pool_exhausted_count`, `pool_rampup_deferred_count`), reported on tier1 only. A high `pool_exhausted_count` with a `peak` well below `effective` means the shared worker pool ran dry, a case that was previously only visible at debug level.
 
   The periodic `substreams request progress` entry gained its own `workers` object (`requested`, `granted`, `effective`, `running`, `idle`, and `pool_exhausted_5m` when jobs failed to get a worker over the window), so the same question can be answered while the request is still running rather than only once it ends. When jobs repeatedly find no free worker while the request still has idle capacity, a hint now says so and names the three ceilings that can cause it — the tier2 fleet being full, the organization's worker quota, or the server's per-session worker cap — since the pool reports a single error for all three.
+### Changed
+
+- Sink: `substreams sink postgres` and `substreams sink clickhouse` in from-proto mode now unmarshal and walk blocks on a worker pool instead of one at a time at flush. Decoding a block was where the sink spent its time — around 7.8µs of the 9.3µs a wide entity cost — while PostgreSQL sat on roughly eight times that in headroom, so the sink itself was the throughput limit. Measured at 4.1x on a wide entity. Workers only fill a per-block buffer; the inserts are still replayed in block order, in the same transaction as before, so the resulting database is unchanged.
+
+  The pool defaults to one worker per core less one, capped at eight, since the work is allocator-bound before it runs out of cores. `SinkerFactoryOptions.DecodeWorkers` overrides it.
+
+- Sink: **Breaking** `db_proto.NewSinker` takes a `decodeWorkers int` parameter, and `SinkerFactoryOptions.Parallel` is gone along with `sql.Database.Clone()`. The parallel flush path they served was unreachable — `Parallel` was hardcoded to false at every call site — and unsound had it run: `Clone()` returned the receiver, so every goroutine shared one `*sql.Tx`.
 
 ### Fixed
 

--- a/sink/sql/db_proto/decoder.go
+++ b/sink/sql/db_proto/decoder.go
@@ -1,0 +1,177 @@
+package db_proto
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	sql "github.com/streamingfast/substreams/sink/sql/db_proto/sql"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// decoder turns buffered blocks into buffered inserts, on several goroutines.
+//
+// Unmarshalling into dynamicpb and walking the message descriptor is where the sink
+// spends its time — measured at ~7.8µs of the ~9.3µs a wide entity costs, see
+// sink/sql/db_proto/benchmarks. Blocks are independent, so that part parallelises
+// cleanly. Everything that touches the database stays on the caller's goroutine: the
+// workers only fill a BufferedInserter each, and the caller replays them in block
+// order.
+type decoder struct {
+	rootMessageDescriptor protoreflect.MessageDescriptor
+	workers               int
+
+	// buffers are reused across flushes to keep the per-row []any allocations from
+	// being handed to the GC every batch.
+	buffers []*sql.BufferedInserter
+}
+
+// decoded is one block's worth of buffered inserts, plus what it cost to produce.
+type decoded struct {
+	blockNum       uint64
+	blockHash      string
+	blockTimestamp time.Time
+	inserts        *sql.BufferedInserter
+	// empty marks a block whose module produced no output. Such a block is skipped
+	// entirely, including its _blocks_ row, as the serial path always did.
+	empty bool
+
+	unmarshalDuration time.Duration
+	walkDuration      time.Duration
+}
+
+func newDecoder(rootMessageDescriptor protoreflect.MessageDescriptor, workers int) *decoder {
+	if workers <= 0 {
+		// One per core, less one for the goroutine draining the gRPC stream, capped at
+		// 8: TestClientDecodeScaling measures 4.13x at eight workers and only 4.24x at
+		// fifteen, the work being allocator-bound well before it runs out of cores.
+		// Taking more would cost the rest of the machine for nothing.
+		workers = min(8, max(1, runtime.NumCPU()-1))
+	}
+
+	return &decoder{
+		rootMessageDescriptor: rootMessageDescriptor,
+		workers:               workers,
+	}
+}
+
+// decodeAll walks every held block and returns the results in the same order.
+//
+// The database is only read for its dialect and descriptors, both immutable once the
+// sinker is running, so this is safe to run concurrently. Nothing here inserts.
+func (d *decoder) decodeAll(holding []*Holder, db sql.Database) ([]*decoded, error) {
+	results := make([]*decoded, len(holding))
+	errs := make([]error, len(holding))
+
+	d.ensureBuffers(len(holding))
+
+	if d.workers == 1 || len(holding) == 1 {
+		for i, holder := range holding {
+			results[i], errs[i] = d.decodeOne(holder, db, d.buffers[i])
+		}
+		return collect(results, errs)
+	}
+
+	var (
+		wg   sync.WaitGroup
+		next = make(chan int)
+	)
+
+	wg.Add(d.workers)
+	for range d.workers {
+		go func() {
+			defer wg.Done()
+			for i := range next {
+				results[i], errs[i] = d.decodeOne(holding[i], db, d.buffers[i])
+			}
+		}()
+	}
+
+	for i := range holding {
+		next <- i
+	}
+	close(next)
+	wg.Wait()
+
+	return collect(results, errs)
+}
+
+func collect(results []*decoded, errs []error) ([]*decoded, error) {
+	for i, err := range errs {
+		if err != nil {
+			return nil, fmt.Errorf("decoding block at index %d: %w", i, err)
+		}
+	}
+
+	return results, nil
+}
+
+// ensureBuffers grows the reusable buffer pool to one per held block and resets them.
+func (d *decoder) ensureBuffers(count int) {
+	for len(d.buffers) < count {
+		d.buffers = append(d.buffers, sql.NewBufferedInserter(64))
+	}
+	for i := range count {
+		d.buffers[i].Reset()
+	}
+}
+
+func (d *decoder) decodeOne(holder *Holder, db sql.Database, into *sql.BufferedInserter) (*decoded, error) {
+	clock := holder.data.Clock
+	out := &decoded{
+		blockNum:       clock.Number,
+		blockHash:      clock.Id,
+		blockTimestamp: clock.Timestamp.AsTime(),
+		inserts:        into,
+	}
+
+	payload := holder.output.GetMapOutput().GetValue()
+	if len(payload) == 0 {
+		out.empty = true
+		return out, nil
+	}
+
+	unmarshalStartAt := time.Now()
+	message := dynamicpb.NewMessage(d.rootMessageDescriptor)
+	if err := proto.Unmarshal(payload, message); err != nil {
+		return nil, fmt.Errorf("unmarshaling message: %w", err)
+	}
+	out.unmarshalDuration = time.Since(unmarshalStartAt)
+
+	walkStartAt := time.Now()
+	if _, err := db.WalkMessageDescriptorAndInsertInto(message, out.blockNum, out.blockTimestamp, nil, into); err != nil {
+		return nil, fmt.Errorf("processing message %q: %w", string(message.Descriptor().FullName()), err)
+	}
+	out.walkDuration = time.Since(walkStartAt)
+
+	return out, nil
+}
+
+// apply performs the decoded inserts against the database, in block order. It runs on
+// the caller's goroutine, so the database sees exactly the sequence it would have seen
+// from a serial walk.
+func (d *decoder) apply(results []*decoded, db sql.Database) (time.Duration, error) {
+	insertDuration := time.Duration(0)
+
+	for _, result := range results {
+		if result.empty {
+			continue
+		}
+
+		startAt := time.Now()
+
+		if err := db.InsertBlock(result.blockNum, result.blockHash, result.blockTimestamp); err != nil {
+			return 0, fmt.Errorf("inserting block %d: %w", result.blockNum, err)
+		}
+		if err := result.inserts.Replay(db); err != nil {
+			return 0, fmt.Errorf("applying block %d: %w", result.blockNum, err)
+		}
+
+		insertDuration += time.Since(startAt)
+	}
+
+	return insertDuration, nil
+}

--- a/sink/sql/db_proto/sinker.go
+++ b/sink/sql/db_proto/sinker.go
@@ -3,7 +3,6 @@ package db_proto
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/streamingfast/logging/zapx"
@@ -12,37 +11,41 @@ import (
 	sql "github.com/streamingfast/substreams/sink/sql/db_proto/sql"
 	"github.com/streamingfast/substreams/sink/sql/db_proto/stats"
 	"go.uber.org/zap"
-	"google.golang.org/appengine"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/types/dynamicpb"
 )
 
 type Sinker struct {
 	*sink.Sinker
 	db                    sql.Database
 	useTransaction        bool
-	parallel              bool
 	blockBatchSize        uint64
 	stats                 *stats.Stats
 	logger                *zap.Logger
 	rootMessageDescriptor protoreflect.MessageDescriptor
 	useConstraints        bool
-	flushLock             sync.Mutex
 	lastAppliedBlockNum   uint64
 	lastAppliedBlockTime  time.Time
+
+	// holding buffers the blocks received since the last flush. It is only ever touched
+	// from the sinker's callbacks, which are called sequentially.
+	holding []*Holder
+
+	decoder *decoder
 }
 
-func NewSinker(rootMessageDescriptor protoreflect.MessageDescriptor, sink *sink.Sinker, db sql.Database, useTransaction bool, useConstraints bool, blockBatchSize int, parallel bool, stats *stats.Stats, logger *zap.Logger) *Sinker {
+// NewSinker builds the from-proto sinker. decodeWorkers bounds how many blocks are
+// unmarshalled and walked concurrently at flush time; zero picks one per core, less one,
+// capped at eight.
+func NewSinker(rootMessageDescriptor protoreflect.MessageDescriptor, sink *sink.Sinker, db sql.Database, useTransaction bool, useConstraints bool, blockBatchSize int, decodeWorkers int, stats *stats.Stats, logger *zap.Logger) *Sinker {
 	return &Sinker{
 		db:                    db,
 		rootMessageDescriptor: rootMessageDescriptor,
 		useTransaction:        useTransaction,
-		parallel:              parallel,
 		blockBatchSize:        uint64(blockBatchSize),
 		stats:                 stats,
 		Sinker:                sink,
 		logger:                logger,
+		decoder:               newDecoder(rootMessageDescriptor, decodeWorkers),
 	}
 }
 
@@ -82,8 +85,6 @@ type Holder struct {
 	cursor *sink.Cursor
 }
 
-var holding []*Holder
-
 func (s *Sinker) HandleBlockScopedData(ctx context.Context, data *pbsubstreamsrpc.BlockScopedData, isLive *bool, cursor *sink.Cursor) (err error) {
 	output := data.Output
 
@@ -118,7 +119,7 @@ func (s *Sinker) HandleBlockScopedData(ctx context.Context, data *pbsubstreamsrp
 		isLive: isLive,
 		cursor: cursor,
 	}
-	holding = append(holding, holder)
+	s.holding = append(s.holding, holder)
 	if data.Clock.Number > (s.lastAppliedBlockNum+s.blockBatchSize) || s.blockBatchSize == 1 || (isLive != nil && *isLive) {
 		if isLive != nil && *isLive && s.stats.FlushDuration.Average() > data.Clock.Timestamp.AsTime().Sub(s.lastAppliedBlockTime) {
 			s.logger.Debug("skipping a flush because we are LIVE and flush average duration is above time between blocks", zapx.HumanDuration("flush_duration_average", s.stats.FlushDuration.Average()), zap.Time("last_block_time", s.lastAppliedBlockTime), zap.Time("block_time", data.Clock.Timestamp.AsTime()))
@@ -139,70 +140,45 @@ func (s *Sinker) HandleBlockScopedData(ctx context.Context, data *pbsubstreamsrp
 // --block-batch-size larger than the range, that meant an empty database and a run that
 // looked successful.
 func (s *Sinker) HandleBlockRangeCompletion(ctx context.Context, cursor *sink.Cursor) error {
-	if len(holding) == 0 {
+	if len(s.holding) == 0 {
 		return nil
 	}
 
-	s.logger.Info("flushing blocks held at the end of the requested range", zap.Int("block_count", len(holding)))
+	s.logger.Info("flushing blocks held at the end of the requested range", zap.Int("block_count", len(s.holding)))
 
 	return s.flushHolding(cursor)
 }
 
 // flushHolding applies every held block, stores the cursor and commits.
 func (s *Sinker) flushHolding(cursor *sink.Cursor) (err error) {
-	if len(holding) == 0 {
+	if len(s.holding) == 0 {
 		return nil
 	}
 
-	lastClock := holding[len(holding)-1].data.Clock
+	lastClock := s.holding[len(s.holding)-1].data.Clock
 
-	if s.useTransaction && !s.parallel {
+	// Decode before opening the transaction: it touches no database state, and holding
+	// one open across the CPU-bound work would pin a connection for nothing.
+	decodedBlocks, err := s.decoder.decodeAll(s.holding, s.db)
+	if err != nil {
+		return fmt.Errorf("decoding blocks: %w", err)
+	}
+
+	if s.useTransaction {
 		if err := s.db.BeginTransaction(); err != nil {
 			return fmt.Errorf("begin tx: %w", err)
 		}
 	}
-	errs := appengine.MultiError{}
-	if s.parallel {
-		wg := sync.WaitGroup{}
-		wg.Add(len(holding))
 
-		for _, h := range holding {
-			go func() {
-				db := s.db.Clone()
-				err := db.BeginTransaction()
-				if err != nil {
-					errs = append(errs, err)
-				}
-
-				err = s.processHolder(h, s.stats)
-				if err != nil {
-					db.RollbackTransaction()
-					errs = append(errs, err)
-				}
-				err = db.CommitTransaction()
-				if err != nil {
-					errs = append(errs, err)
-				}
-				wg.Done()
-			}()
+	insertDuration, err := s.decoder.apply(decodedBlocks, s.db)
+	if err != nil {
+		if s.useTransaction {
+			s.logger.Error("rolling back transaction", zap.Error(err))
+			s.db.RollbackTransaction()
 		}
-		wg.Wait()
-		if len(errs) > 0 {
-			return fmt.Errorf("errors: %w", errs)
-		}
-
-	} else {
-		for _, h := range holding {
-			err = s.processHolder(h, s.stats)
-			if err != nil {
-				if s.useTransaction {
-					s.logger.Error("rolling back transaction", zap.Error(err))
-					s.db.RollbackTransaction()
-				}
-				return fmt.Errorf("process holder: %w", err)
-			}
-		}
+		return fmt.Errorf("applying blocks: %w", err)
 	}
+	s.recordDecodeStats(decodedBlocks, insertDuration)
 
 	flushDuration, err := s.db.Flush()
 	if err != nil {
@@ -210,8 +186,8 @@ func (s *Sinker) flushHolding(cursor *sink.Cursor) (err error) {
 	}
 
 	var flushDurationPerBlock time.Duration
-	if len(holding) > 0 {
-		flushDurationPerBlock = flushDuration / time.Duration(len(holding))
+	if len(s.holding) > 0 {
+		flushDurationPerBlock = flushDuration / time.Duration(len(s.holding))
 	}
 	s.stats.FlushDuration.Add(flushDurationPerBlock)
 
@@ -222,57 +198,27 @@ func (s *Sinker) flushHolding(cursor *sink.Cursor) (err error) {
 		return fmt.Errorf("inserting cursor: %w", err)
 	}
 
-	if s.useTransaction && !s.parallel {
+	if s.useTransaction {
 		if err := s.db.CommitTransaction(); err != nil {
 			return fmt.Errorf("commit tx: %w", err)
 		}
 	}
-	holding = []*Holder{}
+	s.holding = s.holding[:0]
 
 	return nil
 }
 
-func (s *Sinker) processHolder(h *Holder, stats *stats.Stats) (err error) {
-	if len(h.output.GetMapOutput().GetValue()) == 0 {
-		return nil
+// recordDecodeStats folds the per-block timings the workers measured back into the
+// shared stats, on this goroutine: Average.Add is not safe for concurrent use.
+func (s *Sinker) recordDecodeStats(results []*decoded, insertDuration time.Duration) {
+	for _, result := range results {
+		if result.empty {
+			continue
+		}
+		s.stats.UnmarshallingDuration.Add(result.unmarshalDuration)
+		s.stats.EntitiesInsertDuration.Add(result.walkDuration)
 	}
-
-	unmarshalStartAt := time.Now()
-	md := s.rootMessageDescriptor
-	dm := dynamicpb.NewMessage(md)
-	err = proto.Unmarshal(h.data.Output.GetMapOutput().GetValue(), dm)
-	if err != nil {
-		return fmt.Errorf("unmarshaling message: %w", err)
-	}
-
-	//protoscopeOutput := protoscope.Write(h.data.Output.GetMapOutput().GetValue(), protoscope.WriterOptions{})
-	//fmt.Printf("Proto Scope: %s\n", protoscopeOutput)
-
-	stats.UnmarshallingDuration.Add(time.Since(unmarshalStartAt))
-
-	err = processMessage(dm, s.db, h.data.Clock.Number, h.data.Clock.Id, h.data.Clock.Timestamp.AsTime(), stats)
-	if err != nil {
-		return fmt.Errorf("process entity: %w", err)
-	}
-
-	return nil
-}
-func processMessage(dm *dynamicpb.Message, database sql.Database, blockNum uint64, blockHash string, blockTimestamp time.Time, stats *stats.Stats) error {
-	startInsertBlock := time.Now()
-	err := database.InsertBlock(blockNum, blockHash, blockTimestamp)
-	if err != nil {
-		return fmt.Errorf("inserting block: %w", err)
-	}
-	stats.BlockInsertDuration.Add(time.Since(startInsertBlock))
-
-	sqlDuration, err := database.WalkMessageDescriptorAndInsert(dm, blockNum, blockTimestamp, nil)
-	if err != nil {
-		return fmt.Errorf("processing message %q: %w", string(dm.Descriptor().FullName()), err)
-	}
-
-	stats.EntitiesInsertDuration.Add(sqlDuration)
-
-	return nil
+	s.stats.BlockInsertDuration.Add(insertDuration)
 }
 
 func (s *Sinker) HandleBlockUndoSignal(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *sink.Cursor) (err error) {

--- a/sink/sql/db_proto/sinker_factory.go
+++ b/sink/sql/db_proto/sinker_factory.go
@@ -25,9 +25,11 @@ type SinkerFactoryOptions struct {
 	UseConstraints  bool
 	UseTransactions bool
 	BlockBatchSize  int
-	Parallel        bool
-	Encoding        bytes.Encoding
-	Clickhouse      SinkerFactoryClickhouse
+	// DecodeWorkers bounds how many blocks are unmarshalled and walked concurrently at
+	// flush time. Zero picks one per core, less one.
+	DecodeWorkers int
+	Encoding      bytes.Encoding
+	Clickhouse    SinkerFactoryClickhouse
 }
 
 type SinkerFactoryClickhouse struct {
@@ -72,7 +74,7 @@ func SinkerFactory(
 			options.UseTransactions,
 			options.UseConstraints,
 			options.BlockBatchSize,
-			options.Parallel,
+			options.DecodeWorkers,
 			stats2.NewStats(logger),
 			logger,
 		), nil

--- a/sink/sql/db_proto/sql/buffered_inserter.go
+++ b/sink/sql/db_proto/sql/buffered_inserter.go
@@ -1,0 +1,49 @@
+package sql
+
+import "fmt"
+
+// BufferedInserter records the inserts a message walk produces instead of performing
+// them, so the walk can run off the goroutine that owns the database.
+//
+// It is not safe for concurrent use: each worker owns one. Replay puts the recorded
+// inserts back in the exact order the walk produced them, which is what keeps a
+// parent row ahead of its children.
+type BufferedInserter struct {
+	ops []bufferedOp
+}
+
+type bufferedOp struct {
+	table  string
+	values []any
+}
+
+// NewBufferedInserter returns a buffer sized for roughly the given number of rows.
+func NewBufferedInserter(expectedRows int) *BufferedInserter {
+	return &BufferedInserter{ops: make([]bufferedOp, 0, expectedRows)}
+}
+
+func (b *BufferedInserter) Insert(table string, values []any) error {
+	b.ops = append(b.ops, bufferedOp{table: table, values: values})
+
+	return nil
+}
+
+// Rows returns how many inserts are buffered.
+func (b *BufferedInserter) Rows() int { return len(b.ops) }
+
+// Replay performs the buffered inserts against target, in order.
+func (b *BufferedInserter) Replay(target Inserter) error {
+	for _, op := range b.ops {
+		if err := target.Insert(op.table, op.values); err != nil {
+			return fmt.Errorf("inserting buffered row into %q: %w", op.table, err)
+		}
+	}
+
+	return nil
+}
+
+// Reset drops the buffered inserts, keeping the backing array for reuse.
+func (b *BufferedInserter) Reset() {
+	clear(b.ops)
+	b.ops = b.ops[:0]
+}

--- a/sink/sql/db_proto/sql/click_house/accumulator_inserter.go
+++ b/sink/sql/db_proto/sql/click_house/accumulator_inserter.go
@@ -194,7 +194,9 @@ func (i *AccumulatorInserter) insert(table string, values []any) error {
 	if accumulator == nil {
 		return fmt.Errorf("accumulator not found for table %q", table)
 	}
-	i.logger.Debug("inserting", zap.String("table", table), zap.Int("values", len(values)))
+	if ce := i.logger.Check(zap.DebugLevel, "inserting"); ce != nil {
+		ce.Write(zap.String("table", table), zap.Int("values", len(values)))
+	}
 
 	for idx, value := range values {
 		column, found := accumulator.columns[idx]

--- a/sink/sql/db_proto/sql/click_house/database.go
+++ b/sink/sql/db_proto/sql/click_house/database.go
@@ -226,6 +226,10 @@ func (d *Database) WalkMessageDescriptorAndInsert(dm *dynamicpb.Message, blockNu
 	return d.BaseDatabase.WalkMessageDescriptorAndInsertWithDialect(dm, blockNum, blockTimestamp, parent, d.dialect, d)
 }
 
+func (d *Database) WalkMessageDescriptorAndInsertInto(dm *dynamicpb.Message, blockNum uint64, blockTimestamp time.Time, parent *sql.Parent, inserter sql.Inserter) (time.Duration, error) {
+	return d.BaseDatabase.WalkMessageDescriptorAndInsertWithDialect(dm, blockNum, blockTimestamp, parent, d.dialect, inserter)
+}
+
 func (d *Database) BeginTransaction() error {
 	return nil
 }
@@ -476,12 +480,6 @@ func (d *Database) HandleBlocksUndo(lastValidBlockNum uint64) error {
 	}
 
 	return nil
-}
-
-func (d *Database) Clone() sql.Database {
-	base := d.BaseClone()
-	d.BaseDatabase = base
-	return d
 }
 
 func (d *Database) DatabaseHash(schemaName string) (uint64, error) {

--- a/sink/sql/db_proto/sql/database.go
+++ b/sink/sql/db_proto/sql/database.go
@@ -16,12 +16,20 @@ import (
 )
 
 type Database interface {
+	// Inserter: both implementations already pass themselves as the inserter for a
+	// walk, this states it.
+	Inserter
+
 	FetchSinkInfo(schemaName string) (*SinkInfo, error)
 	UpdateSinkInfoHash(schemaName string, newHash string) error
 	StoreSinkInfo(schemaName string, schemaHash string) error
 
 	CreateDatabase(useConstraints bool) error
 	WalkMessageDescriptorAndInsert(dm *dynamicpb.Message, blockNum uint64, blockTimestamp time.Time, parent *Parent) (time.Duration, error)
+	// WalkMessageDescriptorAndInsertInto is the same walk, against a caller-supplied
+	// inserter. It touches no database state, so it is safe to call concurrently with
+	// a BufferedInserter per goroutine.
+	WalkMessageDescriptorAndInsertInto(dm *dynamicpb.Message, blockNum uint64, blockTimestamp time.Time, parent *Parent, inserter Inserter) (time.Duration, error)
 	InsertBlock(blockNum uint64, hash string, timestamp time.Time) error
 
 	HandleBlocksUndo(lastValidBlockNumber uint64) error
@@ -38,7 +46,6 @@ type Database interface {
 
 	GetDialect() Dialect
 
-	Clone() Database
 	Open() error
 }
 
@@ -60,15 +67,6 @@ func NewBaseDatabase(moduleOutputType string, rootMessageDescriptor protoreflect
 		insertStatements:      make(map[string]*sql.Stmt),
 		useProtoOptions:       useProtoOptions,
 	}, nil
-}
-
-func (d *BaseDatabase) BaseClone() *BaseDatabase {
-	return &BaseDatabase{
-		logger:                d.logger,
-		mapOutputType:         d.mapOutputType,
-		RootMessageDescriptor: d.RootMessageDescriptor,
-		insertStatements:      d.insertStatements,
-	}
 }
 
 type Parent struct {
@@ -105,7 +103,11 @@ func (d *BaseDatabase) WalkMessageDescriptorAndInsertWithDialect(dm *dynamicpb.M
 		}
 	}
 
-	d.logger.Debug("Walking message descriptor", zap.String("message_descriptor_name", string(md.Name())), zap.Any("table_info", tableInfo))
+	// Guarded: this runs once per message, and zap.Any on the table info allocates
+	// whether or not debug logging is enabled.
+	if ce := d.logger.Check(zap.DebugLevel, "walking message descriptor"); ce != nil {
+		ce.Write(zap.String("message_descriptor_name", string(md.Name())), zap.Any("table_info", tableInfo))
+	}
 	primaryKey := ""
 	if tableInfo != nil {
 		if table := dialect.GetTable(tableInfo.Name); table != nil {

--- a/sink/sql/db_proto/sql/postgres/database.go
+++ b/sink/sql/db_proto/sql/postgres/database.go
@@ -192,6 +192,10 @@ func (d *Database) WalkMessageDescriptorAndInsert(dm *dynamicpb.Message, blockNu
 	return d.WalkMessageDescriptorAndInsertWithDialect(dm, blockNum, blockTimestamp, parent, d.dialect, d)
 }
 
+func (d *Database) WalkMessageDescriptorAndInsertInto(dm *dynamicpb.Message, blockNum uint64, blockTimestamp time.Time, parent *sql.Parent, inserter sql.Inserter) (time.Duration, error) {
+	return d.WalkMessageDescriptorAndInsertWithDialect(dm, blockNum, blockTimestamp, parent, d.dialect, inserter)
+}
+
 func (d *Database) InsertBlock(blockNum uint64, hash string, timestamp time.Time) error {
 	d.logger.Debug("inserting _blocks_", zap.Uint64("block_num", blockNum), zap.String("block_hash", hash))
 	err := d.inserter.insert("_blocks_", []any{blockNum, hash, timestamp}, d)
@@ -307,12 +311,6 @@ func (d *Database) HandleBlocksUndo(lastValidBlockNum uint64) (err error) {
 	d.logger.Info("undo completed", zap.Int64("row_affected", rowsAffected))
 
 	return nil
-}
-
-func (d *Database) Clone() sql.Database {
-	base := d.BaseClone()
-	d.BaseDatabase = base
-	return d
 }
 
 func (d *Database) DatabaseHash(schemaName string) (uint64, error) {

--- a/sink/sql/db_proto/sql/postgres/row_inserter.go
+++ b/sink/sql/db_proto/sql/postgres/row_inserter.go
@@ -132,7 +132,11 @@ func createInsertFromDescriptor(table *schema.Table, dialect sql2.Dialect) (stri
 }
 
 func (i *RowInserter) insert(table string, values []any, database *Database) error {
-	i.logger.Debug("inserting row", zap.String("table", table), zap.Any("values", values))
+	// Guarded: this runs once per row, and zap.Any on the value slice allocates
+	// whether or not debug logging is enabled.
+	if ce := i.logger.Check(zap.DebugLevel, "inserting row"); ce != nil {
+		ce.Write(zap.String("table", table), zap.Any("values", values))
+	}
 	stmt := i.insertStatements[table]
 	stmt = database.wrapInsertStatement(stmt)
 

--- a/sink/sql/tests/integration/db_proto_clickhouse_test.go
+++ b/sink/sql/tests/integration/db_proto_clickhouse_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/jmoiron/sqlx"
 	"github.com/streamingfast/bstream"
+	"github.com/streamingfast/substreams/manifest"
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 	sink "github.com/streamingfast/substreams/sink"
 	"github.com/streamingfast/substreams/sink/sql/db_proto"
 	pbrelations "github.com/streamingfast/substreams/sink/sql/tests/relations"
-	"github.com/streamingfast/substreams/manifest"
-	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/modules/clickhouse"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -142,7 +142,6 @@ func TestDbProtoClickhouseIntegration(t *testing.T) {
 				UseConstraints:  false,
 				UseTransactions: true,
 				BlockBatchSize:  1,
-				Parallel:        false,
 				Clickhouse: db_proto.SinkerFactoryClickhouse{
 					SinkInfoFolder: clickhouseStateFolder,
 					CursorFilePath: filepath.Join(clickhouseStateFolder, "cursor.txt"),

--- a/sink/sql/tests/integration/db_proto_postgres_bytes_test.go
+++ b/sink/sql/tests/integration/db_proto_postgres_bytes_test.go
@@ -113,7 +113,6 @@ func runBytesSinker(t *testing.T, schema string, useConstraints bool, payload []
 		UseConstraints:  useConstraints,
 		UseTransactions: true,
 		BlockBatchSize:  1,
-		Parallel:        false,
 		Encoding:        sqlbytes.EncodingRaw,
 	}.Defaults()
 	options.Encoding = sqlbytes.EncodingRaw

--- a/sink/sql/tests/integration/db_proto_postgres_decode_workers_test.go
+++ b/sink/sql/tests/integration/db_proto_postgres_decode_workers_test.go
@@ -1,0 +1,165 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+	"github.com/streamingfast/bstream"
+	"github.com/streamingfast/substreams/manifest"
+	sink "github.com/streamingfast/substreams/sink"
+	"github.com/streamingfast/substreams/sink/sql/db_proto"
+	pbrelations "github.com/streamingfast/substreams/sink/sql/tests/relations"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDbProtoPostgresDecodeWorkers asserts that decoding blocks concurrently produces
+// exactly the same database as decoding them one at a time.
+//
+// The workers unmarshal and walk in parallel but only fill a per-block buffer; the
+// inserts are replayed in block order on the flush goroutine. That ordering is what
+// keeps a parent row ahead of the children that reference it, so a divergence between
+// one worker and many is the failure this test exists to catch.
+func TestDbProtoPostgresDecodeWorkers(t *testing.T) {
+	// blockBatchSize 3 over blocks 1..8 flushes twice, four blocks at a time, so the
+	// pool actually has work to spread.
+	const blockBatchSize = 3
+
+	serial := runDecodeWorkersSinker(t, "decode_workers_serial", 1, blockBatchSize)
+	defer serial.Close()
+
+	parallel := runDecodeWorkersSinker(t, "decode_workers_parallel", 8, blockBatchSize)
+	defer parallel.Close()
+
+	for _, table := range []string{"customers", "orders", "order_items", "order_extensions", "_blocks_"} {
+		serialRows := dumpTable(t, serial, "decode_workers_serial", table)
+		parallelRows := dumpTable(t, parallel, "decode_workers_parallel", table)
+
+		require.NotEmpty(t, serialRows, "table %q came out empty, the test would prove nothing", table)
+		require.Equal(t, serialRows, parallelRows,
+			"table %q differs between 1 and 8 decode workers", table)
+	}
+
+	// The comparison above is differential, so it cannot see an ordering mistake that
+	// both runs share. Assert the absolute order too: blocks must reach the database
+	// ascending, whatever order the workers happened to finish in.
+	for _, schema := range []string{"decode_workers_serial", "decode_workers_parallel"} {
+		dbx := serial
+		if schema == "decode_workers_parallel" {
+			dbx = parallel
+		}
+
+		blocks := dumpTable(t, dbx, schema, "_blocks_")
+		require.Len(t, blocks, 8)
+		for i, line := range blocks {
+			require.Contains(t, line, fmt.Sprintf("number=%d|", i+1),
+				"%s._blocks_ row %d is out of order: %s", schema, i, line)
+		}
+	}
+}
+
+// dumpTable renders a whole table as text, in physical row order, so two databases can
+// be compared without knowing the column types.
+//
+// Ordering by ctid is what makes this test able to see the replay order at all: the row
+// *values* here do not depend on insert order, so comparing the tables as sets would
+// pass even if the blocks were applied backwards. These tables are only ever appended
+// to within a transaction, so ctid order is insert order.
+func dumpTable(t *testing.T, dbx *sqlx.DB, schema, table string) []string {
+	t.Helper()
+
+	rows, err := dbx.Query(fmt.Sprintf(`SELECT * FROM %q.%q ORDER BY ctid`, schema, table))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	require.NoError(t, err)
+
+	var out []string
+	for rows.Next() {
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		require.NoError(t, rows.Scan(pointers...))
+
+		line := ""
+		for i, v := range values {
+			line += fmt.Sprintf("%s=%v|", columns[i], v)
+		}
+		out = append(out, line)
+	}
+	require.NoError(t, rows.Err())
+
+	return out
+}
+
+func runDecodeWorkersSinker(t *testing.T, schema string, decodeWorkers, blockBatchSize int) *sqlx.DB {
+	t.Helper()
+
+	outputMessageDescriptor := (*pbrelations.Output)(nil).ProtoReflect().Descriptor()
+	postgresContainer := sharedDbChangesPostgresContainer
+
+	responses := make([]any, 0, 8)
+	for block := 1; block <= 8; block++ {
+		responses = append(responses, relationsBlockData(t,
+			fmt.Sprintf("%da", block), "2025-01-01",
+			entityCustomer(fmt.Sprintf("cust-%d", block), fmt.Sprintf("Customer %d", block)),
+			entityOrder(
+				fmt.Sprintf("order-%d", block),
+				fmt.Sprintf("cust-%d", block),
+				orderExtension(fmt.Sprintf("extension for order %d", block)),
+				orderItem(fmt.Sprintf("item-%d-a", block), int64(block)),
+				orderItem(fmt.Sprintf("item-%d-b", block), int64(block*2)),
+			),
+			entityItem(fmt.Sprintf("item-%d", block), fmt.Sprintf("Item %d", block), float64(block)*1.5),
+		))
+	}
+
+	substreamsClientConfig := setupFakeSubstreamsServer(t, responses...)
+	substreamsPackage := substreamsTestPackage(pbrelations.File_test_relations_relations_proto, outputMessageDescriptor)
+
+	baseSink, err := sink.New(
+		sink.SubstreamsModeProduction,
+		false,
+		substreamsPackage,
+		substreamsPackage.Modules.Modules[0],
+		manifest.ModuleHash{},
+		substreamsClientConfig,
+		logger,
+		tracer,
+		sink.WithBlockRange(bstream.MustParseRange("1-9", bstream.WithExclusiveEnd())),
+		sink.WithRetryBackOff(&backoff.StopBackOff{}),
+	)
+	require.NoError(t, err)
+
+	options := db_proto.SinkerFactoryOptions{
+		UseProtoOption:  true,
+		UseConstraints:  false,
+		UseTransactions: true,
+		BlockBatchSize:  blockBatchSize,
+		DecodeWorkers:   decodeWorkers,
+	}.Defaults()
+	options.DecodeWorkers = decodeWorkers
+	options.BlockBatchSize = blockBatchSize
+
+	createPostgresTestSchema(t, postgresContainer.ConnectionString, schema)
+
+	ctx := context.Background()
+	dbSinker, err := db_proto.SinkerFactory(baseSink, defaultOutputModuleName, outputMessageDescriptor, options)(
+		ctx, postgresContainer.ConnectionString, schema, logger, tracer)
+	require.NoError(t, err)
+
+	require.NoError(t, dbSinker.Run(ctx))
+	require.NoError(t, dbSinker.Err())
+
+	db, err := sql.Open("postgres", postgresContainer.ConnectionString)
+	require.NoError(t, err)
+
+	return sqlx.NewDb(db, "postgres").Unsafe()
+}

--- a/sink/sql/tests/integration/db_proto_postgres_test.go
+++ b/sink/sql/tests/integration/db_proto_postgres_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"github.com/streamingfast/bstream"
+	"github.com/streamingfast/substreams/manifest"
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 	sink "github.com/streamingfast/substreams/sink"
 	"github.com/streamingfast/substreams/sink/sql/db_proto"
 	pbrelations "github.com/streamingfast/substreams/sink/sql/tests/relations"
-	"github.com/streamingfast/substreams/manifest"
-	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,7 +95,6 @@ func TestDbProtoPostgresIntegration(t *testing.T) {
 				UseConstraints:  false,
 				UseTransactions: true,
 				BlockBatchSize:  1,
-				Parallel:        false,
 			}.Defaults()
 
 			sinkerFactory := db_proto.SinkerFactory(


### PR DESCRIPTION
### The sink, not PostgreSQL, was the bottleneck

Unmarshalling into `dynamicpb` and walking the message descriptor is where the from-proto sink spends its time, and it ran on the goroutine draining the stream. Measured with no database involved at all:

| stage | narrow entity (2 cols) | wide entity (60+ cols) |
|---|--:|--:|
| unmarshal only | 1.79M rows/s | 203k rows/s |
| + walk | 855k rows/s | 128k rows/s |
| + encode | 745k rows/s | **96k rows/s** |

Binary COPY absorbs ~800k rows/s, so for wide entities PostgreSQL had roughly eight times the headroom the single-threaded handler could reach.

### What this does

Blocks are independent, so decode now runs on a worker pool. Each worker fills a `BufferedInserter`; the flush goroutine replays them **in block order**, inside the same transaction as before, so the database sees exactly the sequence a serial walk produced. Decoding happens before the transaction opens, since it touches no database state and would otherwise pin a connection for the CPU-bound work.

Scaling on a 16-core machine:

| workers | rows/s | speedup |
|--:|--:|--:|
| 1 | 129k | 1.00x |
| 8 | 534k | **4.13x** |
| 15 | 548k | 4.24x |

Flat past eight — the work is allocator-bound before it runs out of cores — so the default is one per core less one, **capped at eight**. `DecodeWorkers` overrides it.

### It replaces an unsound path rather than adding to one

`SinkerFactoryOptions.Parallel` was hardcoded `false` at every call site, so the existing parallel path was unreachable. Had it run it was unsound: `Database.Clone()` overwrote the receiver's embedded struct and returned the receiver, so every goroutine shared one `*sql.Tx` and raced on it through `BeginTransaction`/`CommitTransaction`, the clone was not used for the inserts anyway, and errors were appended to a shared `appengine.MultiError` without a lock. `Clone()` goes with it, along with the `google.golang.org/appengine` import that only existed to carry that error slice, and `holding` moves from a package-level global into `Sinker`.

Also puts the zap debug fields on the walk behind `Check`. zap builds its `Field` arguments whether or not the level is enabled, so `zap.Any` on a table info struct and on every row's value slice allocated on every call — worth ~6% on a narrow entity.

### Tests

`TestDbProtoPostgresDecodeWorkers` runs the same eight-block stream through one worker and through eight and compares the tables in physical row order, plus an absolute check that blocks land ascending — a differential test alone cannot see an ordering mistake both runs share. Verified to fail when the replay order is reversed.

