### PR TITLE
Suffix last_used marker with the request's plan tier

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Server
+
+- `substreams-tier1` now names the usage marker it writes in every module cache folder after the request's plan tier: `last_used_<plan>` (lowercase, e.g. `last_used_pro`), still plain `last_used` when unauthenticated. `firecore tools substreams purge` reads the plan back from that name to apply a retention per plan.
+
 ## v1.22.0
 
 ### Sink

--- a/reqctx/request.go
+++ b/reqctx/request.go
@@ -19,10 +19,13 @@ type RequestDetails struct {
 	ResolvedStartBlockNum uint64
 	ResolvedCursor        string
 
-	LinearHandoffBlockNum         uint64
-	LinearGateBlockNum            uint64
-	StopBlockNum                  uint64
-	MaxParallelJobs               uint64
+	LinearHandoffBlockNum uint64
+	LinearGateBlockNum    uint64
+	StopBlockNum          uint64
+	MaxParallelJobs       uint64
+	// PlanTier is the substreams plan tier reported by the authentication layer, empty
+	// when the request is unauthenticated.
+	PlanTier                      string
 	MaxStageLayerParallelExecutor uint64
 	LimitProcessedBlocks          uint64
 	UpdateInterval                time.Duration

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -610,15 +610,27 @@ func (s *Tier1Service) writePackage(ctx context.Context, request *pbsubstreamsrp
 	return nil
 }
 
+// lastUsedFilename names the usage marker written in every module's cache folder:
+// `last_used` for unauthenticated requests, `last_used_<plan>` (lowercase) otherwise.
+// `firecore tools substreams purge` reads the plan back from that name to apply a
+// retention per plan.
+func lastUsedFilename(planTier string) string {
+	if planTier == "" {
+		return "last_used"
+	}
+	return "last_used_" + strings.ToLower(planTier)
+}
+
 func (s *Tier1Service) writeLastUsed(ctx context.Context, execGraph *exec.Graph, cacheStore dstore.Store) error {
+	filename := lastUsedFilename(reqctx.Details(ctx).PlanTier)
 	for _, module := range execGraph.UsedModules() {
 		moduleStore, err := cacheStore.SubStore(execGraph.ModuleHashes()[module.Name])
 		if err != nil {
 			return fmt.Errorf("getting substore: %w", err)
 		}
 		moduleStore.SetOverwrite(true)
-		if err := moduleStore.WriteObject(ctx, "last_used", strings.NewReader(time.Now().Format("2006-01-02"))); err != nil {
-			return fmt.Errorf("writing last_used file")
+		if err := moduleStore.WriteObject(ctx, filename, strings.NewReader(time.Now().Format("2006-01-02"))); err != nil {
+			return fmt.Errorf("writing %s file", filename)
 		}
 	}
 	return nil
@@ -700,6 +712,7 @@ func (s *Tier1Service) blocks(
 	parallelism := reqctx.GetEffectiveHeaderValues(ctx, header, s.runtimeConfig.DefaultParallelSubrequests, reqctx.DefaultMaxStageLayerParallelExecutorCount)
 	requestDetails.MaxParallelJobs = parallelism.Workers
 	requestDetails.MaxStageLayerParallelExecutor = parallelism.StageLayerExecutors
+	requestDetails.PlanTier = parallelism.PlanTier
 	reqStats.SetWorkerCounts(parallelism.RequestedWorkers, parallelism.GrantedWorkers, parallelism.Workers)
 	logFields = append(logFields, zap.Object("parallelism", parallelism))
 

--- a/service/tier1_test.go
+++ b/service/tier1_test.go
@@ -261,3 +261,9 @@ func TestWithStoresBackend_BothTiersAligned(t *testing.T) {
 		}
 	})
 }
+
+func TestLastUsedFilename(t *testing.T) {
+	assert.Equal(t, "last_used", lastUsedFilename(""))
+	assert.Equal(t, "last_used_pro", lastUsedFilename("PRO"))
+	assert.Equal(t, "last_used_enterprise", lastUsedFilename("ENTERPRISE"))
+}


### PR DESCRIPTION
\`substreams-tier1\` writes the usage marker in every module cache folder as \`last_used_<plan>\` (lowercase plan tier from the \`x-substreams-plan-tier\` trusted header, e.g. \`last_used_pro\`), or plain \`last_used\` when the request is unauthenticated / the header is empty.

Matches what \`firecore tools substreams purge\` (streamingfast/firehose-core \`feature/tools-substreams-purge\`) parses with \`planOfMarker\` to apply a retention per plan.

Plan tier is carried on \`reqctx.RequestDetails.PlanTier\` (set from the effective parallelism headers in \`Blocks\`).