### PR TITLE
Slow down progress messages and honour requested interval

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,6 +9,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Server
+
+- Progress messages are sent far less often. The cadence now widens with the age of the request — every second for
+  the first minute, every 10 seconds up to 5 minutes, every 30 seconds up to 10 minutes, then every minute — and it
+  applies to the linear phase too, which previously sent one every 200ms. Progress messages count as egress like any
+  other response, so a long-running or live request paid for a steady stream of them.
+
+- `Request.progress_messages_interval_ms` is now honoured: it was validated and then ignored. Setting it pins the
+  progress cadence for the whole request instead of using the ramp above; the 500ms minimum is unchanged.
+
 ## v1.22.0
 
 ### Sink

--- a/pb/sf/substreams/rpc/v2/service.pb.go
+++ b/pb/sf/substreams/rpc/v2/service.pb.go
@@ -139,7 +139,9 @@ type Request struct {
 	// If unset, all the outputs are sent.
 	// This allows the user to reduce the payload in dev mode, while still getting some extra debugging information
 	DevOutputModules []string `protobuf:"bytes,13,rep,name=dev_output_modules,json=devOutputModules,proto3" json:"dev_output_modules,omitempty"`
-	// Progress_messages_interval_ms is the interval between progress messages, in milliseconds (minimum: 500, default: start at 500ms and ramp up to 5000ms within 1min)
+	// Interval between progress messages, in milliseconds (minimum: 500). When left at 0, the
+	// interval widens with the age of the request: 1s for the first minute, 10s up to 5 minutes,
+	// 30s up to 10 minutes, 60s beyond that.
 	ProgressMessagesIntervalMs uint64 `protobuf:"varint,14,opt,name=progress_messages_interval_ms,json=progressMessagesIntervalMs,proto3" json:"progress_messages_interval_ms,omitempty"`
 	// If true, blocks close to head will be sent in "partials" as soon as we get them.
 	// This means that you will get different versions of the same block number, each an incomplete increment

--- a/pb/sf/substreams/rpc/v3/service.pb.go
+++ b/pb/sf/substreams/rpc/v3/service.pb.go
@@ -90,7 +90,9 @@ type Request struct {
 	// If unset, all the outputs are sent.
 	// This allows the user to reduce the payload in dev mode, while still getting some extra debugging information
 	DevOutputModules []string `protobuf:"bytes,13,rep,name=dev_output_modules,json=devOutputModules,proto3" json:"dev_output_modules,omitempty"`
-	// Progress_messages_interval_ms is the interval between progress messages, in milliseconds (minimum: 500, default: start at 500ms and ramp up to 5000ms within 1min)
+	// Interval between progress messages, in milliseconds (minimum: 500). When left at 0, the
+	// interval widens with the age of the request: 1s for the first minute, 10s up to 5 minutes,
+	// 30s up to 10 minutes, 60s beyond that.
 	ProgressMessagesIntervalMs uint64 `protobuf:"varint,14,opt,name=progress_messages_interval_ms,json=progressMessagesIntervalMs,proto3" json:"progress_messages_interval_ms,omitempty"`
 	// If true, blocks close to head will be sent in "partials" as soon as we get them.
 	// This means that you will get different versions of the same block number, each an incomplete increment

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -675,21 +675,10 @@ func (p *Pipeline) runParallelProcess(ctx context.Context, reqPlan *plan.Request
 		stream := response.New(p.respFunc)
 
 		meter := dmetering.GetBytesMeter(ctx)
-		notifyInterval := time.Duration(500 * time.Millisecond)
 
-		count := int64(0)
 		for {
-			count++
-			switch count { // reduce "probably useless" bandwidth consumption after a few minutes.
-			case 120: // after 60 seconds, notify every second
-				notifyInterval = time.Second
-			case 240: // after 3 minutes, notify every 3 seconds
-				notifyInterval = time.Second * 3
-			case 300: // after 6 minutes, notify every 5 seconds
-				notifyInterval = time.Second * 5
-			}
 			select {
-			case <-time.After(notifyInterval):
+			case <-time.After(progressMessageInterval(time.Since(p.startTime), reqDetails.UpdateInterval)):
 				stagesProgress := stats.Stages()
 				jobs := stats.JobsStats()
 				modStats := stats.AggregatedModulesStats()
@@ -798,8 +787,31 @@ func toRPCMapModuleOutputs(in *pbssinternal.ModuleOutput) (out *pbsubstreamsrpc.
 	}
 }
 
+// progressMessageInterval returns how long to wait before the next progress message is
+// sent to the client. A non-zero requested interval, from Request.progress_messages_interval_ms,
+// pins the cadence for the whole request. Otherwise the interval widens as the request ages:
+// progress matters most while the client is still waiting for its first data, and every
+// message is billed as egress.
+func progressMessageInterval(elapsed, requested time.Duration) time.Duration {
+	if requested > 0 {
+		return requested
+	}
+
+	switch {
+	case elapsed < time.Minute:
+		return time.Second
+	case elapsed < 5*time.Minute:
+		return 10 * time.Second
+	case elapsed < 10*time.Minute:
+		return 30 * time.Second
+	default:
+		return time.Minute
+	}
+}
+
 func (p *Pipeline) returnRPCModuleProgressOutputs(forceOutput bool) error {
-	if time.Since(p.lastProgressSent) < progressMessageInterval && !forceOutput {
+	interval := progressMessageInterval(time.Since(p.startTime), reqctx.Details(p.ctx).UpdateInterval)
+	if time.Since(p.lastProgressSent) < interval && !forceOutput {
 		return nil
 	}
 	p.lastProgressSent = time.Now()
@@ -878,7 +890,7 @@ func (p *Pipeline) SendProgressSnapshot() error {
 }
 
 func (p *Pipeline) returnInternalModuleProgressOutputs(clock *pbsubstreams.Clock, forceOutput bool) error {
-	if time.Since(p.lastProgressSent) < progressMessageInterval && !forceOutput {
+	if time.Since(p.lastProgressSent) < internalProgressMessageInterval && !forceOutput {
 		return nil
 	}
 	p.lastProgressSent = time.Now()

--- a/pipeline/terminate.go
+++ b/pipeline/terminate.go
@@ -15,7 +15,9 @@ import (
 	"github.com/streamingfast/substreams/reqctx"
 )
 
-const progressMessageInterval = time.Millisecond * 200
+// internalProgressMessageInterval is the cadence of the tier2 -> tier1 progress updates.
+// Those never reach the client, so they are not throttled like the tier1 progress messages.
+const internalProgressMessageInterval = time.Millisecond * 200
 
 // OnStreamTerminated performs flush of store and setting trailers when the stream terminated gracefully from our point of view.
 // If the stream terminated gracefully, we return `nil` otherwise, the original is returned.

--- a/proto/sf/substreams/rpc/v2/service.proto
+++ b/proto/sf/substreams/rpc/v2/service.proto
@@ -103,7 +103,9 @@ message Request {
   // This allows the user to reduce the payload in dev mode, while still getting some extra debugging information
   repeated string dev_output_modules = 13;
 
-  // Progress_messages_interval_ms is the interval between progress messages, in milliseconds (minimum: 500, default: start at 500ms and ramp up to 5000ms within 1min)
+  // Interval between progress messages, in milliseconds (minimum: 500). When left at 0, the
+  // interval widens with the age of the request: 1s for the first minute, 10s up to 5 minutes,
+  // 30s up to 10 minutes, 60s beyond that.
   uint64 progress_messages_interval_ms = 14;
 
   // previously used in partial alpha tests

--- a/proto/sf/substreams/rpc/v3/service.proto
+++ b/proto/sf/substreams/rpc/v3/service.proto
@@ -104,7 +104,9 @@ message Request {
   // This allows the user to reduce the payload in dev mode, while still getting some extra debugging information
   repeated string dev_output_modules = 13;
 
-  // Progress_messages_interval_ms is the interval between progress messages, in milliseconds (minimum: 500, default: start at 500ms and ramp up to 5000ms within 1min)
+  // Interval between progress messages, in milliseconds (minimum: 500). When left at 0, the
+  // interval widens with the age of the request: 1s for the first minute, 10s up to 5 minutes,
+  // 30s up to 10 minutes, 60s beyond that.
   uint64 progress_messages_interval_ms = 14;
 
   // previously used in partial alpha tests


### PR DESCRIPTION
Every response sent on a tier1 stream is billed as egress — `proto.Size(respAny)` in `tier1ResponseHandler`, no filter on message type. Progress messages are included, and they were sent a lot:

- linear phase: throttled at **200ms** (up to 5/s), for the whole life of a live stream
- parallel phase: ticker ramping 500ms → 1s → 3s → 5s

Each one carries the full `ModulesProgress`: every stage with its `completed_ranges` and module list, plus per-module stats. During live streaming the stage list is frozen (nothing writes it after the parallel phase ends) and gets resent verbatim on every tick.

## Changes

New `progressMessageInterval(elapsed, requested)` in `pipeline/pipeline.go`, used by both emitters:

| request age | interval |
|---|---|
| < 1 min | 1s |
| < 5 min | 10s |
| < 10 min | 30s |
| beyond | 60s |

`forceOutput` sends (segment boundary, error, stream termination) still bypass the throttle.

`Request.progress_messages_interval_ms` is now honoured. It was validated in `service/tier1.go` and stored into `RequestDetails.UpdateInterval`, which nothing ever read. A non-zero value pins the cadence for the whole request; the 500ms minimum is unchanged.

The tier2 → tier1 internal updates keep their 200ms cadence under `internalProgressMessageInterval` — they never reach a client and are not billed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGdm5rjh4vPxNnqj7Tp5kf