### PR TITLE
Retrieve API key via browser in substreams auth

### DIFF
--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -11,7 +11,7 @@ This document lists all environment variables used by the Substreams project, or
 - **Purpose**: Indicates if running in local development mode
 - **Usage**: Set to "true" to use localhost URLs instead of production URLs
 - **Default**: `false` (device login talks to `https://admin.streamingfast.io`; `--paste` uses `https://thegraph.market`)
-- **Local values**: device login talks to `http://localhost:9000`; `--paste` uses `http://localhost:3000`
+- **Local values**: device login talks to `http://localhost:9000`; `--paste` uses `http://localhost:3000`. JWT issue uses `http://localhost:8080` (see `SUBSTREAMS_AUTH_ISSUE_URL`); if that issuer is unavailable the API key is stored instead of failing.
 - **Location**: `cmd/substreams/auth.go`
 
 #### `SUBSTREAMS_PORTAL_API`

--- a/ENVIRONMENT_VARIABLES.md
+++ b/ENVIRONMENT_VARIABLES.md
@@ -10,7 +10,22 @@ This document lists all environment variables used by the Substreams project, or
 **Development environment indicator**
 - **Purpose**: Indicates if running in local development mode
 - **Usage**: Set to "true" to use localhost URLs instead of production URLs
-- **Default**: `false` (uses production URLs: https://thegraph.market/auth/substreams-devenv)
+- **Default**: `false` (device login talks to `https://admin.streamingfast.io`; `--paste` uses `https://thegraph.market`)
+- **Local values**: device login talks to `http://localhost:9000`; `--paste` uses `http://localhost:3000`
+- **Location**: `cmd/substreams/auth.go`
+
+#### `SUBSTREAMS_PORTAL_API`
+**Portal API base URL override**
+- **Purpose**: Override the Portal API used by `substreams auth` browser login
+- **Usage**: Full base URL, e.g. `http://localhost:9000`
+- **Default**: `https://admin.streamingfast.io` (or `http://localhost:9000` when `LOCAL_DEVELOPMENT=true`)
+- **Location**: `cmd/substreams/auth.go`
+
+#### `SUBSTREAMS_AUTH_ISSUE_URL`
+**JWT issue base URL override**
+- **Purpose**: Override the `/v1/auth/issue` host used to exchange a `server_` API key for a JWT
+- **Usage**: Full base URL, e.g. `http://localhost:8080`
+- **Default**: `https://auth.thegraph.market` (or `http://localhost:8080` when `LOCAL_DEVELOPMENT=true`)
 - **Location**: `cmd/substreams/auth.go`
 
 ### `substreams registry` Commands

--- a/cmd/substreams/auth.go
+++ b/cmd/substreams/auth.go
@@ -8,33 +8,76 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/cli"
+	"github.com/streamingfast/cli/sflags"
+)
+
+const (
+	defaultPortalAPIURL = "https://admin.streamingfast.io"
+	localPortalAPIURL   = "http://localhost:9000"
+	defaultAuthBaseURL  = "https://auth.thegraph.market"
+	localAuthBaseURL    = "http://localhost:8080"
+	defaultMarketURL    = "https://thegraph.market"
+	localMarketURL      = "http://localhost:3000"
+	deviceClientName    = "substreams CLI"
+	authEnvFilename     = ".substreams.env"
 )
 
 var authCmd = &cobra.Command{
-	Use:          "auth",
-	Short:        "Login command for Substreams development",
+	Use:   "auth",
+	Short: "Login for Substreams development",
+	Long: `Login to The Graph Market and retrieve an API key without copy/paste.
+
+The command opens a browser so you can pick an organization (if you have more
+than one) and an API key. The selected key is fetched over the API, exchanged
+for a JWT, and written to .substreams.env.
+
+Use --paste to enter a JWT or API key yourself.`,
 	RunE:         runAuthE,
 	SilenceUsage: true,
 }
 
 func init() {
+	authCmd.Flags().Bool("paste", false, "Paste a JWT or API key instead of picking one in the browser")
 	rootCmd.AddCommand(authCmd)
 }
 
 func runAuthE(cmd *cobra.Command, args []string) error {
-	localDevelopment := os.Getenv("LOCAL_DEVELOPMENT")
+	if sflags.MustGetBool(cmd, "paste") {
+		creds, err := runPasteAuth()
+		if err != nil {
+			return err
+		}
+		return writeAuthCredentials(creds)
+	}
 
-	baseURL := "https://thegraph.market"
-	authBaseURL := "https://auth.thegraph.market"
+	key, err := runCliAPIKeyAuth(cmd.Context(), newPortalClient(portalAPIBaseURL()), os.Stdout, tryOpenURL)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return fmt.Errorf("login cancelled")
+		}
+		return err
+	}
 
-	if localDevelopment == "true" {
-		baseURL = "http://localhost:3000"
+	creds, err := resolveCredentials(key)
+	if err != nil {
+		return err
+	}
+	return writeAuthCredentials(creds)
+}
+
+func runPasteAuth() (authCredentials, error) {
+	baseURL := defaultMarketURL
+	if os.Getenv("LOCAL_DEVELOPMENT") == "true" {
+		baseURL = localMarketURL
 	}
 
 	signupURL := baseURL + "/auth/signup"
@@ -46,7 +89,7 @@ func runAuthE(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Println("If you already have an account, follow this link to generate a JWT token:")
 	fmt.Println("    " + cli.PurpleStyle.Render(baseURL+"/auth/substreams-devenv"))
-	fmt.Println("")
+	fmt.Println()
 
 	var token string
 	form := huh.NewForm(
@@ -66,34 +109,99 @@ func runAuthE(cmd *cobra.Command, args []string) error {
 	)
 
 	if err := form.Run(); err != nil {
-		return fmt.Errorf("error running form: %w", err)
+		return authCredentials{}, fmt.Errorf("error running form: %w", err)
 	}
 
-	if strings.HasPrefix(token, "server_") {
-		fmt.Println("Detected API key, exchanging for JWT token...")
-		jwtToken, err := exchangeAPIKeyForJWT(token, authBaseURL)
-		if err != nil {
-			return fmt.Errorf("exchanging API key for JWT token: %w", err)
-		}
-		token = jwtToken
-		fmt.Println("Successfully obtained JWT token.")
-		fmt.Println()
+	return resolveCredentials(token)
+}
+
+type authCredentials struct {
+	token  string
+	apiKey string
+}
+
+func resolveCredentials(value string) (authCredentials, error) {
+	if !strings.HasPrefix(value, "server_") {
+		return authCredentials{token: value}, nil
 	}
 
-	fmt.Println("Writing `./.substreams.env`.  NOTE: Add it to `.gitignore`.")
-	fmt.Println("")
-
-	err := os.WriteFile(".substreams.env", []byte(fmt.Sprintf("export SUBSTREAMS_API_TOKEN=%s\n", token)), 0644)
+	fmt.Println("Exchanging API key for JWT token...")
+	jwtToken, err := exchangeAPIKeyForJWT(value, authIssueBaseURL())
 	if err != nil {
+		if os.Getenv("LOCAL_DEVELOPMENT") == "true" {
+			fmt.Println("Could not issue a JWT from the local issuer; writing the API key instead.")
+			fmt.Println()
+			return authCredentials{apiKey: value}, nil
+		}
+		return authCredentials{}, fmt.Errorf("exchanging API key for JWT token: %w", err)
+	}
+	fmt.Println("Successfully obtained JWT token.")
+	fmt.Println()
+	return authCredentials{token: jwtToken}, nil
+}
+
+func writeAuthCredentials(creds authCredentials) error {
+	fmt.Println("Writing `./.substreams.env`.  NOTE: Add it to `.gitignore`.")
+	fmt.Println()
+
+	if err := writeAuthEnvFile(authEnvFilename, creds); err != nil {
 		return fmt.Errorf("writing .substreams.env file: %w", err)
 	}
 
 	fmt.Println("Load credentials in current terminal with the following command:")
-	fmt.Println("")
+	fmt.Println()
 	fmt.Println(cli.PurpleStyle.Render("       . ./.substreams.env"))
 	fmt.Println()
 
 	return nil
+}
+
+func writeAuthEnvFile(path string, creds authCredentials) error {
+	if creds.token == "" && creds.apiKey == "" {
+		return errors.New("no credentials to write")
+	}
+	var b strings.Builder
+	if creds.token != "" {
+		fmt.Fprintf(&b, "export SUBSTREAMS_API_TOKEN=%s\n", creds.token)
+	}
+	if creds.apiKey != "" {
+		fmt.Fprintf(&b, "export SUBSTREAMS_API_KEY=%s\n", creds.apiKey)
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o600)
+}
+
+func portalAPIBaseURL() string {
+	if u := strings.TrimSpace(os.Getenv("SUBSTREAMS_PORTAL_API")); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	if os.Getenv("LOCAL_DEVELOPMENT") == "true" {
+		return localPortalAPIURL
+	}
+	return defaultPortalAPIURL
+}
+
+func authIssueBaseURL() string {
+	if u := strings.TrimSpace(os.Getenv("SUBSTREAMS_AUTH_ISSUE_URL")); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	if os.Getenv("LOCAL_DEVELOPMENT") == "true" {
+		return localAuthBaseURL
+	}
+	return defaultAuthBaseURL
+}
+
+func tryOpenURL(rawURL string) error {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name, args = "open", []string{rawURL}
+	case "windows":
+		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", rawURL}
+	default:
+		name, args = "xdg-open", []string{rawURL}
+	}
+	return exec.Command(name, args...).Start()
 }
 
 func exchangeAPIKeyForJWT(apiKey string, authBaseURL string) (string, error) {
@@ -121,12 +229,12 @@ func exchangeAPIKeyForJWT(apiKey string, authBaseURL string) (string, error) {
 	}
 
 	if response.StatusCode != 200 {
-		return "", fmt.Errorf("request failed with code %d: %s", response.StatusCode, fullBody)
+		return "", fmt.Errorf("request failed with code %d: %s", response.StatusCode, redactSecrets(string(fullBody)))
 	}
 
 	var authResp authIssueResponse
 	if err := json.Unmarshal(fullBody, &authResp); err != nil {
-		return "", fmt.Errorf("unmarshalling response %q: %w", fullBody, err)
+		return "", fmt.Errorf("unmarshalling response %q: %w", redactSecrets(string(fullBody)), err)
 	}
 
 	return authResp.Token, nil
@@ -134,4 +242,14 @@ func exchangeAPIKeyForJWT(apiKey string, authBaseURL string) (string, error) {
 
 type authIssueResponse struct {
 	Token string `json:"token"`
+}
+
+var (
+	serverKeyPattern  = regexp.MustCompile(`server_[A-Za-z0-9]+`)
+	apiKeyJSONPattern = regexp.MustCompile(`"api_key"\s*:\s*"[^"]*"`)
+)
+
+func redactSecrets(s string) string {
+	s = apiKeyJSONPattern.ReplaceAllString(s, `"api_key":"[redacted]"`)
+	return serverKeyPattern.ReplaceAllString(s, "server_[redacted]")
 }

--- a/cmd/substreams/auth.go
+++ b/cmd/substreams/auth.go
@@ -167,7 +167,11 @@ func writeAuthEnvFile(path string, creds authCredentials) error {
 	if creds.apiKey != "" {
 		fmt.Fprintf(&b, "export SUBSTREAMS_API_KEY=%s\n", creds.apiKey)
 	}
-	return os.WriteFile(path, []byte(b.String()), 0o600)
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		return err
+	}
+	// WriteFile only applies the mode on create; re-login must tighten an existing file.
+	return os.Chmod(path, 0o600)
 }
 
 func portalAPIBaseURL() string {
@@ -191,6 +195,9 @@ func authIssueBaseURL() string {
 }
 
 func tryOpenURL(rawURL string) error {
+	if !isHTTPURL(rawURL) {
+		return fmt.Errorf("refusing to open non-http(s) URL")
+	}
 	var name string
 	var args []string
 	switch runtime.GOOS {
@@ -245,11 +252,15 @@ type authIssueResponse struct {
 }
 
 var (
-	serverKeyPattern  = regexp.MustCompile(`server_[A-Za-z0-9]+`)
-	apiKeyJSONPattern = regexp.MustCompile(`"api_key"\s*:\s*"[^"]*"`)
+	serverKeyPattern       = regexp.MustCompile(`server_[A-Za-z0-9]+`)
+	apiKeyJSONPattern      = regexp.MustCompile(`"api_key"\s*:\s*"[^"]*"`)
+	deviceCodeJSONPattern  = regexp.MustCompile(`"device_code"\s*:\s*"[^"]*"`)
+	deviceCodeCamelPattern = regexp.MustCompile(`"deviceCode"\s*:\s*"[^"]*"`)
 )
 
 func redactSecrets(s string) string {
 	s = apiKeyJSONPattern.ReplaceAllString(s, `"api_key":"[redacted]"`)
+	s = deviceCodeJSONPattern.ReplaceAllString(s, `"device_code":"[redacted]"`)
+	s = deviceCodeCamelPattern.ReplaceAllString(s, `"deviceCode":"[redacted]"`)
 	return serverKeyPattern.ReplaceAllString(s, "server_[redacted]")
 }

--- a/cmd/substreams/auth_cli.go
+++ b/cmd/substreams/auth_cli.go
@@ -1,0 +1,419 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	portalAPIPrefix        = "/sf.portalapi.v1.PortalApi/"
+	defaultDevicePollWait  = 5 * time.Second
+	slowDownExtraWait      = 5 * time.Second
+	connectProtocolVersion = "1"
+)
+
+type cliAPIKeyStatus string
+
+const (
+	cliAPIKeyPending  cliAPIKeyStatus = "PENDING"
+	cliAPIKeySlowDown cliAPIKeyStatus = "SLOW_DOWN"
+	cliAPIKeyDenied   cliAPIKeyStatus = "DENIED"
+	cliAPIKeyExpired  cliAPIKeyStatus = "EXPIRED"
+	cliAPIKeyApproved cliAPIKeyStatus = "APPROVED"
+	cliAPIKeyUnknown  cliAPIKeyStatus = "UNKNOWN"
+)
+
+type cliAPIKeyAuthorizeResult struct {
+	DeviceCode              string
+	UserCode                string
+	VerificationURI         string
+	VerificationURIComplete string
+	ExpiresIn               time.Duration
+	Interval                time.Duration
+}
+
+type cliAPIKeyTokenResult struct {
+	Status         cliAPIKeyStatus
+	APIKey         string
+	APIKeyID       string
+	APIKeyName     string
+	OrganizationID string
+}
+
+type cliAPIKeyTokener interface {
+	CliAPIKeyToken(ctx context.Context, deviceCode string) (*cliAPIKeyTokenResult, error)
+}
+
+type portalClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func newPortalClient(baseURL string) *portalClient {
+	return &portalClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+func (c *portalClient) CliAPIKeyAuthorize(ctx context.Context, clientName string) (*cliAPIKeyAuthorizeResult, error) {
+	body, err := c.post(ctx, "CliApiKeyAuthorize", map[string]string{
+		"client_name": clientName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var wire cliAPIKeyAuthorizeWire
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return nil, fmt.Errorf("decoding CliApiKeyAuthorize response: %w", err)
+	}
+
+	result := &cliAPIKeyAuthorizeResult{
+		DeviceCode:              firstNonEmpty(wire.DeviceCode, wire.DeviceCodeSnake),
+		UserCode:                firstNonEmpty(wire.UserCode, wire.UserCodeSnake),
+		VerificationURI:         firstNonEmpty(wire.VerificationURI, wire.VerificationURISnake),
+		VerificationURIComplete: firstNonEmpty(wire.VerificationURIComplete, wire.VerificationURICompleteSnake),
+		ExpiresIn:               time.Duration(wire.ExpiresIn.Int64()) * time.Second,
+		Interval:                time.Duration(wire.Interval.Int64()) * time.Second,
+	}
+	if result.DeviceCode == "" {
+		return nil, fmt.Errorf("CliApiKeyAuthorize response missing device code")
+	}
+	return result, nil
+}
+
+func (c *portalClient) CliAPIKeyToken(ctx context.Context, deviceCode string) (*cliAPIKeyTokenResult, error) {
+	body, err := c.post(ctx, "CliApiKeyToken", map[string]string{
+		"device_code": deviceCode,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var wire cliAPIKeyTokenWire
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return nil, fmt.Errorf("decoding CliApiKeyToken response: %w", err)
+	}
+
+	return &cliAPIKeyTokenResult{
+		Status:         wire.Status,
+		APIKey:         firstNonEmpty(wire.APIKey, wire.APIKeySnake),
+		APIKeyID:       firstNonEmpty(wire.APIKeyID, wire.APIKeyIDSnake),
+		APIKeyName:     firstNonEmpty(wire.APIKeyName, wire.APIKeyNameSnake),
+		OrganizationID: firstNonEmpty(wire.OrganizationID, wire.OrganizationIDSnake),
+	}, nil
+}
+
+func (c *portalClient) post(ctx context.Context, method string, payload any) ([]byte, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encoding %s request: %w", method, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+portalAPIPrefix+method, bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("creating %s request: %w", method, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Connect-Protocol-Version", connectProtocolVersion)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s request: %w", method, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s response: %w", method, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s failed: %s", method, connectErrorMessage(resp.StatusCode, body))
+	}
+	return body, nil
+}
+
+type cliAPIKeyAuthorizeWire struct {
+	DeviceCode                   string    `json:"deviceCode"`
+	DeviceCodeSnake              string    `json:"device_code"`
+	UserCode                     string    `json:"userCode"`
+	UserCodeSnake                string    `json:"user_code"`
+	VerificationURI              string    `json:"verificationUri"`
+	VerificationURISnake         string    `json:"verification_uri"`
+	VerificationURIComplete      string    `json:"verificationUriComplete"`
+	VerificationURICompleteSnake string    `json:"verification_uri_complete"`
+	ExpiresIn                    jsonInt64 `json:"expiresIn"`
+	Interval                     jsonInt64 `json:"interval"`
+}
+
+func (w *cliAPIKeyAuthorizeWire) UnmarshalJSON(data []byte) error {
+	type alias cliAPIKeyAuthorizeWire
+	var camel alias
+	if err := json.Unmarshal(data, &camel); err != nil {
+		return err
+	}
+	*w = cliAPIKeyAuthorizeWire(camel)
+
+	var snake struct {
+		ExpiresIn jsonInt64 `json:"expires_in"`
+		Interval  jsonInt64 `json:"interval"`
+	}
+	if err := json.Unmarshal(data, &snake); err != nil {
+		return err
+	}
+	if w.ExpiresIn == 0 {
+		w.ExpiresIn = snake.ExpiresIn
+	}
+	if w.Interval == 0 {
+		w.Interval = snake.Interval
+	}
+	return nil
+}
+
+type cliAPIKeyTokenWire struct {
+	Status              cliAPIKeyStatus `json:"status"`
+	APIKey              string          `json:"apiKey"`
+	APIKeySnake         string          `json:"api_key"`
+	APIKeyID            string          `json:"apiKeyId"`
+	APIKeyIDSnake       string          `json:"api_key_id"`
+	APIKeyName          string          `json:"apiKeyName"`
+	APIKeyNameSnake     string          `json:"api_key_name"`
+	OrganizationID      string          `json:"organizationId"`
+	OrganizationIDSnake string          `json:"organization_id"`
+}
+
+type jsonInt64 int64
+
+func (j jsonInt64) Int64() int64 { return int64(j) }
+
+func (j *jsonInt64) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+	if len(data) > 0 && data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		if s == "" {
+			return nil
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		*j = jsonInt64(n)
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*j = jsonInt64(n)
+	return nil
+}
+
+func (s *cliAPIKeyStatus) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var raw string
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return err
+		}
+		*s = parseCLIAPIKeyStatus(raw)
+		return nil
+	}
+	var n int
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*s = cliAPIKeyStatusFromNumber(n)
+	return nil
+}
+
+func parseCLIAPIKeyStatus(raw string) cliAPIKeyStatus {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case "PENDING", "CLI_API_KEY_TOKEN_STATUS_PENDING":
+		return cliAPIKeyPending
+	case "SLOW_DOWN", "CLI_API_KEY_TOKEN_STATUS_SLOW_DOWN":
+		return cliAPIKeySlowDown
+	case "DENIED", "CLI_API_KEY_TOKEN_STATUS_DENIED":
+		return cliAPIKeyDenied
+	case "EXPIRED", "CLI_API_KEY_TOKEN_STATUS_EXPIRED":
+		return cliAPIKeyExpired
+	case "APPROVED", "CLI_API_KEY_TOKEN_STATUS_APPROVED":
+		return cliAPIKeyApproved
+	default:
+		return cliAPIKeyUnknown
+	}
+}
+
+func cliAPIKeyStatusFromNumber(n int) cliAPIKeyStatus {
+	switch n {
+	case 1:
+		return cliAPIKeyPending
+	case 2:
+		return cliAPIKeySlowDown
+	case 3:
+		return cliAPIKeyDenied
+	case 4:
+		return cliAPIKeyExpired
+	case 5:
+		return cliAPIKeyApproved
+	default:
+		return cliAPIKeyUnknown
+	}
+}
+
+type connectErrorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func connectErrorMessage(status int, body []byte) string {
+	var parsed connectErrorBody
+	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Message != "" {
+		if parsed.Code != "" {
+			return fmt.Sprintf("HTTP %d (%s): %s", status, parsed.Code, parsed.Message)
+		}
+		return fmt.Sprintf("HTTP %d: %s", status, parsed.Message)
+	}
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return fmt.Sprintf("HTTP %d", status)
+	}
+	return fmt.Sprintf("HTTP %d: %s", status, trimmed)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func runCliAPIKeyAuth(ctx context.Context, client *portalClient, out io.Writer, openURL func(string) error) (string, error) {
+	auth, err := client.CliAPIKeyAuthorize(ctx, deviceClientName)
+	if err != nil {
+		return "", fmt.Errorf("starting login: %w", err)
+	}
+
+	verifyURL := auth.VerificationURIComplete
+	if verifyURL == "" && auth.VerificationURI != "" && auth.UserCode != "" {
+		verifyURL = auth.VerificationURI + "?user_code=" + auth.UserCode
+	}
+
+	fmt.Fprintln(out, "Authenticate with The Graph Market.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Open this link, pick an organization if asked, then select an API key:")
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "    %s\n", verifyURL)
+	fmt.Fprintln(out)
+	if auth.UserCode != "" {
+		fmt.Fprintf(out, "User code: %s\n", auth.UserCode)
+		fmt.Fprintln(out)
+	}
+
+	if openURL != nil && verifyURL != "" {
+		if err := openURL(verifyURL); err == nil {
+			fmt.Fprintln(out, "Opened the key picker in your browser.")
+		}
+	}
+
+	expiresIn := auth.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 10 * time.Minute
+	}
+	fmt.Fprintf(out, "Waiting for you to select an API key (expires in %s)...\n", expiresIn.Round(time.Second))
+
+	result, err := waitForCLIAPIKey(ctx, client, auth.DeviceCode, auth.Interval, expiresIn, sleepWithContext)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Fprintln(out)
+	if result.APIKeyName != "" {
+		fmt.Fprintf(out, "Selected API key %q.\n", result.APIKeyName)
+	} else {
+		fmt.Fprintln(out, "Selected an API key.")
+	}
+	fmt.Fprintln(out)
+	return result.APIKey, nil
+}
+
+func waitForCLIAPIKey(
+	ctx context.Context,
+	client cliAPIKeyTokener,
+	deviceCode string,
+	interval, expiresIn time.Duration,
+	sleep func(context.Context, time.Duration) error,
+) (*cliAPIKeyTokenResult, error) {
+	if sleep == nil {
+		sleep = sleepWithContext
+	}
+	deadline := time.Now().Add(expiresIn)
+	wait := interval
+	if wait <= 0 {
+		wait = defaultDevicePollWait
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("login expired before a key was selected")
+		}
+
+		result, err := client.CliAPIKeyToken(ctx, deviceCode)
+		if err != nil {
+			return nil, fmt.Errorf("polling login: %w", err)
+		}
+
+		switch result.Status {
+		case cliAPIKeyApproved:
+			if result.APIKey == "" {
+				return nil, fmt.Errorf("login approved but no API key was returned")
+			}
+			return result, nil
+		case cliAPIKeyDenied:
+			return nil, fmt.Errorf("login was denied")
+		case cliAPIKeyExpired:
+			return nil, fmt.Errorf("login expired before a key was selected")
+		case cliAPIKeySlowDown:
+			wait += slowDownExtraWait
+		}
+
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("login expired before a key was selected")
+		}
+		if err := sleep(ctx, wait); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/cmd/substreams/auth_cli.go
+++ b/cmd/substreams/auth_cli.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -114,31 +116,49 @@ func (c *portalClient) CliAPIKeyToken(ctx context.Context, deviceCode string) (*
 	}, nil
 }
 
+type portalAPIError struct {
+	retryable bool
+	err       error
+}
+
+func (e *portalAPIError) Error() string   { return e.err.Error() }
+func (e *portalAPIError) Unwrap() error   { return e.err }
+func (e *portalAPIError) Retryable() bool { return e.retryable }
+
 func (c *portalClient) post(ctx context.Context, method string, payload any) ([]byte, error) {
 	raw, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("encoding %s request: %w", method, err)
+		return nil, &portalAPIError{err: fmt.Errorf("encoding %s request: %w", method, err)}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+portalAPIPrefix+method, bytes.NewReader(raw))
 	if err != nil {
-		return nil, fmt.Errorf("creating %s request: %w", method, err)
+		return nil, &portalAPIError{err: fmt.Errorf("creating %s request: %w", method, err)}
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Connect-Protocol-Version", connectProtocolVersion)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s request: %w", method, err)
+		return nil, &portalAPIError{
+			retryable: !errors.Is(err, context.Canceled),
+			err:       fmt.Errorf("%s request: %w", method, err),
+		}
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s response: %w", method, err)
+		return nil, &portalAPIError{
+			retryable: true,
+			err:       fmt.Errorf("reading %s response: %w", method, err),
+		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s failed: %s", method, connectErrorMessage(resp.StatusCode, body))
+		return nil, &portalAPIError{
+			retryable: resp.StatusCode >= 500,
+			err:       fmt.Errorf("%s failed: %s", method, connectErrorMessage(resp.StatusCode, body)),
+		}
 	}
 	return body, nil
 }
@@ -282,16 +302,56 @@ type connectErrorBody struct {
 func connectErrorMessage(status int, body []byte) string {
 	var parsed connectErrorBody
 	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Message != "" {
+		msg := redactSecrets(parsed.Message)
 		if parsed.Code != "" {
-			return fmt.Sprintf("HTTP %d (%s): %s", status, parsed.Code, parsed.Message)
+			return fmt.Sprintf("HTTP %d (%s): %s", status, redactSecrets(parsed.Code), msg)
 		}
-		return fmt.Sprintf("HTTP %d: %s", status, parsed.Message)
+		return fmt.Sprintf("HTTP %d: %s", status, msg)
 	}
 	trimmed := strings.TrimSpace(string(body))
 	if trimmed == "" {
 		return fmt.Sprintf("HTTP %d", status)
 	}
-	return fmt.Sprintf("HTTP %d: %s", status, trimmed)
+	return fmt.Sprintf("HTTP %d: %s", status, redactSecrets(trimmed))
+}
+
+func isHTTPURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return true
+	default:
+		return false
+	}
+}
+
+func verificationURL(auth *cliAPIKeyAuthorizeResult) (string, error) {
+	raw := auth.VerificationURIComplete
+	if raw == "" && auth.VerificationURI != "" && auth.UserCode != "" {
+		u, err := url.Parse(auth.VerificationURI)
+		if err != nil {
+			return "", fmt.Errorf("invalid verification URL: %w", err)
+		}
+		q := u.Query()
+		q.Set("user_code", auth.UserCode)
+		u.RawQuery = q.Encode()
+		raw = u.String()
+	}
+	if !isHTTPURL(raw) {
+		return "", fmt.Errorf("missing http(s) verification URL")
+	}
+	return raw, nil
+}
+
+func isRetryablePollError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	var p *portalAPIError
+	return errors.As(err, &p) && p.Retryable()
 }
 
 func firstNonEmpty(values ...string) string {
@@ -309,9 +369,9 @@ func runCliAPIKeyAuth(ctx context.Context, client *portalClient, out io.Writer, 
 		return "", fmt.Errorf("starting login: %w", err)
 	}
 
-	verifyURL := auth.VerificationURIComplete
-	if verifyURL == "" && auth.VerificationURI != "" && auth.UserCode != "" {
-		verifyURL = auth.VerificationURI + "?user_code=" + auth.UserCode
+	verifyURL, err := verificationURL(auth)
+	if err != nil {
+		return "", fmt.Errorf("starting login: %w", err)
 	}
 
 	fmt.Fprintln(out, "Authenticate with The Graph Market.")
@@ -378,21 +438,23 @@ func waitForCLIAPIKey(
 
 		result, err := client.CliAPIKeyToken(ctx, deviceCode)
 		if err != nil {
-			return nil, fmt.Errorf("polling login: %w", err)
-		}
-
-		switch result.Status {
-		case cliAPIKeyApproved:
-			if result.APIKey == "" {
-				return nil, fmt.Errorf("login approved but no API key was returned")
+			if !isRetryablePollError(err) {
+				return nil, fmt.Errorf("polling login: %w", err)
 			}
-			return result, nil
-		case cliAPIKeyDenied:
-			return nil, fmt.Errorf("login was denied")
-		case cliAPIKeyExpired:
-			return nil, fmt.Errorf("login expired before a key was selected")
-		case cliAPIKeySlowDown:
-			wait += slowDownExtraWait
+		} else {
+			switch result.Status {
+			case cliAPIKeyApproved:
+				if result.APIKey == "" {
+					return nil, fmt.Errorf("login approved but no API key was returned")
+				}
+				return result, nil
+			case cliAPIKeyDenied:
+				return nil, fmt.Errorf("login was denied")
+			case cliAPIKeyExpired:
+				return nil, fmt.Errorf("login expired before a key was selected")
+			case cliAPIKeySlowDown:
+				wait += slowDownExtraWait
+			}
 		}
 
 		if !time.Now().Before(deadline) {

--- a/cmd/substreams/auth_test.go
+++ b/cmd/substreams/auth_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortalAPIBaseURL(t *testing.T) {
+	t.Run("default production", func(t *testing.T) {
+		t.Setenv("SUBSTREAMS_PORTAL_API", "")
+		t.Setenv("LOCAL_DEVELOPMENT", "")
+		assert.Equal(t, defaultPortalAPIURL, portalAPIBaseURL())
+	})
+
+	t.Run("local development", func(t *testing.T) {
+		t.Setenv("SUBSTREAMS_PORTAL_API", "")
+		t.Setenv("LOCAL_DEVELOPMENT", "true")
+		assert.Equal(t, localPortalAPIURL, portalAPIBaseURL())
+	})
+
+	t.Run("explicit override wins", func(t *testing.T) {
+		t.Setenv("LOCAL_DEVELOPMENT", "true")
+		t.Setenv("SUBSTREAMS_PORTAL_API", "http://example.test:9000/")
+		assert.Equal(t, "http://example.test:9000", portalAPIBaseURL())
+	})
+}
+
+func TestWriteAuthEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".substreams.env")
+
+	require.NoError(t, writeAuthEnvFile(path, authCredentials{token: "jwt-token"}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "export SUBSTREAMS_API_TOKEN=jwt-token\n", string(got))
+}
+
+func TestWriteAuthEnvFileAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".substreams.env")
+
+	require.NoError(t, writeAuthEnvFile(path, authCredentials{apiKey: "server_abc"}))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "export SUBSTREAMS_API_KEY=server_abc\n", string(got))
+}
+
+func TestAuthIssueBaseURL(t *testing.T) {
+	t.Setenv("SUBSTREAMS_AUTH_ISSUE_URL", "")
+	t.Setenv("LOCAL_DEVELOPMENT", "")
+	assert.Equal(t, defaultAuthBaseURL, authIssueBaseURL())
+
+	t.Setenv("LOCAL_DEVELOPMENT", "true")
+	assert.Equal(t, localAuthBaseURL, authIssueBaseURL())
+
+	t.Setenv("SUBSTREAMS_AUTH_ISSUE_URL", "http://issuer.test/")
+	assert.Equal(t, "http://issuer.test", authIssueBaseURL())
+}
+
+func TestResolveCredentialsPassthrough(t *testing.T) {
+	got, err := resolveCredentials("eyJhbGciOiJIUzI1NiJ9.e30.ok")
+	require.NoError(t, err)
+	assert.Equal(t, "eyJhbGciOiJIUzI1NiJ9.e30.ok", got.token)
+	assert.Empty(t, got.apiKey)
+}
+
+func TestResolveCredentialsLocalFallback(t *testing.T) {
+	t.Setenv("LOCAL_DEVELOPMENT", "true")
+	t.Setenv("SUBSTREAMS_AUTH_ISSUE_URL", "http://127.0.0.1:1")
+
+	got, err := resolveCredentials("server_abc")
+	require.NoError(t, err)
+	assert.Empty(t, got.token)
+	assert.Equal(t, "server_abc", got.apiKey)
+}
+
+func TestRedactSecrets(t *testing.T) {
+	in := `{"code":"auth_unauthorized_api_key_error","details":{"api_key":"server_deadbeef0123456789"}}`
+	got := redactSecrets(in)
+	assert.NotContains(t, got, "server_deadbeef0123456789")
+	assert.Contains(t, got, "[redacted]")
+}
+
+func TestPortalClientAuthorizeCamelCase(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/sf.portalapi.v1.PortalApi/CliApiKeyAuthorize", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "1", r.Header.Get("Connect-Protocol-Version"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotBody = body
+		_, _ = w.Write([]byte(`{
+			"deviceCode": "device_secret",
+			"userCode": "ABCD-1234",
+			"verificationUri": "http://localhost:3000/auth/cli",
+			"verificationUriComplete": "http://localhost:3000/auth/cli?user_code=ABCD-1234",
+			"expiresIn": "600",
+			"interval": "5"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := newPortalClient(srv.URL).CliAPIKeyAuthorize(t.Context(), "substreams CLI")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"client_name":"substreams CLI"}`, string(gotBody))
+	assert.Equal(t, "device_secret", got.DeviceCode)
+	assert.Equal(t, "ABCD-1234", got.UserCode)
+	assert.Equal(t, "http://localhost:3000/auth/cli", got.VerificationURI)
+	assert.Equal(t, "http://localhost:3000/auth/cli?user_code=ABCD-1234", got.VerificationURIComplete)
+	assert.Equal(t, 10*time.Minute, got.ExpiresIn)
+	assert.Equal(t, 5*time.Second, got.Interval)
+}
+
+func TestPortalClientAuthorizeSnakeCase(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"device_code": "device_secret",
+			"user_code": "ABCD-1234",
+			"verification_uri": "http://localhost:3000/auth/cli",
+			"verification_uri_complete": "http://localhost:3000/auth/cli?user_code=ABCD-1234",
+			"expires_in": 600,
+			"interval": 5
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := newPortalClient(srv.URL).CliAPIKeyAuthorize(t.Context(), "cli")
+	require.NoError(t, err)
+	assert.Equal(t, "device_secret", got.DeviceCode)
+	assert.Equal(t, 10*time.Minute, got.ExpiresIn)
+}
+
+func TestPortalClientTokenApproved(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/sf.portalapi.v1.PortalApi/CliApiKeyToken", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"device_code":"device_secret"}`, string(body))
+		_, _ = w.Write([]byte(`{
+			"status": "CLI_API_KEY_TOKEN_STATUS_APPROVED",
+			"apiKey": "server_abc",
+			"apiKeyId": "key-1",
+			"apiKeyName": "dev",
+			"organizationId": "org-1"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := newPortalClient(srv.URL).CliAPIKeyToken(t.Context(), "device_secret")
+	require.NoError(t, err)
+	assert.Equal(t, cliAPIKeyApproved, got.Status)
+	assert.Equal(t, "server_abc", got.APIKey)
+	assert.Equal(t, "key-1", got.APIKeyID)
+	assert.Equal(t, "dev", got.APIKeyName)
+	assert.Equal(t, "org-1", got.OrganizationID)
+}
+
+func TestPortalClientTokenNumericStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":1}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := newPortalClient(srv.URL).CliAPIKeyToken(t.Context(), "code")
+	require.NoError(t, err)
+	assert.Equal(t, cliAPIKeyPending, got.Status)
+}
+
+func TestPortalClientConnectError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":"invalid_argument","message":"unknown device code"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newPortalClient(srv.URL).CliAPIKeyToken(t.Context(), "nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown device code")
+	assert.Contains(t, err.Error(), "invalid_argument")
+}
+
+func TestParseCLIAPIKeyStatus(t *testing.T) {
+	assert.Equal(t, cliAPIKeyApproved, parseCLIAPIKeyStatus("CLI_API_KEY_TOKEN_STATUS_APPROVED"))
+	assert.Equal(t, cliAPIKeyPending, parseCLIAPIKeyStatus("pending"))
+	assert.Equal(t, cliAPIKeySlowDown, parseCLIAPIKeyStatus("SLOW_DOWN"))
+	assert.Equal(t, cliAPIKeyUnknown, parseCLIAPIKeyStatus("CLI_API_KEY_TOKEN_STATUS_UNSPECIFIED"))
+}
+
+func TestWaitForCLIAPIKeyApprovedAfterPending(t *testing.T) {
+	fake := &scriptedTokener{results: []cliAPIKeyTokenResult{
+		{Status: cliAPIKeyPending},
+		{Status: cliAPIKeyApproved, APIKey: "server_abc", APIKeyName: "dev"},
+	}}
+	var sleeps []time.Duration
+
+	got, err := waitForCLIAPIKey(t.Context(), fake, "code", 5*time.Second, time.Minute, func(ctx context.Context, d time.Duration) error {
+		sleeps = append(sleeps, d)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "server_abc", got.APIKey)
+	assert.Equal(t, []time.Duration{5 * time.Second}, sleeps)
+	assert.Equal(t, 2, fake.calls)
+}
+
+func TestWaitForCLIAPIKeySlowDownIncreasesInterval(t *testing.T) {
+	fake := &scriptedTokener{results: []cliAPIKeyTokenResult{
+		{Status: cliAPIKeySlowDown},
+		{Status: cliAPIKeyApproved, APIKey: "server_abc"},
+	}}
+	var sleeps []time.Duration
+
+	got, err := waitForCLIAPIKey(t.Context(), fake, "code", 5*time.Second, time.Minute, func(ctx context.Context, d time.Duration) error {
+		sleeps = append(sleeps, d)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "server_abc", got.APIKey)
+	assert.Equal(t, []time.Duration{10 * time.Second}, sleeps)
+}
+
+func TestWaitForCLIAPIKeyDenied(t *testing.T) {
+	fake := &scriptedTokener{results: []cliAPIKeyTokenResult{
+		{Status: cliAPIKeyDenied},
+	}}
+	_, err := waitForCLIAPIKey(t.Context(), fake, "code", time.Second, time.Minute, func(context.Context, time.Duration) error {
+		require.Fail(t, "should not sleep after deny")
+		return nil
+	})
+	require.EqualError(t, err, "login was denied")
+}
+
+func TestWaitForCLIAPIKeyExpiredStatus(t *testing.T) {
+	fake := &scriptedTokener{results: []cliAPIKeyTokenResult{
+		{Status: cliAPIKeyExpired},
+	}}
+	_, err := waitForCLIAPIKey(t.Context(), fake, "code", time.Second, time.Minute, nil)
+	require.EqualError(t, err, "login expired before a key was selected")
+}
+
+func TestWaitForCLIAPIKeyCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	fake := &scriptedTokener{results: []cliAPIKeyTokenResult{
+		{Status: cliAPIKeyPending},
+	}}
+	_, err := waitForCLIAPIKey(ctx, fake, "code", time.Second, time.Minute, nil)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWaitForCLIAPIKeyDeadline(t *testing.T) {
+	fake := &scriptedTokener{results: []cliAPIKeyTokenResult{
+		{Status: cliAPIKeyPending},
+	}}
+	_, err := waitForCLIAPIKey(t.Context(), fake, "code", time.Second, 0, func(context.Context, time.Duration) error {
+		require.Fail(t, "should not sleep after deadline")
+		return nil
+	})
+	require.EqualError(t, err, "login expired before a key was selected")
+}
+
+func TestRunCliAPIKeyAuthSuccess(t *testing.T) {
+	var authorizeCalls, tokenCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/sf.portalapi.v1.PortalApi/CliApiKeyAuthorize":
+			authorizeCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"deviceCode":              "device_secret",
+				"userCode":                "ABCD-1234",
+				"verificationUri":         "http://localhost:3000/auth/cli",
+				"verificationUriComplete": "http://localhost:3000/auth/cli?user_code=ABCD-1234",
+				"expiresIn":               "600",
+				"interval":                "1",
+			})
+		case "/sf.portalapi.v1.PortalApi/CliApiKeyToken":
+			tokenCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":         "CLI_API_KEY_TOKEN_STATUS_APPROVED",
+				"apiKey":         "server_abc",
+				"apiKeyId":       "key-1",
+				"apiKeyName":     "dev",
+				"organizationId": "org-1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var opened string
+	var out strings.Builder
+	got, err := runCliAPIKeyAuth(t.Context(), newPortalClient(srv.URL), &out, func(u string) error {
+		opened = u
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, int(authorizeCalls.Load()))
+	assert.Equal(t, 1, int(tokenCalls.Load()))
+	assert.Equal(t, "http://localhost:3000/auth/cli?user_code=ABCD-1234", opened)
+	assert.Equal(t, "server_abc", got)
+	assert.Contains(t, out.String(), "ABCD-1234")
+	assert.Contains(t, out.String(), "Opened the key picker")
+	assert.Contains(t, out.String(), `"dev"`)
+	assert.NotContains(t, out.String(), "device_secret")
+	assert.NotContains(t, out.String(), "server_abc")
+}
+
+type scriptedTokener struct {
+	results []cliAPIKeyTokenResult
+	calls   int
+}
+
+func (s *scriptedTokener) CliAPIKeyToken(ctx context.Context, deviceCode string) (*cliAPIKeyTokenResult, error) {
+	if s.calls >= len(s.results) {
+		result := s.results[len(s.results)-1]
+		s.calls++
+		return &result, ctx.Err()
+	}
+	result := s.results[s.calls]
+	s.calls++
+	return &result, nil
+}

--- a/cmd/substreams/auth_test.go
+++ b/cmd/substreams/auth_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -63,6 +65,22 @@ func TestWriteAuthEnvFileAPIKey(t *testing.T) {
 	assert.Equal(t, "export SUBSTREAMS_API_KEY=server_abc\n", string(got))
 }
 
+func TestWriteAuthEnvFileChmodsExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".substreams.env")
+	require.NoError(t, os.WriteFile(path, []byte("export OLD=1\n"), 0o644))
+
+	require.NoError(t, writeAuthEnvFile(path, authCredentials{token: "jwt-token"}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "export SUBSTREAMS_API_TOKEN=jwt-token\n", string(got))
+}
+
 func TestAuthIssueBaseURL(t *testing.T) {
 	t.Setenv("SUBSTREAMS_AUTH_ISSUE_URL", "")
 	t.Setenv("LOCAL_DEVELOPMENT", "")
@@ -97,6 +115,16 @@ func TestRedactSecrets(t *testing.T) {
 	got := redactSecrets(in)
 	assert.NotContains(t, got, "server_deadbeef0123456789")
 	assert.Contains(t, got, "[redacted]")
+}
+
+func TestRedactSecretsDeviceCode(t *testing.T) {
+	in := `{"device_code":"secret-device","deviceCode":"camel-device","message":"bad"}`
+	got := redactSecrets(in)
+	assert.NotContains(t, got, "secret-device")
+	assert.NotContains(t, got, "camel-device")
+	assert.Contains(t, got, `"device_code":"[redacted]"`)
+	assert.Contains(t, got, `"deviceCode":"[redacted]"`)
+	assert.Contains(t, got, "bad")
 }
 
 func TestPortalClientAuthorizeCamelCase(t *testing.T) {
@@ -199,6 +227,19 @@ func TestPortalClientConnectError(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid_argument")
 }
 
+func TestPortalClientConnectErrorRedactsDeviceCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`not-json {"device_code":"secret-device"} leftover`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := newPortalClient(srv.URL).CliAPIKeyToken(t.Context(), "secret-device")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "secret-device")
+	assert.Contains(t, err.Error(), `"device_code":"[redacted]"`)
+}
+
 func TestParseCLIAPIKeyStatus(t *testing.T) {
 	assert.Equal(t, cliAPIKeyApproved, parseCLIAPIKeyStatus("CLI_API_KEY_TOKEN_STATUS_APPROVED"))
 	assert.Equal(t, cliAPIKeyPending, parseCLIAPIKeyStatus("pending"))
@@ -279,6 +320,168 @@ func TestWaitForCLIAPIKeyDeadline(t *testing.T) {
 	require.EqualError(t, err, "login expired before a key was selected")
 }
 
+func TestWaitForCLIAPIKeyRetries5xxThenSucceeds(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"code":"unavailable","message":"try again"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"APPROVED","apiKey":"server_abc"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := waitForCLIAPIKey(t.Context(), newPortalClient(srv.URL), "code", time.Millisecond, time.Minute, func(context.Context, time.Duration) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "server_abc", got.APIKey)
+	assert.Equal(t, 2, int(n.Load()))
+}
+
+func TestWaitForCLIAPIKeyFailsFastOn4xx(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":"invalid_argument","message":"unknown device code"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := waitForCLIAPIKey(t.Context(), newPortalClient(srv.URL), "code", time.Second, time.Minute, func(context.Context, time.Duration) error {
+		require.Fail(t, "should not sleep after 4xx")
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "polling login")
+	assert.Equal(t, 1, int(n.Load()))
+}
+
+func TestWaitForCLIAPIKeyRetriesTransportThenSucceeds(t *testing.T) {
+	var calls int
+	tok := &funcTokener{fn: func() (*cliAPIKeyTokenResult, error) {
+		calls++
+		if calls == 1 {
+			return nil, &portalAPIError{retryable: true, err: errors.New("connection refused")}
+		}
+		return &cliAPIKeyTokenResult{Status: cliAPIKeyApproved, APIKey: "server_abc"}, nil
+	}}
+
+	got, err := waitForCLIAPIKey(t.Context(), tok, "code", time.Millisecond, time.Minute, func(context.Context, time.Duration) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "server_abc", got.APIKey)
+	assert.Equal(t, 2, calls)
+}
+
+func TestWaitForCLIAPIKeyRetriesTimeoutThenSucceeds(t *testing.T) {
+	var calls int
+	tok := &funcTokener{fn: func() (*cliAPIKeyTokenResult, error) {
+		calls++
+		if calls == 1 {
+			return nil, &portalAPIError{
+				retryable: true,
+				err:       fmt.Errorf("CliApiKeyToken request: %w", context.DeadlineExceeded),
+			}
+		}
+		return &cliAPIKeyTokenResult{Status: cliAPIKeyApproved, APIKey: "server_abc"}, nil
+	}}
+
+	got, err := waitForCLIAPIKey(t.Context(), tok, "code", time.Millisecond, time.Minute, func(context.Context, time.Duration) error {
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "server_abc", got.APIKey)
+	assert.Equal(t, 2, calls)
+}
+
+func TestWaitForCLIAPIKeyDoesNotRetryCanceled(t *testing.T) {
+	tok := &funcTokener{fn: func() (*cliAPIKeyTokenResult, error) {
+		return nil, &portalAPIError{
+			retryable: false,
+			err:       fmt.Errorf("CliApiKeyToken request: %w", context.Canceled),
+		}
+	}}
+	_, err := waitForCLIAPIKey(t.Context(), tok, "code", time.Second, time.Minute, func(context.Context, time.Duration) error {
+		require.Fail(t, "should not sleep after cancel")
+		return nil
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestVerificationURLComplete(t *testing.T) {
+	got, err := verificationURL(&cliAPIKeyAuthorizeResult{
+		VerificationURIComplete: "https://thegraph.market/auth/cli?user_code=ABCD-1234",
+		VerificationURI:         "https://thegraph.market/auth/cli",
+		UserCode:                "ABCD-1234",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://thegraph.market/auth/cli?user_code=ABCD-1234", got)
+}
+
+func TestVerificationURLFallback(t *testing.T) {
+	got, err := verificationURL(&cliAPIKeyAuthorizeResult{
+		VerificationURI: "http://localhost:3000/auth/cli",
+		UserCode:        "ABCD-1234",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:3000/auth/cli?user_code=ABCD-1234", got)
+}
+
+func TestVerificationURLQueryEscapesUserCode(t *testing.T) {
+	got, err := verificationURL(&cliAPIKeyAuthorizeResult{
+		VerificationURI: "http://localhost:3000/auth/cli",
+		UserCode:        "A B",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:3000/auth/cli?user_code=A+B", got)
+}
+
+func TestVerificationURLMissing(t *testing.T) {
+	_, err := verificationURL(&cliAPIKeyAuthorizeResult{DeviceCode: "device_secret"})
+	require.EqualError(t, err, "missing http(s) verification URL")
+}
+
+func TestVerificationURLRejectsNonHTTP(t *testing.T) {
+	_, err := verificationURL(&cliAPIKeyAuthorizeResult{
+		VerificationURIComplete: "javascript:alert(1)",
+	})
+	require.EqualError(t, err, "missing http(s) verification URL")
+}
+
+func TestRunCliAPIKeyAuthRequiresHTTPVerificationURL(t *testing.T) {
+	var tokenCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/sf.portalapi.v1.PortalApi/CliApiKeyAuthorize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"deviceCode": "device_secret",
+				"expiresIn":  "600",
+				"interval":   "1",
+			})
+		case "/sf.portalapi.v1.PortalApi/CliApiKeyToken":
+			tokenCalls.Add(1)
+			http.Error(w, "should not poll", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	var opened string
+	_, err := runCliAPIKeyAuth(t.Context(), newPortalClient(srv.URL), io.Discard, func(u string) error {
+		opened = u
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing http(s) verification URL")
+	assert.Equal(t, 0, int(tokenCalls.Load()))
+	assert.Empty(t, opened)
+}
+
 func TestRunCliAPIKeyAuthSuccess(t *testing.T) {
 	var authorizeCalls, tokenCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -324,6 +527,14 @@ func TestRunCliAPIKeyAuthSuccess(t *testing.T) {
 	assert.Contains(t, out.String(), `"dev"`)
 	assert.NotContains(t, out.String(), "device_secret")
 	assert.NotContains(t, out.String(), "server_abc")
+}
+
+type funcTokener struct {
+	fn func() (*cliAPIKeyTokenResult, error)
+}
+
+func (f *funcTokener) CliAPIKeyToken(ctx context.Context, deviceCode string) (*cliAPIKeyTokenResult, error) {
+	return f.fn()
 }
 
 type scriptedTokener struct {

--- a/docs/how-to-guides/cli/authentication.md
+++ b/docs/how-to-guides/cli/authentication.md
@@ -4,62 +4,57 @@ This guide explains how to authenticate when running a Substreams package (`.spk
 
 ## Overview
 
-Substreams requires authentication to ensure secure and controlled access to providers. This guide focuses on obtaining and using a JWT token from The Graph Market to authenticate your Substreams execution.
+`substreams auth` opens a browser so you can pick an organization (if you belong to more than one) and an API key. The CLI retrieves the selected key over the API — you do not copy and paste it — exchanges it for a JWT, and writes the token to `.substreams.env`.
 
 ## Prerequisites
 
-- A Substreams package (`.spkg`) ready to deploy.
-- An account with [The Graph Market](https://thegraph.market).
+- The [Substreams CLI](./installing-the-cli.md) installed.
+- A browser, so you can sign in and pick a key.
+- An account with [The Graph Market](https://thegraph.market), or be ready to create one during login.
 
-## Step 1: Obtain a JWT Token
+## Step 1: Run login
 
-To authenticate with The Graph Market, you need to generate a JWT token. Follow these steps:
+```bash
+substreams auth
+```
 
-1. **Log in to The Graph Market**:
-   - Visit [https://thegraph.market](https://thegraph.market).
-   - Log in to your existing account or create a new one if you don't have an account.
+The command prints an approval URL (and tries to open it in your browser). Sign in, choose an organization if asked, then select an API key.
 
-2. **Access the Dashboard**:
-   - Click on `Dashboard` in the navigation menu or go directly to [https://thegraph.market/dashboard](https://thegraph.market/dashboard).
+On success it writes `.substreams.env` with `SUBSTREAMS_API_TOKEN`. Add that file to `.gitignore`.
 
-   ![Dashboard](../../.gitbook/assets/intro/thegraphmarket.png)
+## Step 2: Load the credentials
 
-3. **Create a New API Key**:
-   - In the dashboard, click on `Create New Key`.
-   - Input a recognizable name for future reference.
-   - This is not the _authentication token_, but a key to generate tokens.
+```bash
+. ./.substreams.env
+```
 
-4. **Generate an API Token**:
-   - For security reasons, the API token is hidden. In the `API TOKEN` section, click the button besides the hidden token.
-   - The system will generate a JWT token. **Copy** and **save** this token securely, as it will be required for authentication.
+Other `substreams` commands also read `.substreams.env` automatically when it is present next to the manifest (or in the current directory).
 
-## Step 2: Set the JWT Token as an Environment Variable
+## Paste a JWT or API key instead
 
-To authenticate Substreams on your local machine, you need to set the JWT token as an environment variable.
+If you already have a Graph Market JWT or `server_` API key:
 
-### Unix-like Systems (macOS, Linux)
+```bash
+substreams auth --paste
+```
 
-1. **Open a terminal** on your machine.
+Paste the value when prompted. An API key is exchanged for a JWT automatically.
 
-2. **Set the environment variable** using the following command:
+You can also set the token yourself:
 
-   ```bash
-   export SUBSTREAMS_API_TOKEN="<YOUR-JWT-TOKEN>"
-   ```
+```bash
+export SUBSTREAMS_API_TOKEN="<YOUR-JWT-TOKEN>"
+```
 
-   Replace `<YOUR-JWT-TOKEN>` with the JWT token you obtained earlier.
+## Step 3: Verify authentication
 
-## Step 3: Verify Authentication
+Run a test Substreams against Ethereum Mainnet:
 
-To ensure that your authentication is set up correctly, you can run a test Substreams. Here's how:
+```bash
+substreams gui ethereum-common@v0.3.1 all_events --start-block=15000000
+```
 
-1. Run the following command in your terminal to get all the events on Ethereum Mainnet:
-
-   ```bash
-   substreams gui ethereum-common@v0.3.1 all_events --start-block=15000000
-   ```
-
-2. Verify that the Substreams runs without errors, confirming that your authentication is successful.
+If the stream starts without an authentication error, your credentials are in place.
 
 ## Need Help?
 

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -139,7 +139,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Changed: `substreams auth` opens a browser so you can pick an organization (if you have more than one) and
   an API key. The CLI retrieves the selected key over the API — no copy/paste — exchanges it for a JWT, and
-  writes `.substreams.env`. The previous paste-a-JWT-or-API-key flow is `--paste`. With `LOCAL_DEVELOPMENT=true`,
+  writes `.substreams.env` (mode 0600, including when the file already exists). The previous paste-a-JWT-or-API-key
+  flow is `--paste`. Login polling keeps going through transport errors, timeouts, and 5xx until the device-code
+  deadline, and fails fast without a usable `http`/`https` verification URL. With `LOCAL_DEVELOPMENT=true`,
   JWT issue uses the local issuer; if that issuer is unavailable the API key is stored instead of failing.
 
 - `substreams run` reports backprocessing as progress and rates instead of a list of block ranges. A four-line session

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -137,6 +137,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### CLI
 
+- Changed: `substreams auth` opens a browser so you can pick an organization (if you have more than one) and
+  an API key. The CLI retrieves the selected key over the API — no copy/paste — exchanges it for a JWT, and
+  writes `.substreams.env`. The previous paste-a-JWT-or-API-key flow is `--paste`. With `LOCAL_DEVELOPMENT=true`,
+  JWT issue uses the local issuer; if that issuer is unavailable the API key is stored instead of failing.
+
 - `substreams run` reports backprocessing as progress and rates instead of a list of block ranges. A four-line session
   header (trace ID, module, chain, work to do including what was already cached) is printed once and stays in the
   scrollback, followed by a compact live block: overall percentage, blocks per second, ETA, running jobs against the

--- a/docs/tutorials/cosmos-compatible/injective.md
+++ b/docs/tutorials/cosmos-compatible/injective.md
@@ -25,7 +25,7 @@ Tip: Have the start block of your transaction or specific events ready.
 
 ## Step 2: Visualize the Data
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Run `substreams build` to compile the project.
 

--- a/docs/tutorials/evm.md
+++ b/docs/tutorials/evm.md
@@ -23,7 +23,7 @@ In this tutorial, you'll learn how to initialize a EVM-based Substreams project 
 ## Step 2: Visualize the Data
 
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Run `substreams build` to compile the project.
 

--- a/docs/tutorials/monad.md
+++ b/docs/tutorials/monad.md
@@ -26,7 +26,7 @@ The CLI installation is supported only on Linux and macOS. If you're using Windo
 
 ## Step 2: Visualize the Data
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Run `substreams build` to compile the project.
 

--- a/docs/tutorials/near.md
+++ b/docs/tutorials/near.md
@@ -20,7 +20,7 @@ In this tutorial, you'll learn how to initialize a NEAR-based Substreams project
 
 ## Step 2: Visualize the Data
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Run `substreams build` to compile the project.
 

--- a/docs/tutorials/solana/solana.md
+++ b/docs/tutorials/solana/solana.md
@@ -28,7 +28,7 @@ The modules within Solana Common exclude voting transactions, to benefit from a 
 
 ## Step 2: Visualize the Data
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Run `substreams build` to compile the project.
 

--- a/docs/tutorials/stellar.md
+++ b/docs/tutorials/stellar.md
@@ -50,7 +50,7 @@ In this guide, you'll learn how to initialize a Stellar-based Substreams project
 
 ## Step 2: Visualize the Data
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Now you can freely use the `substreams gui` to visualize and iterate on your extracted data.
 

--- a/docs/tutorials/tron.md
+++ b/docs/tutorials/tron.md
@@ -22,7 +22,7 @@ In this tutorial, you'll learn how to initialize a TRON-based Substreams project
 
 ## Step 2: Visualize the Data
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Run `substreams build` to compile the project.
 

--- a/docs/tutorials/world-chain.md
+++ b/docs/tutorials/world-chain.md
@@ -30,7 +30,7 @@ substreams run -e mainnet.worldchain.streamingfast.io:443 substreams.yaml [modul
 
 ## Step 3: Visualize the Data
 
-1. Run `substreams auth` to create your [account](https://thegraph.market/) and generate an authentication token (JWT), then pass this token back as input.
+1. Run `substreams auth` to sign in at [The Graph Market](https://thegraph.market/), pick an API key in your browser, then load credentials with `. ./.substreams.env`.
 
 2. Run `substreams build` to compile the project.
 


### PR DESCRIPTION
`substreams auth` now opens a browser so you can pick an organization and an API key. The CLI fetches the selected key over the Portal device-code flow, exchanges it for a JWT, and writes `.substreams.env` at mode 0600 — including when the file already existed. You no longer copy a secret out of the browser. The previous paste-a-JWT-or-API-key path is `--paste`.

Login polling keeps going through transport errors, timeouts, and 5xx until the device-code deadline, and fails fast on 4xx, DENIED, and EXPIRED. Authorize refuses to start unless there is an `http`/`https` verification URL, so we never poll for ten minutes on an empty or `javascript:` link. Portal error bodies redact `device_code` / `deviceCode` (the existing `api_key` / `server_` patterns do not cover this flow).

Local development still remaps hosts via `LOCAL_DEVELOPMENT`, with `SUBSTREAMS_PORTAL_API` and `SUBSTREAMS_AUTH_ISSUE_URL` as explicit overrides. If the local JWT issuer is down, the API key is stored instead of failing. The `LOCAL_DEVELOPMENT` env doc now points at that issuer remap.

The Portal client accepts both camelCase and snake_case JSON so the CLI does not depend on one protobuf JSON mapping.

Trade-offs: transient poll failures are retried silently (no extra log noise); 4xx is fail-fast so a bad device code is not hammered. Query-escaping `user_code` uses `url.Values` rather than raw concatenation. Redaction is JSON-field based, not a full allowlist of portal error text.

Reopens the work from #893 (merged, then reverted on `develop` because GitHub cannot reopen a merged PR).