### PR TITLE
Releasing v1.22.0

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v1.22.0
 
 ### Sink
 


### PR DESCRIPTION
Marks the current `Unreleased` change-log section as `v1.22.0` in preparation for the release.

Minor bump from `v1.21.0` — the section carries new features (spool observability, `substreams sink protojson --compression`, `substreams tools devenv` / `extract-proto`, cost-estimate endpoint, browser-based `substreams auth`) alongside breaking fixes in the SQL sink's Relational Mappings Mode (BYTEA binary storage, backslash escaping, microsecond timestamps, automatic `_block_number_` index).

Merging this is the last step before tagging `v1.22.0`.
