### PR TITLE
chore: bump firehose-networks to v0.2.3 (Hoodi StreamingFast endpoints)

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- CLI: the Ethereum Hoodi testnet (`hoodi`) now resolves to StreamingFast endpoints (`hoodi.eth.streamingfast.io:443`), so `network: hoodi` in a manifest streams without an explicit `--endpoint`. Comes from bumping `firehose-networks` to `v0.2.3`, which overrides the upstream Graph networks registry entry — listing only Pinax endpoints — with the StreamingFast ones.
+
 ### Fixed
 
 - Server: `substreams-tier1` now restarts when its block hub can no longer link incoming live blocks, instead of hanging every request at a frozen head indefinitely. A live-source gap whose one-block files were already merged away can never be linked, and the head-block metrics keep tracking the live source, so the process looked healthy throughout.

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/streamingfast/dsession v0.0.0-20251029144057-b94d1030e142
 	github.com/streamingfast/dummy-blockchain v1.7.7
 	github.com/streamingfast/firehose-ethereum/types v0.0.0-20251113151010-c9c94d64348a
-	github.com/streamingfast/firehose-networks v0.2.2
+	github.com/streamingfast/firehose-networks v0.2.3
 	github.com/streamingfast/services-control-plane v0.0.0-20260619122356-7b2e68aea813
 	github.com/streamingfast/sf-tracing v0.0.0-20251218140752-bafd5572499f
 	github.com/streamingfast/shutter v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/streamingfast/dummy-blockchain v1.7.7 h1:9IZk0zmkeqHirSIRSNtbxrl5kRzy
 github.com/streamingfast/dummy-blockchain v1.7.7/go.mod h1:EP8X3OwOoGYjJfzhw+zD1A0GTNSDg+v1OKDwSTDhHyc=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20251113151010-c9c94d64348a h1:qatil0YhFzTVAFQnH7iMcq+gpVUNEs9Se3lLq4eaof8=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20251113151010-c9c94d64348a/go.mod h1:CG22ObinxSbKIP19bAj0uro0a290kzZTiBbjL8VR0SE=
-github.com/streamingfast/firehose-networks v0.2.2 h1:araNCSHVa9C8+7hGrxNJYt8TlbK65kNDxQMBJuzBjxA=
-github.com/streamingfast/firehose-networks v0.2.2/go.mod h1:/XyroRcAUOO9DdxdgHktuVI1U6uKgjj6+1r+zgLEb90=
+github.com/streamingfast/firehose-networks v0.2.3 h1:kFqhWlp5QtkKW9kezee0cqVjZlChEMGqlkrHK+mtj38=
+github.com/streamingfast/firehose-networks v0.2.3/go.mod h1:/XyroRcAUOO9DdxdgHktuVI1U6uKgjj6+1r+zgLEb90=
 github.com/streamingfast/graph v0.0.0-20220329181048-a5710712d873 h1:8+TXT26c2p6f8JMg0w4JQ8t4fAbfMmR11zLN4KFVRC8=
 github.com/streamingfast/graph v0.0.0-20220329181048-a5710712d873/go.mod h1:M7l9klD6EPgXwPOrhzQrLLKZHZSNTt4nm+GDRFNbQdc=
 github.com/streamingfast/logging v0.0.0-20210811175431-f3b44b61606a/go.mod h1:4GdqELhZOXj4xwc4IaBmzofzdErGynnaSzuzxy0ZIBo=

--- a/go.work.sum
+++ b/go.work.sum
@@ -742,6 +742,7 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/btcsuite/btcd/btcec/v2 v2.3.5/go.mod h1:m22FrOAiuxl/tht9wIqAoGHcbnCCaPWyauO8y2LGGtQ=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -1533,6 +1534,7 @@ go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
Bumps `github.com/streamingfast/firehose-networks` from `v0.2.2` to [`v0.2.3`](https://github.com/streamingfast/firehose-networks/releases/tag/v0.2.3).

## What this brings

v0.2.3 adds StreamingFast Firehose and Substreams endpoints for the Ethereum Hoodi testnet (`hoodi`, caip2 `eip155:560048`). The upstream Graph networks registry lists Hoodi with Pinax endpoints only, so it introduces a "service overrides" mechanism that merges extra endpoints into networks already present upstream — overridden endpoints take precedence and duplicates are dropped.

## Impact here

None beyond the dependency: the change is additive and backward compatible, and **no code change was required**. The diff is `go.mod` / `go.sum` / `go.work.sum` plus the change log.

The registry consumers in this repo (`manifest.ExtractNetworkEndpoint`, `codegen`, `client`, `sink.InferBytesRepresentation`, `substreams tools default-endpoint`) all go through `networks.GetSubstreamsEndpoint` / `GetSubstreamsRegistry` and pick the new entry up for free. There is no leftover local copy of the network registry in this repo — the `sepolia` hits under `manifest/` are manifest `networks:` params, unrelated to endpoint resolution.

## Verification

```
$ substreams tools default-endpoint hoodi
hoodi.eth.streamingfast.io:443

$ substreams tools default-endpoint mainnet
mainnet.eth.streamingfast.io:443
```

`go test ./...` passes fully, both before and after the bump (no pre-existing failures), and `go build ./...` succeeds.

Note: looking up a network by its caip2 id (`eip155:560048`) still returns no endpoint, but that is not a regression — `eip155:1` behaves the same way on `v0.2.2`. Lookups are by network label and alias.