### PR TITLE
Keep `substreams run` stdout to module data only

### DIFF
--- a/cmd/substreams/run.go
+++ b/cmd/substreams/run.go
@@ -160,7 +160,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	ctx, cancelCause := context.WithCancelCause(ctx)
 	go func() {
 		s := <-derr.SetupSignalHandler(0)
-		fmt.Println("received", s.String())
+		fmt.Fprintln(os.Stderr, "received", s.String())
 		cancelCause(fmt.Errorf("received signal %q", s.String()))
 	}()
 
@@ -188,7 +188,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
-		fmt.Println("Completed successfully")
+		fmt.Fprintln(os.Stderr, "Completed successfully")
 		return nil
 	}
 

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -173,6 +173,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   block, stage count and cached-blocks summary the non-TTY output has always shown — the line was guarded on a field
   nothing ever set and rendered as blank lines.
 
+- Fixed: `substreams run` wrote human-readable messages to standard output, so its output could not be piped into `jq`
+  or any other consumer without filtering. The `Completed successfully` line, the signal-received notice, the
+  `cursor`/`clock` output mode banners, the message-wrapping error and the `.substreams.env` loader messages now go to
+  standard error, leaving only the module data on standard output. Scripts detecting success by grepping stdout for
+  `Completed successfully` must check the exit code instead.
+
 - Added Ethereum Hoodi testnet (`hoodi`) StreamingFast endpoints (`hoodi.eth.streamingfast.io:443`).
 
 ### Server

--- a/sink/utils.go
+++ b/sink/utils.go
@@ -127,19 +127,19 @@ func LoadSubstreamsAuthEnvFile(manifestPath string) {
 				if os.IsNotExist(err) {
 					return
 				} else {
-					fmt.Printf("Error reading stats on auth file: %v: %s\n", authFile, err.Error())
+					fmt.Fprintf(os.Stderr, "Error reading stats on auth file: %v: %s\n", authFile, err.Error())
 					return
 				}
 			}
 		} else {
-			fmt.Printf("Error reading stats on auth file: %v: %s\n", authFile, err.Error())
+			fmt.Fprintf(os.Stderr, "Error reading stats on auth file: %v: %s\n", authFile, err.Error())
 			return
 		}
 	}
 
 	cnt, err := os.ReadFile(authFile)
 	if err != nil {
-		fmt.Printf("Error reading auth file: %v: %s\n", authFile, err.Error())
+		fmt.Fprintf(os.Stderr, "Error reading auth file: %v: %s\n", authFile, err.Error())
 		return
 	}
 
@@ -154,7 +154,7 @@ func LoadSubstreamsAuthEnvFile(manifestPath string) {
 		if len(parts) == 2 {
 			key := strings.TrimSpace(parts[0])
 			value := strings.TrimSpace(parts[1])
-			fmt.Printf("Reading %s from %s\n", key, authFile)
+			fmt.Fprintf(os.Stderr, "Reading %s from %s\n", key, authFile)
 			os.Setenv(key, value)
 		}
 	}

--- a/tui/print.go
+++ b/tui/print.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -156,7 +157,7 @@ func (ui *TUI) jsonBlockScopedData(
 
 			wrappedCnt, err := ui.decoder.WrapMessage(msgType, clock.Number, out.Name, dataContent, partialIndex, lastPartial)
 			if err != nil {
-				fmt.Printf("Error wrapping message: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Error wrapping message: %v\n", err)
 			} else {
 				cnt := ui.prettyFormat(wrappedCnt, true)
 				fmt.Println(string(cnt))

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -153,9 +153,9 @@ func (ui *TUI) configureOutputMode(outputMode string) error {
 		ui.prettyPrintOutput = true
 	case OutputModeJSONL:
 	case OutputModeCURSOR:
-		fmt.Println("printing cursor only, no data")
+		fmt.Fprintln(os.Stderr, "printing cursor only, no data")
 	case OutputModeCLOCK:
-		fmt.Println("Writing clock information only (no data)")
+		fmt.Fprintln(os.Stderr, "Writing clock information only (no data)")
 	case OutputModeJSON:
 		ui.prettyPrintOutput = true
 	default:


### PR DESCRIPTION
`substreams run` mixed human-readable status lines into standard output, so piping its JSON into `jq` or any other consumer broke on the first non-JSON line. The most visible one was the `Completed successfully` trailer printed after the last block.

All informational and diagnostic output from the run path now goes to standard error, leaving standard output carrying nothing but module data:

- `Completed successfully` and the `received <signal>` notice on shutdown.
- The `cursor` and `clock` output-mode banners, which polluted the very streams those modes exist to produce.
- The `Error wrapping message` diagnostic emitted while formatting JSON output.
- The `.substreams.env` loader messages (`Reading SUBSTREAMS_API_TOKEN from ...` and its read errors), which fire on every invocation when the file exists.

The `.substreams.env` messages live in the shared `sink` package, so this also affects the sink CLIs that load auth the same way — stderr is the correct stream for them too.

Scripts that grep stdout for `Completed successfully` to detect success will stop matching; they should check the exit code, or read stderr.

Verified: an invocation in a directory holding a `.substreams.env` now produces an empty stdout, with the auth line on stderr. The `Completed successfully` path itself was not exercised end-to-end — that needs a live endpoint and an API token, which this environment does not have.
