### PR TITLE
Add comment documenting Dockerfile runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN --mount=target=. \
       CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
       GOWORK=off go build -ldflags="-X 'main.version=${VERSION}'" -o /app/substreams ./cmd/substreams
 
-# Runtime stage: minimal Ubuntu base carrying only the built binary.
+# Runtime stage: minimal Ubuntu base carrying only the built binary
+# (no toolchain, no source tree).
 FROM ubuntu:24.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=target=. \
       CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
       GOWORK=off go build -ldflags="-X 'main.version=${VERSION}'" -o /app/substreams ./cmd/substreams
 
+# Runtime stage: minimal Ubuntu base carrying only the built binary.
 FROM ubuntu:24.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
Adds a one-line comment above the final `FROM ubuntu:24.04` stage in the Dockerfile. No behavior change — the image builds identically.

This PR exists mainly to exercise the Docker Scout GitHub PR commenter on a real pull request.
