### PR TITLE
Send tier2 jobs in the order the client reads them

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -48,6 +48,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   still do not count towards the retry limit, while a refused connection or an `Unavailable: no healthy upstream` from
   the load balancer means no instance is reachable at all, so those keep the growing 1s-to-5s backoff.
 
+- Jobs are now scheduled up to twice the request's worker count ahead of the blocks the client is reading, instead of
+  1.5 times, so a client that reads slowly still keeps the workers busy.
+
 - Store snapshots (fullKV files) can now be pruned to save disk space: tier1 no longer assumes that a fullKV at block
   `x` implies that every earlier fullKV still exists. At request start it walks backwards from the first segment
   needing work, in growing listing windows, until it finds the last block where every store module still has a

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -34,19 +34,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Jobs of a tier1 request now reach the tier2 fleet in the order the client will read their output, instead of
   racing each other for whatever instance has room. A job asks a per-request launch queue for its turn before every
-  request it sends to a tier2, first attempt included. The queue holds the jobs a tier2 turned away
-  (`ResourceExhausted: service currently overloaded`) plus the ones held back behind them, ordered by lowest segment
-  first and, within a segment, by highest stage. Only the first 20% of that queue may dial at all, at least two jobs;
-  the ones behind them send nothing until a job ahead gets in and moves the window up. So with 10 workers and every
-  job refused, the two lowest segments redial every 100ms while the other eight stay silent, and a job the scheduler
-  creates late for a low segment goes to the front of the queue and dials right away. A job with nothing queued ahead
-  of it dials immediately, so a fleet with room is paced no differently than before. Without this, the segment the
-  client reads first was no more likely to land than one it would only read minutes later, and a whole request could
-  idle behind a single unlucky low segment. Tunable with `SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT` (default 20),
-  `SUBSTREAMS_WORKER_OVERLOADED_RETRY_DELAY` (default 100ms, was 300ms) and `SUBSTREAMS_WORKER_OVERLOADED_RETRY_JITTER`
-  (default 100ms, added to a retry delay so jobs refused at the same instant do not redial in lockstep). Refusals
-  still do not count towards the retry limit, while a refused connection or an `Unavailable: no healthy upstream` from
-  the load balancer means no instance is reachable at all, so those keep the growing 1s-to-5s backoff.
+  request it sends to a tier2, first attempt and retries alike, and leaves the queue the moment a tier2 takes it. The
+  queue holds the jobs waiting to get in, ordered by lowest segment first and, within a segment, by highest stage.
+  Only the first 20% of that queue may dial at all, at least two jobs; the ones behind them send nothing until a job
+  ahead gets in and moves the window up. So with 10 workers and every job turned away, the two lowest segments redial
+  every 100ms while the other eight stay silent, and a job the scheduler creates late for a low segment goes to the
+  front of the queue and dials right away. A job with nothing queued ahead of it dials immediately, so a fleet with
+  room is paced no differently than before. Without this, the segment the client reads first was no more likely to
+  land than one it would only read minutes later, and a whole request could idle behind a single unlucky low segment.
+
+- A tier2 job that fails is no longer retried on a growing 1s-to-5s backoff of its own. Every reason to dial again
+  now goes through the same queue, so retries keep the request's reading order: a job that could not get in at all
+  (`ResourceExhausted: service currently overloaded`, a refused connection, `Unavailable: no healthy upstream`)
+  waits 100ms, and a job that got in and then failed waits 5 seconds once — if a tier2 then turns it away for
+  capacity, it is back on the 100ms delay with its failure already counted. The counters that end a hopeless request
+  are unchanged: five failures, or two execution timeouts, and neither is charged for a job that never got in.
+  Tunable with `SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT` (default 20), `SUBSTREAMS_WORKER_OVERLOADED_RETRY_DELAY`
+  (default 100ms, was 300ms), `SUBSTREAMS_WORKER_FAILED_RETRY_DELAY` (default 5s) and
+  `SUBSTREAMS_WORKER_OVERLOADED_RETRY_JITTER` (default 100ms, added to a wait so jobs turned away at the same instant
+  do not redial in lockstep).
 
 - Jobs are now scheduled up to twice the request's worker count ahead of the blocks the client is reading, instead of
   1.5 times, so a client that reads slowly still keeps the workers busy.

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -32,12 +32,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   emitter, opened and torn down on every `ProcessRange` call; its 4 shutdown-lifecycle logs are now `Debug` too
   (bumped to `github.com/streamingfast/dmetering@v0.0.0-20260901152443-1ff4cd0d617d`).
 
-- A tier2 that refuses a job because it is at its concurrent-request limit (`ResourceExhausted: service currently
-  overloaded`) is now retried after 300ms +/- 100ms instead of on the growing 1s-to-5s backoff shared with real
-  failures. The retry dials again and can land on a different instance, so waiting seconds on a busy fleet only
-  slowed the search down. Tunable with `SUBSTREAMS_WORKER_OVERLOADED_RETRY_DELAY` and
-  `SUBSTREAMS_WORKER_OVERLOADED_RETRY_JITTER`. A refused connection or an `Unavailable: no healthy upstream` from
-  the load balancer means no instance is reachable at all, so those keep the growing backoff.
+- Jobs of a tier1 request now reach the tier2 fleet in the order the client will read their output, instead of
+  racing each other for whatever instance has room. A job asks a per-request launch queue for its turn before every
+  request it sends to a tier2, first attempt included. The queue holds the jobs a tier2 turned away
+  (`ResourceExhausted: service currently overloaded`) plus the ones held back behind them, ordered by lowest segment
+  first and, within a segment, by highest stage. Only the first 20% of that queue may dial at all, at least two jobs;
+  the ones behind them send nothing until a job ahead gets in and moves the window up. So with 10 workers and every
+  job refused, the two lowest segments redial every 100ms while the other eight stay silent, and a job the scheduler
+  creates late for a low segment goes to the front of the queue and dials right away. A job with nothing queued ahead
+  of it dials immediately, so a fleet with room is paced no differently than before. Without this, the segment the
+  client reads first was no more likely to land than one it would only read minutes later, and a whole request could
+  idle behind a single unlucky low segment. Tunable with `SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT` (default 20),
+  `SUBSTREAMS_WORKER_OVERLOADED_RETRY_DELAY` (default 100ms, was 300ms) and `SUBSTREAMS_WORKER_OVERLOADED_RETRY_JITTER`
+  (default 100ms, added to a retry delay so jobs refused at the same instant do not redial in lockstep). Refusals
+  still do not count towards the retry limit, while a refused connection or an `Unavailable: no healthy upstream` from
+  the load balancer means no instance is reachable at all, so those keep the growing 1s-to-5s backoff.
 
 - Store snapshots (fullKV files) can now be pruned to save disk space: tier1 no longer assumes that a fullKV at block
   `x` implies that every earlier fullKV still exists. At request start it walks backwards from the first segment

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -36,12 +36,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   racing each other for whatever instance has room. A job asks a per-request launch queue for its turn before every
   request it sends to a tier2, first attempt and retries alike, and leaves the queue the moment a tier2 takes it. The
   queue holds the jobs waiting to get in, ordered by lowest segment first and, within a segment, by highest stage.
-  Only the first 20% of that queue may dial at all, at least two jobs; the ones behind them send nothing until a job
-  ahead gets in and moves the window up. So with 10 workers and every job turned away, the two lowest segments redial
-  every 100ms while the other eight stay silent, and a job the scheduler creates late for a low segment goes to the
-  front of the queue and dials right away. A job with nothing queued ahead of it dials immediately, so a fleet with
-  room is paced no differently than before. Without this, the segment the client reads first was no more likely to
-  land than one it would only read minutes later, and a whole request could idle behind a single unlucky low segment.
+  Only the first 20% of that queue may dial at all, at least two jobs and at most 15; the ones behind them send
+  nothing until a job ahead gets in and moves the window up. So with 10 workers and every job turned away, the two
+  lowest segments redial every 100ms while the other eight stay silent, and a job the scheduler creates late for a
+  low segment goes to the front of the queue and dials right away. A job with nothing queued ahead of it dials
+  immediately, so a fleet with room is paced no differently than before. Without this, the segment the client reads
+  first was no more likely to land than one it would only read minutes later, and a whole request could idle behind
+  a single unlucky low segment.
 
 - A tier2 job that fails is no longer retried on a growing 1s-to-5s backoff of its own. Every reason to dial again
   now goes through the same queue, so retries keep the request's reading order: a job that could not get in at all
@@ -49,8 +50,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   waits 100ms, and a job that got in and then failed waits 5 seconds once — if a tier2 then turns it away for
   capacity, it is back on the 100ms delay with its failure already counted. The counters that end a hopeless request
   are unchanged: five failures, or two execution timeouts, and neither is charged for a job that never got in.
-  Tunable with `SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT` (default 20), `SUBSTREAMS_WORKER_OVERLOADED_RETRY_DELAY`
-  (default 100ms, was 300ms), `SUBSTREAMS_WORKER_FAILED_RETRY_DELAY` (default 5s) and
+  Tunable with `SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT` (default 20), `SUBSTREAMS_WORKER_LAUNCH_WINDOW_MAX`
+  (default 15), `SUBSTREAMS_WORKER_OVERLOADED_RETRY_DELAY` (default 100ms, was 300ms),
+  `SUBSTREAMS_WORKER_FAILED_RETRY_DELAY` (default 5s) and
   `SUBSTREAMS_WORKER_OVERLOADED_RETRY_JITTER` (default 100ms, added to a wait so jobs turned away at the same instant
   do not redial in lockstep).
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -238,6 +238,7 @@ cloud.google.com/go/dataplex v1.27.1 h1:renSEYTQZMQ3ag7lM0BDmSj4FWqaTGW60YQ/lvAE
 cloud.google.com/go/dataplex v1.27.1/go.mod h1:VB+xlYJiJ5kreonXsa2cHPj0A3CfPh/mgiHG4JFhbUA=
 cloud.google.com/go/dataplex v1.28.0 h1:rROI3iqMVI9nXT701ULoFRETQVAOAPC3mPSWFDxXFl0=
 cloud.google.com/go/dataplex v1.28.0/go.mod h1:VB+xlYJiJ5kreonXsa2cHPj0A3CfPh/mgiHG4JFhbUA=
+cloud.google.com/go/dataproc v1.8.0/go.mod h1:5OW+zNAH0pMpw14JVrPONsxMQYMBqJuzORhIBfBn9uI=
 cloud.google.com/go/dataproc/v2 v2.10.1/go.mod h1:fq+LSN/HYUaaV2EnUPFVPxfe1XpzGVqFnL0TTXs8juk=
 cloud.google.com/go/dataproc/v2 v2.14.1 h1:Kxq0iomU0H4MlVP4HYeYPNJnV+YxNctf/hFrprmGy5Y=
 cloud.google.com/go/dataproc/v2 v2.14.1/go.mod h1:tSdkodShfzrrUNPDVEL6MdH9/mIEvp/Z9s9PBdbsZg8=
@@ -303,6 +304,7 @@ cloud.google.com/go/firestore v1.21.0/go.mod h1:1xH6HNcnkf/gGyR8udd6pFO4Z7GWJSwL
 cloud.google.com/go/functions v1.19.3/go.mod h1:nOZ34tGWMmwfiSJjoH/16+Ko5106x+1Iji29wzrBeOo=
 cloud.google.com/go/functions v1.19.7 h1:7LcOD18euIVGRUPaeCmgO6vfWSLNIsi6STWRQcdANG8=
 cloud.google.com/go/functions v1.19.7/go.mod h1:xbcKfS7GoIcaXr2FSwmtn9NXal1JR4TV6iYZlgXffwA=
+cloud.google.com/go/gaming v1.8.0/go.mod h1:xAqjS8b7jAVW0KFYeRUxngo9My3f33kFmua++Pi+ggM=
 cloud.google.com/go/gkebackup v1.6.3/go.mod h1:JJzGsA8/suXpTDtqI7n9RZW97PXa2CIp+n8aRC/y57k=
 cloud.google.com/go/gkebackup v1.8.1 h1:gUgI3lZJYALZsHXE7YJOKI8bMpoAX/tF6jnNugvzT1g=
 cloud.google.com/go/gkebackup v1.8.1/go.mod h1:GAaAl+O5D9uISH5MnClUop2esQW4pDa2qe/95A4l7YQ=
@@ -499,11 +501,14 @@ cloud.google.com/go/securitycenter v1.38.0 h1:sU+tckApsBLZHrTALVvetgz4XcPsgbL0TX
 cloud.google.com/go/securitycenter v1.38.0/go.mod h1:Ge2D/SlG2lP1FrQD7wXHy8qyeloRenvKXeB4e7zO6z0=
 cloud.google.com/go/securitycenter v1.38.1 h1:D9zpeguY4frQU35GBw8+M6Gw79CiuTF9iVs4sFm3FDY=
 cloud.google.com/go/securitycenter v1.38.1/go.mod h1:Ge2D/SlG2lP1FrQD7wXHy8qyeloRenvKXeB4e7zO6z0=
+cloud.google.com/go/servicecontrol v1.5.0/go.mod h1:qM0CnXHhyqKVuiZnGKrIurvVImCs8gmqWsDoqe9sU1s=
 cloud.google.com/go/servicedirectory v1.12.3/go.mod h1:dwTKSCYRD6IZMrqoBCIvZek+aOYK/6+jBzOGw8ks5aY=
 cloud.google.com/go/servicedirectory v1.12.6 h1:pl/KUNvFzlXpxgnPgzQjyTQQcv5WsQ97zCHaPrLQlYA=
 cloud.google.com/go/servicedirectory v1.12.6/go.mod h1:OojC1KhOMDYC45oyTn3Mup08FY/S0Kj7I58dxUMMTpg=
 cloud.google.com/go/servicedirectory v1.12.7 h1:je2yZlVcVFI/TshPXjjF9ZAlWedj0s5EbO2kozJrzBo=
 cloud.google.com/go/servicedirectory v1.12.7/go.mod h1:gOtN+qbuCMH6tj2dqlDY3qQL7w3V0+nkWaZElnJK8Ps=
+cloud.google.com/go/servicemanagement v1.5.0/go.mod h1:XGaCRe57kfqu4+lRxaFEAuqmjzF0r+gWHjWqKqBvKFo=
+cloud.google.com/go/serviceusage v1.4.0/go.mod h1:SB4yxXSaYVuUBYUml6qklyONXNLt83U0Rb+CXyhjEeU=
 cloud.google.com/go/shell v1.8.3/go.mod h1:OYcrgWF6JSp/uk76sNTtYFlMD0ho2+Cdzc7U3P/bF54=
 cloud.google.com/go/shell v1.8.6 h1:jLWyztGlNWBx55QXBM4HbWvfv7aiRjPzRKTUkZA8dXk=
 cloud.google.com/go/shell v1.8.6/go.mod h1:GNbTWf1QA/eEtYa+kWSr+ef/XTCDkUzRpV3JPw0LqSk=
@@ -709,6 +714,7 @@ github.com/RoaringBitmap/roaring v0.9.4/go.mod h1:icnadbWcNyfEHlYdr+tDlOTih1Bf/h
 github.com/RoaringBitmap/roaring v1.9.1/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
 github.com/ShinyTrinkets/meta-logger v0.2.0/go.mod h1:cY1KnpPfpLIopR+arZXHYVrVGO6AETrhi3HmRGFjU+U=
 github.com/ShinyTrinkets/overseer v0.3.0/go.mod h1:MeOEZb808w8+F5WLhiWI2VpOvtkWH55oOlTlAqYI1Pk=
+github.com/Shopify/sarama v1.37.2/go.mod h1:Nxye/E+YPru//Bpaorfhc3JsSGYwCaDDj+R4bK52U5o=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
@@ -808,6 +814,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd h1:qdGvebPBDuYD
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723 h1:ZA/jbKoGcVAnER6pCHPEkGdZOV7U1oLUedErBHCUMs0=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=
 github.com/btcsuite/winsvc v1.0.0 h1:J9B4L7e3oqhXOcm+2IuNApwzQec85lE+QaikUcCs+dk=
+github.com/bufbuild/connect-go v1.0.0/go.mod h1:9iNvh/NOsfhNBUH5CtvXeVUskQO1xsrEviH7ZArwZ3I=
+github.com/bufbuild/connect-grpcreflect-go v1.0.0/go.mod h1:825I20H8bfE9rLnBH/046JSpmm3uwpNYdG4duCARetc=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
 github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
@@ -1081,6 +1089,7 @@ github.com/googleapis/gax-go/v2 v2.20.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fH
 github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8 h1:tlyzajkF3030q6M8SvmJSemC9DTHL/xaMa18b65+JM4=
+github.com/googleinterns/cloud-operations-api-mock v0.0.0-20200709193332-a1e58c29bdd3/go.mod h1:h/KNeRx7oYU4SpA4SoY7W2/NxDKEEVuwA6j9A27L4OI=
 github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc h1:cJlkeAx1QYgO5N80aF5xRGstVsRQwgLR7uA2FnP1ZjY=
 github.com/gorilla/handlers v0.0.0-20181012153334-350d97a79266 h1:mQtDGATRCnuJe8ZPx1AgBT5ILOSUQG9oIAeZGJMN0yQ=
 github.com/gorilla/handlers v0.0.0-20181012153334-350d97a79266/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
@@ -1332,9 +1341,11 @@ github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0
 github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0 h1:LiZB1h0GIcudcDci2bxbqI6DXV8bF8POAnArqvRrIyw=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0/go.mod h1:F/7q8/HZz+TXjlsoZQQKVYvXTZaFH4QRa3y+j1p7MS0=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=

--- a/orchestrator/scheduler/scheduler.go
+++ b/orchestrator/scheduler/scheduler.go
@@ -178,9 +178,9 @@ func (s *Scheduler) Update(msg loop.Msg) loop.Cmd {
 			if current < first {
 				current = first // cover for execoutwalker initialisation
 			}
-			// if we have 10 maxParallelJobs, we don't schedule jobs more than 15 segments ahead of the execout walker (1.5x)
+			// if we have 10 maxParallelJobs, we don't schedule jobs more than 20 segments ahead of the execout walker (2x)
 			// This way, a client reading blocks very slowly will not cause the parallel processing of millions of blocks
-			notAboveSegment = current + int(reqctx.Details(s.ctx).MaxParallelJobs)*3/2
+			notAboveSegment = current + int(reqctx.Details(s.ctx).MaxParallelJobs)*2
 		}
 
 		workUnit, workRange, skippedAboveSegment := s.Stages.NextJob(notAboveSegment)

--- a/orchestrator/work/launchqueue.go
+++ b/orchestrator/work/launchqueue.go
@@ -18,11 +18,12 @@ import (
 // land than the one it reads last, and a whole request can idle behind one unlucky low
 // segment.
 //
-// The queue holds the jobs a tier2 turned away, plus the ones held back behind them,
-// ordered by what the client reads first: lowest segment, then highest stage, the job that
-// also produces the partials of the stages under it. Only the first windowSize jobs of
-// that queue may dial at all; the ones behind them send nothing and wait. A job leaves the
-// queue as soon as a tier2 takes it, which lets exactly one more job start dialing.
+// The queue holds the jobs waiting to get into a tier2 — turned away for capacity, waiting
+// out a failure, or held back behind those — ordered by what the client reads first:
+// lowest segment, then highest stage, the job that also produces the partials of the
+// stages under it. Only the first windowSize jobs of that queue may dial at all; the ones
+// behind them send nothing and wait. A job leaves the queue the moment a tier2 takes it,
+// which lets exactly one more job start dialing.
 //
 // A job with nothing queued ahead of it dials immediately and never joins, so a fleet with
 // room is paced no differently than without the queue.
@@ -34,8 +35,9 @@ type LaunchQueue struct {
 }
 
 type launchWaiter struct {
-	refusedAt time.Time // zero until a tier2 turns the job away
-	jitter    time.Duration
+	// nextAttempt is when the job may dial again; zero means as soon as the window
+	// reaches it.
+	nextAttempt time.Time
 }
 
 // launchWindowPercent is how much of a request's worker count may be dialing tier2
@@ -72,11 +74,6 @@ func (q *LaunchQueue) WaitTurn(ctx context.Context, unit stage.Unit) error {
 		if wait <= 0 {
 			return nil
 		}
-		// Look again at least once per retry delay: the job's place in the queue moves on
-		// its own as the jobs ahead of it get in.
-		if wait > workerOverloadedRetryDelay {
-			wait = workerOverloadedRetryDelay
-		}
 
 		timer := time.NewTimer(wait)
 		select {
@@ -88,8 +85,9 @@ func (q *LaunchQueue) WaitTurn(ctx context.Context, unit stage.Unit) error {
 	}
 }
 
-// Refused records that a tier2 turned the job away. The job keeps its place in the queue.
-func (q *LaunchQueue) Refused(unit stage.Unit) {
+// Retry holds the job back for at least the given delay before it dials again. It keeps
+// its place in the queue, ahead of the jobs the client reads after it.
+func (q *LaunchQueue) Retry(unit stage.Unit, after time.Duration) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -97,8 +95,7 @@ func (q *LaunchQueue) Refused(unit stage.Unit) {
 	if !queued {
 		waiter = q.joinLocked(unit)
 	}
-	waiter.refusedAt = time.Now()
-	waiter.jitter = newJitter()
+	waiter.nextAttempt = time.Now().Add(after + newJitter())
 }
 
 // Leave takes the job out of the queue, moving up every job behind it. It is called once
@@ -137,14 +134,11 @@ func (q *LaunchQueue) waitFor(unit stage.Unit) time.Duration {
 		// this one sends nothing at all. Come back when the queue has moved.
 		return workerOverloadedRetryDelay
 	}
-	if waiter.refusedAt.IsZero() {
-		return 0
-	}
-	return time.Until(waiter.refusedAt.Add(workerOverloadedRetryDelay + waiter.jitter))
+	return time.Until(waiter.nextAttempt)
 }
 
 func (q *LaunchQueue) joinLocked(unit stage.Unit) *launchWaiter {
-	waiter := &launchWaiter{jitter: newJitter()}
+	waiter := &launchWaiter{}
 	q.waiting[unit] = waiter
 	return waiter
 }

--- a/orchestrator/work/launchqueue.go
+++ b/orchestrator/work/launchqueue.go
@@ -1,0 +1,169 @@
+package work
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/streamingfast/substreams/orchestrator/stage"
+)
+
+// LaunchQueue decides which jobs of one tier1 request may send a request to a tier2, and
+// when. A tier2 at its concurrent-request limit refuses the job without doing any work, so
+// the job dials again and can land on an instance that has room; when every job of the
+// request dials at the same rate, the segment the client reads first is no more likely to
+// land than the one it reads last, and a whole request can idle behind one unlucky low
+// segment.
+//
+// The queue holds the jobs a tier2 turned away, plus the ones held back behind them,
+// ordered by what the client reads first: lowest segment, then highest stage, the job that
+// also produces the partials of the stages under it. Only the first windowSize jobs of
+// that queue may dial at all; the ones behind them send nothing and wait. A job leaves the
+// queue as soon as a tier2 takes it, which lets exactly one more job start dialing.
+//
+// A job with nothing queued ahead of it dials immediately and never joins, so a fleet with
+// room is paced no differently than without the queue.
+type LaunchQueue struct {
+	windowSize int
+
+	mu      sync.Mutex
+	waiting map[stage.Unit]*launchWaiter
+}
+
+type launchWaiter struct {
+	refusedAt time.Time // zero until a tier2 turns the job away
+	jitter    time.Duration
+}
+
+// launchWindowPercent is how much of a request's worker count may be dialing tier2
+// instances while the fleet has no room, as a percentage.
+var launchWindowPercent = 20
+
+// minLaunchWindow keeps a small request from serializing onto a single job.
+const minLaunchWindow = 2
+
+func init() {
+	if val := os.Getenv("SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT"); val != "" {
+		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
+			launchWindowPercent = parsed
+		}
+	}
+}
+
+func NewLaunchQueue(maxWorkers int) *LaunchQueue {
+	windowSize := maxWorkers * launchWindowPercent / 100
+	if windowSize < minLaunchWindow {
+		windowSize = minLaunchWindow
+	}
+
+	return &LaunchQueue{
+		windowSize: windowSize,
+		waiting:    make(map[stage.Unit]*launchWaiter),
+	}
+}
+
+// WaitTurn blocks until the job may send its request to a tier2.
+func (q *LaunchQueue) WaitTurn(ctx context.Context, unit stage.Unit) error {
+	for {
+		wait := q.waitFor(unit)
+		if wait <= 0 {
+			return nil
+		}
+		// Look again at least once per retry delay: the job's place in the queue moves on
+		// its own as the jobs ahead of it get in.
+		if wait > workerOverloadedRetryDelay {
+			wait = workerOverloadedRetryDelay
+		}
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// Refused records that a tier2 turned the job away. The job keeps its place in the queue.
+func (q *LaunchQueue) Refused(unit stage.Unit) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	waiter, queued := q.waiting[unit]
+	if !queued {
+		waiter = q.joinLocked(unit)
+	}
+	waiter.refusedAt = time.Now()
+	waiter.jitter = newJitter()
+}
+
+// Leave takes the job out of the queue, moving up every job behind it. It is called once
+// the job is through to a tier2, and again when the job ends.
+func (q *LaunchQueue) Leave(unit stage.Unit) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	delete(q.waiting, unit)
+}
+
+// waitFor returns how long the job must wait before dialing, putting it in the queue if it
+// isn't there yet.
+func (q *LaunchQueue) waitFor(unit stage.Unit) time.Duration {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	position := 0
+	for other := range q.waiting {
+		if launchesBefore(other, unit) {
+			position++
+		}
+	}
+
+	waiter, queued := q.waiting[unit]
+	if !queued {
+		if position == 0 {
+			// Nothing is waiting for a tier2 ahead of it: the fleet is not pushing back.
+			return 0
+		}
+		waiter = q.joinLocked(unit)
+	}
+
+	if position >= q.windowSize {
+		// Outside the window: jobs the client needs sooner are still trying to get in, so
+		// this one sends nothing at all. Come back when the queue has moved.
+		return workerOverloadedRetryDelay
+	}
+	if waiter.refusedAt.IsZero() {
+		return 0
+	}
+	return time.Until(waiter.refusedAt.Add(workerOverloadedRetryDelay + waiter.jitter))
+}
+
+func (q *LaunchQueue) joinLocked(unit stage.Unit) *launchWaiter {
+	waiter := &launchWaiter{jitter: newJitter()}
+	q.waiting[unit] = waiter
+	return waiter
+}
+
+// launchesBefore orders jobs by what the client reads first: the lowest segment, and
+// within a segment the highest stage, whose job also produces the partials of the stages
+// under it. It is the order Stages.NextJob hands jobs out.
+func launchesBefore(a, b stage.Unit) bool {
+	if a.Segment != b.Segment {
+		return a.Segment < b.Segment
+	}
+	return a.Stage > b.Stage
+}
+
+// newJitter keeps jobs refused at the same instant from redialing in lockstep. It is only
+// ever added to the delay, never subtracted.
+func newJitter() time.Duration {
+	if workerOverloadedRetryJitter <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(workerOverloadedRetryJitter)))
+}

--- a/orchestrator/work/launchqueue.go
+++ b/orchestrator/work/launchqueue.go
@@ -41,10 +41,13 @@ type launchWaiter struct {
 }
 
 // launchWindowPercent is how much of a request's worker count may be dialing tier2
-// instances while the fleet has no room, as a percentage.
+// instances while the fleet has no room, as a percentage. maxLaunchWindow caps it: past a
+// few tens of workers, a wider window only spreads the fleet's free slots over more jobs
+// without getting the client its first segments any sooner. minLaunchWindow keeps a small
+// request from serializing onto a single job.
 var launchWindowPercent = 20
+var maxLaunchWindow = 15
 
-// minLaunchWindow keeps a small request from serializing onto a single job.
 const minLaunchWindow = 2
 
 func init() {
@@ -53,10 +56,19 @@ func init() {
 			launchWindowPercent = parsed
 		}
 	}
+
+	if val := os.Getenv("SUBSTREAMS_WORKER_LAUNCH_WINDOW_MAX"); val != "" {
+		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
+			maxLaunchWindow = parsed
+		}
+	}
 }
 
 func NewLaunchQueue(maxWorkers int) *LaunchQueue {
 	windowSize := maxWorkers * launchWindowPercent / 100
+	if windowSize > maxLaunchWindow {
+		windowSize = maxLaunchWindow
+	}
 	if windowSize < minLaunchWindow {
 		windowSize = minLaunchWindow
 	}

--- a/orchestrator/work/launchqueue_test.go
+++ b/orchestrator/work/launchqueue_test.go
@@ -50,7 +50,7 @@ func TestLaunchQueue_HeadRedialsOnTheRetryDelay(t *testing.T) {
 
 	q := NewLaunchQueue(10)
 	head := stage.Unit{Segment: 1}
-	q.Refused(head)
+	q.Retry(head, workerOverloadedRetryDelay)
 
 	start := time.Now()
 	require.NoError(t, q.WaitTurn(context.Background(), head))
@@ -66,8 +66,8 @@ func TestLaunchQueue_OutsideWindowDoesNotDial(t *testing.T) {
 
 	q := NewLaunchQueue(10) // window of 2
 	first, second := stage.Unit{Segment: 1}, stage.Unit{Segment: 2}
-	q.Refused(first)
-	q.Refused(second)
+	q.Retry(first, workerOverloadedRetryDelay)
+	q.Retry(second, workerOverloadedRetryDelay)
 
 	third := stage.Unit{Segment: 3}
 	done := make(chan struct{})
@@ -98,7 +98,7 @@ func TestLaunchQueue_LowSegmentGoesFirst(t *testing.T) {
 
 	q := NewLaunchQueue(10)
 	for segment := 10; segment < 20; segment++ {
-		q.Refused(stage.Unit{Segment: segment})
+		q.Retry(stage.Unit{Segment: segment}, workerOverloadedRetryDelay)
 	}
 
 	start := time.Now()
@@ -110,8 +110,8 @@ func TestLaunchQueue_ContextCanceled(t *testing.T) {
 	testLaunchDelays(t, 10*time.Second, 0)
 
 	q := NewLaunchQueue(10)
-	q.Refused(stage.Unit{Segment: 1})
-	q.Refused(stage.Unit{Segment: 2})
+	q.Retry(stage.Unit{Segment: 1}, workerOverloadedRetryDelay)
+	q.Retry(stage.Unit{Segment: 2}, workerOverloadedRetryDelay)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/orchestrator/work/launchqueue_test.go
+++ b/orchestrator/work/launchqueue_test.go
@@ -1,0 +1,120 @@
+package work
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/substreams/orchestrator/stage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLaunchDelays(t *testing.T, delay, jitter time.Duration) {
+	t.Helper()
+	prevDelay, prevJitter := workerOverloadedRetryDelay, workerOverloadedRetryJitter
+	workerOverloadedRetryDelay, workerOverloadedRetryJitter = delay, jitter
+	t.Cleanup(func() { workerOverloadedRetryDelay, workerOverloadedRetryJitter = prevDelay, prevJitter })
+}
+
+func TestLaunchQueue_WindowSize(t *testing.T) {
+	assert.Equal(t, 2, NewLaunchQueue(10).windowSize)
+	assert.Equal(t, 40, NewLaunchQueue(200).windowSize)
+	assert.Equal(t, 2, NewLaunchQueue(1).windowSize, "a small request never serializes onto one job")
+	assert.Equal(t, 2, NewLaunchQueue(0).windowSize)
+}
+
+func TestLaunchesBefore(t *testing.T) {
+	assert.True(t, launchesBefore(stage.Unit{Segment: 1, Stage: 0}, stage.Unit{Segment: 2, Stage: 3}))
+	assert.True(t, launchesBefore(stage.Unit{Segment: 1, Stage: 2}, stage.Unit{Segment: 1, Stage: 1}), "the last stage carries the ones under it")
+	assert.False(t, launchesBefore(stage.Unit{Segment: 2, Stage: 2}, stage.Unit{Segment: 1, Stage: 0}))
+}
+
+// TestLaunchQueue_NoQueueNoWait validates that jobs dial without delay while no tier2 is
+// turning them away.
+func TestLaunchQueue_NoQueueNoWait(t *testing.T) {
+	testLaunchDelays(t, time.Second, 0)
+
+	q := NewLaunchQueue(10)
+	start := time.Now()
+	for segment := 0; segment < 10; segment++ {
+		require.NoError(t, q.WaitTurn(context.Background(), stage.Unit{Segment: segment}))
+	}
+	assert.Less(t, time.Since(start), 100*time.Millisecond)
+}
+
+// TestLaunchQueue_HeadRedialsOnTheRetryDelay validates that a refused job at the head of
+// the queue keeps dialing on the short retry delay.
+func TestLaunchQueue_HeadRedialsOnTheRetryDelay(t *testing.T) {
+	testLaunchDelays(t, 50*time.Millisecond, 0)
+
+	q := NewLaunchQueue(10)
+	head := stage.Unit{Segment: 1}
+	q.Refused(head)
+
+	start := time.Now()
+	require.NoError(t, q.WaitTurn(context.Background(), head))
+	assert.GreaterOrEqual(t, time.Since(start), 40*time.Millisecond)
+	assert.Less(t, time.Since(start), 200*time.Millisecond)
+}
+
+// TestLaunchQueue_OutsideWindowDoesNotDial validates the point of the window: with the
+// first two jobs of a 10-worker request refused, the third sends nothing at all until one
+// of them is through.
+func TestLaunchQueue_OutsideWindowDoesNotDial(t *testing.T) {
+	testLaunchDelays(t, 20*time.Millisecond, 0)
+
+	q := NewLaunchQueue(10) // window of 2
+	first, second := stage.Unit{Segment: 1}, stage.Unit{Segment: 2}
+	q.Refused(first)
+	q.Refused(second)
+
+	third := stage.Unit{Segment: 3}
+	done := make(chan struct{})
+	go func() {
+		require.NoError(t, q.WaitTurn(context.Background(), third))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("job outside the launch window dialed a tier2")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	q.Leave(first) // it got in: the window moves up to the second and third jobs
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job never dialed after the window moved up to it")
+	}
+}
+
+// TestLaunchQueue_LowSegmentGoesFirst validates that a job the scheduler creates late for
+// a low segment dials right away, ahead of the higher segments already queued.
+func TestLaunchQueue_LowSegmentGoesFirst(t *testing.T) {
+	testLaunchDelays(t, time.Second, 0)
+
+	q := NewLaunchQueue(10)
+	for segment := 10; segment < 20; segment++ {
+		q.Refused(stage.Unit{Segment: segment})
+	}
+
+	start := time.Now()
+	require.NoError(t, q.WaitTurn(context.Background(), stage.Unit{Segment: 1}))
+	assert.Less(t, time.Since(start), 100*time.Millisecond)
+}
+
+func TestLaunchQueue_ContextCanceled(t *testing.T) {
+	testLaunchDelays(t, 10*time.Second, 0)
+
+	q := NewLaunchQueue(10)
+	q.Refused(stage.Unit{Segment: 1})
+	q.Refused(stage.Unit{Segment: 2})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.ErrorIs(t, q.WaitTurn(ctx, stage.Unit{Segment: 3}), context.Canceled)
+}

--- a/orchestrator/work/launchqueue_test.go
+++ b/orchestrator/work/launchqueue_test.go
@@ -19,7 +19,8 @@ func testLaunchDelays(t *testing.T, delay, jitter time.Duration) {
 
 func TestLaunchQueue_WindowSize(t *testing.T) {
 	assert.Equal(t, 2, NewLaunchQueue(10).windowSize)
-	assert.Equal(t, 40, NewLaunchQueue(200).windowSize)
+	assert.Equal(t, 10, NewLaunchQueue(50).windowSize)
+	assert.Equal(t, 15, NewLaunchQueue(200).windowSize, "the window is capped, a wider one only spreads the fleet thinner")
 	assert.Equal(t, 2, NewLaunchQueue(1).windowSize, "a small request never serializes onto one job")
 	assert.Equal(t, 2, NewLaunchQueue(0).windowSize)
 }

--- a/orchestrator/work/sessionworkerpool.go
+++ b/orchestrator/work/sessionworkerpool.go
@@ -39,6 +39,8 @@ type SessionWorkerPool struct {
 	borrowedWorkers      map[string]Worker
 	borrowedWorkersMutex sync.Mutex
 
+	launchQueue *LaunchQueue
+
 	rampingUp         *atomic.Bool
 	rampupWorkerGiven *atomic.Bool
 }
@@ -68,6 +70,7 @@ func NewSessionWorkerPool(
 		sessionKey:           sessionKey,
 		maxWorkersPerSession: maxWorkers,
 		borrowedWorkers:      make(map[string]Worker),
+		launchQueue:          NewLaunchQueue(maxWorkers),
 		rampingUp:            &atomic.Bool{},
 		rampupWorkerGiven:    &atomic.Bool{},
 	}
@@ -125,7 +128,7 @@ func (p *SessionWorkerPool) Borrow(ctx context.Context) (Worker, error) {
 		return nil, fmt.Errorf("failed to get worker: %w", err)
 	}
 
-	worker := NewRemoteWorker(p.clientFactory, workerKey, p.logger)
+	worker := NewRemoteWorker(p.clientFactory, workerKey, p.logger, p.launchQueue)
 
 	p.borrowedWorkersMutex.Lock()
 	p.borrowedWorkers[workerKey] = worker

--- a/orchestrator/work/worker.go
+++ b/orchestrator/work/worker.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/streamingfast/bstream"
 	"github.com/streamingfast/dauth"
-	"github.com/streamingfast/derr"
 	"github.com/streamingfast/dgrpc"
 	"github.com/streamingfast/substreams/client"
 	"github.com/streamingfast/substreams/metrics"
@@ -108,7 +106,13 @@ func NewRequest(ctx context.Context, req *reqctx.RequestDetails, stageIndex int,
 
 var workerMaxRetries = 5
 var workerMaxTimeoutRetries = 2
+
+// workerOverloadedRetryDelay is how long a job waits before dialing again when it could
+// not get into a tier2 at all. workerFailedRetryDelay is the one-time wait after a job
+// that did get in came back with a failure; a capacity refusal on the way back in is
+// again on the short delay.
 var workerOverloadedRetryDelay = 100 * time.Millisecond
+var workerFailedRetryDelay = 5 * time.Second
 var workerOverloadedRetryJitter = 100 * time.Millisecond
 
 func init() {
@@ -130,6 +134,12 @@ func init() {
 		}
 	}
 
+	if val := os.Getenv("SUBSTREAMS_WORKER_FAILED_RETRY_DELAY"); val != "" {
+		if parsed, err := time.ParseDuration(val); err == nil {
+			workerFailedRetryDelay = parsed
+		}
+	}
+
 	if val := os.Getenv("SUBSTREAMS_WORKER_OVERLOADED_RETRY_JITTER"); val != "" {
 		if parsed, err := time.ParseDuration(val); err == nil {
 			workerOverloadedRetryJitter = parsed
@@ -146,6 +156,27 @@ func isInstanceOverloadedErr(err error) bool {
 
 	grpcError := dgrpc.AsGRPCError(err)
 	return grpcError != nil && grpcError.Code() == codes.ResourceExhausted
+}
+
+// isJobRejectedErr reports whether the job never got into a tier2: refused at its
+// concurrent-request limit, the dial failed, or the load balancer had no instance to send
+// it to. Nothing ran, so another instance can take it right away.
+func isJobRejectedErr(err error) bool {
+	if isInstanceOverloadedErr(err) || errors.Is(err, ErrConnectionRefused) {
+		return true
+	}
+
+	grpcError := dgrpc.AsGRPCError(err)
+	return grpcError != nil && grpcError.Code() == codes.Unavailable && strings.Contains(err.Error(), "no healthy upstream")
+}
+
+// isExecutionTimeoutErr reports whether the tier2 was still running the job when the
+// deadline passed.
+func isExecutionTimeoutErr(err error) bool {
+	if grpcError := dgrpc.AsGRPCError(err); grpcError != nil && grpcError.Code() == codes.DeadlineExceeded {
+		return true
+	}
+	return strings.Contains(err.Error(), "DeadlineExceeded")
 }
 
 func (w *RemoteWorker) Work(ctx context.Context, unit stage.Unit, startBlock uint64, moduleNames []string, upstream *response.Stream, streamOutput bool) loop.Cmd {
@@ -168,13 +199,17 @@ func (w *RemoteWorker) Work(ctx context.Context, unit stage.Unit, startBlock uin
 		// waiting move up a position.
 		defer w.launchQueue.Leave(unit)
 
+		// The job stops competing for capacity the moment a tier2 takes it, not when it is
+		// done: the jobs behind it move up right away.
+		admitted := func() { w.launchQueue.Leave(unit) }
+
 		var previousError error
-		err := derr.RetryContext(ctx, math.MaxUint64, func(ctx context.Context) error {
+		err := func() error {
 			for {
 				// Every request sent to a tier2, first attempt included, waits for the jobs
 				// the client reads before this one.
 				if err := w.launchQueue.WaitTurn(ctx, unit); err != nil {
-					return derr.NewFatalError(err)
+					return err
 				}
 
 				w.logger.Info("launching remote worker",
@@ -186,77 +221,55 @@ func (w *RemoteWorker) Work(ctx context.Context, unit stage.Unit, startBlock uin
 					zap.NamedError("previous_error", previousError),
 				)
 
-				res = w.work(ctx, request, moduleNames, upstream, jobIdx)
+				res = w.work(ctx, request, moduleNames, upstream, jobIdx, admitted)
 				err := res.Error
 				// Keep the reason around: the request progress log reports failure counts, but
 				// only the error text says whether jobs die on an unreachable RPC endpoint, a
 				// module panic or an overloaded tier2.
 				stats.RecordJobError(jobIdx, err)
 
-				if _, ok := err.(*RetryableErr); ok && isInstanceOverloadedErr(err) {
-					// The retry is looking for a different instance rather than waiting on this
-					// one, so it goes back to the launch queue instead of the growing backoff,
-					// and does not count towards maxRetries.
-					previousError = err
+				if _, ok := err.(*RetryableErr); !ok {
+					// The job is done, or it failed for a reason no retry will fix.
+					return err
+				}
+				previousError = err
+
+				if isJobRejectedErr(err) {
+					// Nothing ran on the tier2. Another instance may have room right now, so the
+					// job goes back to the queue on the short delay, and this does not count
+					// towards maxRetries.
 					stats.RecordJobDelayed(jobIdx)
 					metrics.Tier1WorkerRejectedOverloadedCounter.Inc()
-					w.launchQueue.Refused(unit)
+					w.launchQueue.Retry(unit, workerOverloadedRetryDelay)
 					continue
 				}
 
-				// The job is through to a tier2, or failed for a reason redialing will not
-				// fix: either way it stops holding back the jobs behind it.
-				w.launchQueue.Leave(unit)
+				if streamOutput && upstream.DataSent() {
+					// never retry for jobs that stream blocks and have already sent some data
+					segmentStart := request.SegmentNumber * request.SegmentSize
+					return fmt.Errorf("segment [%d-%d] failed while streaming data: %w", segmentStart, segmentStart+request.SegmentSize, err)
+				}
 
-				switch err.(type) {
-				case *RetryableErr:
-					previousError = err
-					if errors.Is(err, ErrConnectionRefused) { // tier2 unavailable
-						stats.RecordJobDelayed(jobIdx)
-						metrics.Tier1WorkerRejectedOverloadedCounter.Inc()
-						// don't count towards maxRetries
-						return err
-					}
-					if grpcError := dgrpc.AsGRPCError(err); grpcError != nil && grpcError.Code() == codes.Unavailable && strings.Contains(err.Error(), "no healthy upstream") {
-						stats.RecordJobDelayed(jobIdx)
-						metrics.Tier1WorkerRejectedOverloadedCounter.Inc()
-						// don't count towards maxRetries
-						return err
-					}
+				metrics.Tier1WorkerRetryCounter.Inc()
+				stats.RecordJobRetried(jobIdx)
 
-					if streamOutput && upstream.DataSent() {
-						// never retry for jobs that stream blocks and have already sent some data
-						segmentStart := request.SegmentNumber * request.SegmentSize
-						return derr.NewFatalError(fmt.Errorf("segment [%d-%d] failed while streaming data: %w", segmentStart, segmentStart+request.SegmentSize, err))
+				segmentStart := request.SegmentNumber * request.SegmentSize
+				if isExecutionTimeoutErr(err) {
+					executionTimeouts++
+					if executionTimeouts >= maxExecutionTimeouts {
+						return fmt.Errorf("segment [%d-%d] timed out %d times, giving up. Last error from worker: %s", segmentStart, segmentStart+request.SegmentSize, executionTimeouts, err)
 					}
-					metrics.Tier1WorkerRetryCounter.Inc()
-					stats.RecordJobRetried(jobIdx)
-
-					grpcError := dgrpc.AsGRPCError(err)
-					if (grpcError != nil && grpcError.Code() == codes.DeadlineExceeded) || strings.Contains(err.Error(), "DeadlineExceeded") {
-						executionTimeouts++
-						if executionTimeouts >= maxExecutionTimeouts {
-							segmentStart := request.SegmentNumber * request.SegmentSize
-							return derr.NewFatalError(fmt.Errorf("segment [%d-%d] timed out %d times, giving up. Last error from worker: %s", segmentStart, segmentStart+request.SegmentSize, executionTimeouts, err))
-						}
-						return err
-					}
-
+				} else {
 					retryIdx++
 					if retryIdx >= maxRetries {
-						segmentStart := request.SegmentNumber * request.SegmentSize
-						return derr.NewFatalError(fmt.Errorf("segment [%d-%d] failed %d times, giving up. Last error from worker: %s", segmentStart, segmentStart+request.SegmentSize, retryIdx, err))
+						return fmt.Errorf("segment [%d-%d] failed %d times, giving up. Last error from worker: %s", segmentStart, segmentStart+request.SegmentSize, retryIdx, err)
 					}
-
-					return err
-				default:
-					if err != nil {
-						return derr.NewFatalError(err)
-					}
-					return nil
 				}
+
+				// The job ran and failed: it waits once, then goes back in line like any other.
+				w.launchQueue.Retry(unit, workerFailedRetryDelay)
 			}
-		})
+		}()
 
 		timeTook := time.Since(startTime)
 		if err != nil {
@@ -311,7 +324,7 @@ func (w *RemoteWorker) Work(ctx context.Context, unit stage.Unit, startBlock uin
 
 var ErrConnectionRefused = errors.New("connection refused")
 
-func (w *RemoteWorker) work(ctx context.Context, request *pbssinternal.ProcessRangeRequest, _ []string, upstream *response.Stream, jobIdx uint64) (res *Result) {
+func (w *RemoteWorker) work(ctx context.Context, request *pbssinternal.ProcessRangeRequest, _ []string, upstream *response.Stream, jobIdx uint64, admitted func()) (res *Result) {
 	metrics.Tier1ActiveWorkerRequest.Inc()
 	metrics.Tier1WorkerRequestCounter.Inc()
 	defer metrics.Tier1ActiveWorkerRequest.Dec()
@@ -373,8 +386,17 @@ func (w *RemoteWorker) work(ctx context.Context, request *pbssinternal.ProcessRa
 
 	stats := reqctx.ReqStats(ctx)
 	var processedBlocks uint64
+	firstResponse := true
 	for {
 		resp, err := stream.Recv()
+
+		if firstResponse {
+			firstResponse = false
+			if err == nil || !isJobRejectedErr(err) {
+				// The tier2 did not turn the job away, so it is running it.
+				admitted()
+			}
+		}
 
 		if err := ctx.Err(); err != nil {
 			if err == context.Canceled {

--- a/orchestrator/work/worker.go
+++ b/orchestrator/work/worker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -53,15 +52,22 @@ type RemoteWorker struct {
 	tracer        ttrace.Tracer
 	logger        *zap.Logger
 	id            string
+	// launchQueue is shared by every worker of the request: it decides which job gets to
+	// send its request to a tier2 first when the fleet has no room.
+	launchQueue *LaunchQueue
 }
 
-func NewRemoteWorker(clientFactory client.InternalClientFactory, id string, logger *zap.Logger) *RemoteWorker {
+func NewRemoteWorker(clientFactory client.InternalClientFactory, id string, logger *zap.Logger, launchQueue *LaunchQueue) *RemoteWorker {
 	logger = logger.Named("remote-worker")
+	if launchQueue == nil {
+		launchQueue = NewLaunchQueue(1)
+	}
 	return &RemoteWorker{
 		clientFactory: clientFactory,
 		tracer:        otel.GetTracerProvider().Tracer("worker"),
 		logger:        logger,
 		id:            id,
+		launchQueue:   launchQueue,
 	}
 }
 
@@ -102,7 +108,7 @@ func NewRequest(ctx context.Context, req *reqctx.RequestDetails, stageIndex int,
 
 var workerMaxRetries = 5
 var workerMaxTimeoutRetries = 2
-var workerOverloadedRetryDelay = 300 * time.Millisecond
+var workerOverloadedRetryDelay = 100 * time.Millisecond
 var workerOverloadedRetryJitter = 100 * time.Millisecond
 
 func init() {
@@ -142,26 +148,6 @@ func isInstanceOverloadedErr(err error) bool {
 	return grpcError != nil && grpcError.Code() == codes.ResourceExhausted
 }
 
-// waitBeforeRetryOverloaded sleeps workerOverloadedRetryDelay plus or minus
-// workerOverloadedRetryJitter, returning the context error if the request goes away
-// while waiting.
-func waitBeforeRetryOverloaded(ctx context.Context) error {
-	delay := workerOverloadedRetryDelay
-	if workerOverloadedRetryJitter > 0 {
-		delay += time.Duration(rand.Int63n(int64(workerOverloadedRetryJitter)*2)) - workerOverloadedRetryJitter
-	}
-
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
-}
-
 func (w *RemoteWorker) Work(ctx context.Context, unit stage.Unit, startBlock uint64, moduleNames []string, upstream *response.Stream, streamOutput bool) loop.Cmd {
 	request := NewRequest(ctx, reqctx.Details(ctx), unit.Stage, startBlock, streamOutput)
 	logger := reqctx.Logger(ctx)
@@ -178,9 +164,19 @@ func (w *RemoteWorker) Work(ctx context.Context, unit stage.Unit, startBlock uin
 		startBlock := request.SegmentNumber * request.SegmentSize
 		jobIdx := stats.RecordNewSubrequest(request.Stage, startBlock, startBlock+request.SegmentSize)
 
+		// Whatever ends this job, it stops competing for a tier2, so the jobs still
+		// waiting move up a position.
+		defer w.launchQueue.Leave(unit)
+
 		var previousError error
 		err := derr.RetryContext(ctx, math.MaxUint64, func(ctx context.Context) error {
 			for {
+				// Every request sent to a tier2, first attempt included, waits for the jobs
+				// the client reads before this one.
+				if err := w.launchQueue.WaitTurn(ctx, unit); err != nil {
+					return derr.NewFatalError(err)
+				}
+
 				w.logger.Info("launching remote worker",
 					zap.Uint64("segment", request.SegmentNumber),
 					zap.Uint32("stage", request.Stage),
@@ -199,16 +195,18 @@ func (w *RemoteWorker) Work(ctx context.Context, unit stage.Unit, startBlock uin
 
 				if _, ok := err.(*RetryableErr); ok && isInstanceOverloadedErr(err) {
 					// The retry is looking for a different instance rather than waiting on this
-					// one, so it runs on a short fixed delay instead of the growing backoff, and
-					// does not count towards maxRetries.
+					// one, so it goes back to the launch queue instead of the growing backoff,
+					// and does not count towards maxRetries.
 					previousError = err
 					stats.RecordJobDelayed(jobIdx)
 					metrics.Tier1WorkerRejectedOverloadedCounter.Inc()
-					if err := waitBeforeRetryOverloaded(ctx); err != nil {
-						return derr.NewFatalError(err)
-					}
+					w.launchQueue.Refused(unit)
 					continue
 				}
+
+				// The job is through to a tier2, or failed for a reason redialing will not
+				// fix: either way it stops holding back the jobs behind it.
+				w.launchQueue.Leave(unit)
 
 				switch err.(type) {
 				case *RetryableErr:

--- a/orchestrator/work/worker_foundational_store_test.go
+++ b/orchestrator/work/worker_foundational_store_test.go
@@ -76,7 +76,7 @@ func newFakeWorker(streamErr error) (*RemoteWorker, *fakeSubstreamsClient) {
 	factory := func() (pbssinternal.SubstreamsClient, func() error, []grpc.CallOption, client.Headers, error) {
 		return fake, func() error { return nil }, nil, client.Headers{}, nil
 	}
-	return NewRemoteWorker(factory, "test-worker", zap.NewNop()), fake
+	return NewRemoteWorker(factory, "test-worker", zap.NewNop(), NewLaunchQueue(1)), fake
 }
 
 // TestWork_FoundationalStoreFatalIsRetryable validates how tier1 classifies the

--- a/orchestrator/work/worker_foundational_store_test.go
+++ b/orchestrator/work/worker_foundational_store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/streamingfast/substreams"
 	"github.com/streamingfast/substreams/client"
@@ -89,7 +90,7 @@ func TestWork_FoundationalStoreFatalIsRetryable(t *testing.T) {
 
 	t.Run("internal (foundational store fatal) is retryable", func(t *testing.T) {
 		w, _ := newFakeWorker(status.Error(codes.Internal, "module \"m\": foundational store request failed: store unreachable: connection refused"))
-		res := w.work(testWorkerCtx(), request, nil, upstream, 0)
+		res := w.work(testWorkerCtx(), request, nil, upstream, 0, func() {})
 
 		var retryable *RetryableErr
 		require.True(t, errors.As(res.Error, &retryable), "codes.Internal must be retryable, got: %v", res.Error)
@@ -97,7 +98,7 @@ func TestWork_FoundationalStoreFatalIsRetryable(t *testing.T) {
 
 	t.Run("invalid argument (deterministic) is not retryable", func(t *testing.T) {
 		w, _ := newFakeWorker(status.Error(codes.InvalidArgument, "module \"m\": boom (deterministic error)"))
-		res := w.work(testWorkerCtx(), request, nil, upstream, 0)
+		res := w.work(testWorkerCtx(), request, nil, upstream, 0, func() {})
 
 		var retryable *RetryableErr
 		require.False(t, errors.As(res.Error, &retryable), "codes.InvalidArgument must NOT be retryable, got: %v", res.Error)
@@ -107,12 +108,12 @@ func TestWork_FoundationalStoreFatalIsRetryable(t *testing.T) {
 
 // TestWork_RetriesThenBubblesUp validates that a foundational store fatal error
 // (arriving as codes.Internal) is retried exactly workerMaxRetries times before
-// it gives up and bubbles up to the user as a failed job. workerMaxRetries is
-// lowered here to keep the test fast (the real default is 5).
+// it gives up and bubbles up to the user as a failed job. workerMaxRetries and the
+// between-attempts wait are lowered here to keep the test fast.
 func TestWork_RetriesThenBubblesUp(t *testing.T) {
-	prev := workerMaxRetries
-	workerMaxRetries = 2
-	defer func() { workerMaxRetries = prev }()
+	prevRetries, prevDelay := workerMaxRetries, workerFailedRetryDelay
+	workerMaxRetries, workerFailedRetryDelay = 2, 10*time.Millisecond
+	defer func() { workerMaxRetries, workerFailedRetryDelay = prevRetries, prevDelay }()
 
 	w, fake := newFakeWorker(status.Error(codes.Internal, "module \"m\": foundational store request failed: organization id mismatch"))
 

--- a/orchestrator/work/worker_overloaded_test.go
+++ b/orchestrator/work/worker_overloaded_test.go
@@ -40,12 +40,12 @@ func newScriptedWorker(errs ...error) (*RemoteWorker, *scriptedSubstreamsClient)
 	factory := func() (pbssinternal.SubstreamsClient, func() error, []grpc.CallOption, client.Headers, error) {
 		return fake, func() error { return nil }, nil, client.Headers{}, nil
 	}
-	return NewRemoteWorker(factory, "test-worker", zap.NewNop()), fake
+	return NewRemoteWorker(factory, "test-worker", zap.NewNop(), NewLaunchQueue(1)), fake
 }
 
 // TestWork_OverloadedRetriesFastAndDoesNotCount validates that a tier2 refusing the job at
-// its concurrent-request limit is redialed on the short fixed delay rather than the growing
-// Fibonacci backoff, and that those attempts are not charged against workerMaxRetries.
+// its concurrent-request limit is redialed on the launch queue's short delay rather than the
+// growing Fibonacci backoff, and that those attempts are not charged against workerMaxRetries.
 func TestWork_OverloadedRetriesFastAndDoesNotCount(t *testing.T) {
 	prevRetries, prevDelay, prevJitter := workerMaxRetries, workerOverloadedRetryDelay, workerOverloadedRetryJitter
 	workerMaxRetries, workerOverloadedRetryDelay, workerOverloadedRetryJitter = 2, 10*time.Millisecond, 5*time.Millisecond
@@ -64,19 +64,6 @@ func TestWork_OverloadedRetriesFastAndDoesNotCount(t *testing.T) {
 	require.True(t, ok, "expected MsgJobSucceeded, got %T (%v)", msg, msg)
 	assert.Equal(t, 4, fake.calls, "3 refusals then a successful attempt, none charged to workerMaxRetries")
 	assert.Less(t, time.Since(start), time.Second, "refusals must not fall back to the Fibonacci backoff")
-}
-
-// TestWaitBeforeRetryOverloaded_ContextCanceled validates that a job whose request goes
-// away while it waits for a free tier2 stops instead of dialing again.
-func TestWaitBeforeRetryOverloaded_ContextCanceled(t *testing.T) {
-	prevDelay := workerOverloadedRetryDelay
-	workerOverloadedRetryDelay = 10 * time.Second
-	defer func() { workerOverloadedRetryDelay = prevDelay }()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	assert.ErrorIs(t, waitBeforeRetryOverloaded(ctx), context.Canceled)
 }
 
 func TestIsInstanceOverloadedErr(t *testing.T) {

--- a/orchestrator/work/worker_overloaded_test.go
+++ b/orchestrator/work/worker_overloaded_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/streamingfast/substreams"
 	"github.com/streamingfast/substreams/client"
+	"github.com/streamingfast/substreams/orchestrator/loop"
 	"github.com/streamingfast/substreams/orchestrator/response"
 	"github.com/streamingfast/substreams/orchestrator/stage"
 	pbssinternal "github.com/streamingfast/substreams/pb/sf/substreams/intern/v2"
@@ -16,6 +17,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -72,4 +74,114 @@ func TestIsInstanceOverloadedErr(t *testing.T) {
 	assert.False(t, isInstanceOverloadedErr(status.Error(codes.Unavailable, "no healthy upstream")), "whole fleet unreachable, keep the growing backoff")
 	assert.False(t, isInstanceOverloadedErr(ErrConnectionRefused))
 	assert.False(t, isInstanceOverloadedErr(status.Error(codes.Internal, "boom")))
+}
+
+// blockingProcessRangeStream answers the first Recv, then holds the stream open until it
+// is released, standing in for a tier2 that took the job and is running it.
+type blockingProcessRangeStream struct {
+	started  chan struct{}
+	release  chan struct{}
+	answered bool
+}
+
+func (s *blockingProcessRangeStream) Recv() (*pbssinternal.ProcessRangeResponse, error) {
+	if !s.answered {
+		s.answered = true
+		close(s.started)
+		return &pbssinternal.ProcessRangeResponse{}, nil
+	}
+	<-s.release
+	return nil, io.EOF
+}
+func (s *blockingProcessRangeStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+func (s *blockingProcessRangeStream) Trailer() metadata.MD         { return nil }
+func (s *blockingProcessRangeStream) CloseSend() error             { return nil }
+func (s *blockingProcessRangeStream) Context() context.Context     { return context.Background() }
+func (s *blockingProcessRangeStream) SendMsg(any) error            { return nil }
+func (s *blockingProcessRangeStream) RecvMsg(any) error            { return nil }
+
+// refusedThenBlockingClient refuses the first job the way a tier2 at its concurrent-request
+// limit does, then takes the second one and keeps running it.
+type refusedThenBlockingClient struct {
+	blocking *blockingProcessRangeStream
+	calls    int
+}
+
+func (c *refusedThenBlockingClient) ProcessRange(ctx context.Context, in *pbssinternal.ProcessRangeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[pbssinternal.ProcessRangeResponse], error) {
+	c.calls++
+	if c.calls == 1 {
+		return &fakeProcessRangeStream{err: status.Error(codes.ResourceExhausted, "service currently overloaded")}, nil
+	}
+	return c.blocking, nil
+}
+
+// TestWork_LeavesLaunchQueueOnceAdmitted validates that a job stops holding its place in
+// the launch queue as soon as a tier2 takes it, rather than when it finishes: the jobs
+// behind it must be free to dial while it runs.
+func TestWork_LeavesLaunchQueueOnceAdmitted(t *testing.T) {
+	prevDelay, prevJitter := workerOverloadedRetryDelay, workerOverloadedRetryJitter
+	workerOverloadedRetryDelay, workerOverloadedRetryJitter = 10*time.Millisecond, 0
+	defer func() { workerOverloadedRetryDelay, workerOverloadedRetryJitter = prevDelay, prevJitter }()
+
+	blocking := &blockingProcessRangeStream{started: make(chan struct{}), release: make(chan struct{})}
+	fake := &refusedThenBlockingClient{blocking: blocking}
+	factory := func() (pbssinternal.SubstreamsClient, func() error, []grpc.CallOption, client.Headers, error) {
+		return fake, func() error { return nil }, nil, client.Headers{}, nil
+	}
+
+	queue := NewLaunchQueue(10)
+	w := NewRemoteWorker(factory, "test-worker", zap.NewNop(), queue)
+
+	unit := stage.Unit{Stage: 0, Segment: 0}
+	done := make(chan loop.Msg, 1)
+	go func() {
+		cmd := w.Work(testWorkerCtx(), unit, 0, []string{"m"}, response.New(func(substreams.ResponseFromAnyTier) error { return nil }), false)
+		done <- cmd()
+	}()
+
+	select {
+	case <-blocking.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker never got into the fake tier2")
+	}
+
+	queue.mu.Lock()
+	queued := len(queue.waiting)
+	queue.mu.Unlock()
+	assert.Equal(t, 0, queued, "a running job must not hold its place in the launch queue")
+
+	close(blocking.release)
+	select {
+	case msg := <-done:
+		_, ok := msg.(MsgJobSucceeded)
+		assert.True(t, ok, "expected MsgJobSucceeded, got %T (%v)", msg, msg)
+	case <-time.After(2 * time.Second):
+		t.Fatal("job never completed")
+	}
+}
+
+// TestWork_FailedJobWaitsOnceThenRetriesFast validates that the longer wait belongs to the
+// failure itself: a tier2 refusing the job on the way back in puts it on the short delay
+// again rather than on another failure wait.
+func TestWork_FailedJobWaitsOnceThenRetriesFast(t *testing.T) {
+	prevFailed, prevDelay, prevJitter := workerFailedRetryDelay, workerOverloadedRetryDelay, workerOverloadedRetryJitter
+	workerFailedRetryDelay, workerOverloadedRetryDelay, workerOverloadedRetryJitter = 300*time.Millisecond, 10*time.Millisecond, 0
+	defer func() {
+		workerFailedRetryDelay, workerOverloadedRetryDelay, workerOverloadedRetryJitter = prevFailed, prevDelay, prevJitter
+	}()
+
+	overloaded := status.Error(codes.ResourceExhausted, "service currently overloaded")
+	failed := status.Error(codes.Internal, "module \"m\": boom")
+	w, fake := newScriptedWorker(failed, overloaded, overloaded)
+
+	start := time.Now()
+	cmd := w.Work(testWorkerCtx(), stage.Unit{Stage: 0, Segment: 0}, 0, []string{"m"}, response.New(func(substreams.ResponseFromAnyTier) error { return nil }), false)
+	msg := cmd()
+	took := time.Since(start)
+
+	_, ok := msg.(MsgJobSucceeded)
+	require.True(t, ok, "expected MsgJobSucceeded, got %T (%v)", msg, msg)
+	assert.Equal(t, 4, fake.calls)
+	assert.GreaterOrEqual(t, took, 300*time.Millisecond, "the failure waits once")
+	assert.Less(t, took, 600*time.Millisecond, "the refusals that follow it do not")
 }


### PR DESCRIPTION
Jobs of a tier1 request race each other for whatever tier2 instance has room. A tier2 at its concurrent-request limit refuses the job without doing any work, the job redials and can land anywhere, so the segment the client reads first is no more likely to land than one it will only read minutes later. When the low segment loses that race a few times, the execout walker stalls on it and the whole request idles behind it.

This adds a per-request `LaunchQueue` (`orchestrator/work/launchqueue.go`). A job asks it for a turn before every request it sends to a tier2, first attempt and retries alike.

**The queue** holds the jobs waiting to get in, ordered by what the client reads first: lowest segment, then highest stage within a segment (that job also produces the partials of the stages under it). A job leaves the queue the moment a tier2 takes it — not when it finishes — so the jobs behind it move up while it runs.

**The window.** Only the first 20% of the queue may dial at all, at least two jobs and at most 15. The ones behind them send nothing — they are not retrying slowly, they are not dialing. Each admission moves the window up by one job.

**No queue, no wait.** A job with nothing queued ahead of it dials immediately and never joins, so a fleet with room is paced exactly as before.

### One retry path, two delays

`derr.RetryContext` and its growing 1s-to-5s backoff are gone from the worker. It was only ever contributing the sleep: `maxRetries` and `maxExecutionTimeouts` are hand-rolled locals in the loop, and derr was passed `math.MaxUint64` retries. Every reason to dial again now goes through the queue, which means retries keep the request's reading order instead of jumping ahead of it. Two delays replace the curve:

- **100ms** — the job never got in and nothing ran: refused for capacity, connection refused, or `no healthy upstream`. Another instance may have room right now. Not charged to any counter, as before.
- **5s, once** — the job got in and then failed: an execution timeout or any other retryable error. If a tier2 then turns it away for capacity on the way back in, it is back on the 100ms delay with its failure already counted.

The counters that end a hopeless request are unchanged: five failures, or two execution timeouts.

### What it looks like with 10 workers, fleet full

Jobs for segments 1-10 are dispatched. Segment 1 dials, is refused, joins the queue; segments 2-10 join behind it. Segments 1 and 2 redial every 100ms; segments 3-10 send nothing. A tier2 frees a slot and it goes to segment 1 or 2 — it cannot go to segment 7, which isn't dialing. Segment 1 gets in and leaves, and segment 3 starts dialing.

At 50 workers the window is 10 jobs. At 200 it is 15, not 40: past a few tens of workers a wider window only spreads the fleet's free slots over more jobs without getting the client its first segments any sooner.

Because the order is the segment and not the job's age, a job the scheduler re-creates late for a low segment (the re-run after a missing execout file) goes to the front of the queue and dials on its next tick.

### Also here

`orchestrator/scheduler/scheduler.go` now schedules jobs up to 2x the request's worker count ahead of the blocks the client is reading, instead of 1.5x.

### Trade-offs worth knowing

- A job dialing, or waiting out its 5s after a failure, still holds its window slot. At 10 workers that leaves one other job dialing meanwhile.
- Under pressure the request fills freed slots at up to the window size per 100ms. Jobs run for seconds, so this doesn't cost throughput, but it is a real change.
- The dial load on the fleet drops at high worker counts (15 per 100ms at 200 workers, against 200 per 300ms before) and barely moves at low ones. `SUBSTREAMS_WORKER_LAUNCH_WINDOW_PERCENT` (default 20) and `SUBSTREAMS_WORKER_LAUNCH_WINDOW_MAX` (default 15) are the levers.

### Tests

`launchqueue_test.go` covers the window sizing and its cap, the launch order, no wait while nothing is queued, a job outside the window staying silent until the window reaches it, a late low segment going to the front, the head's redial cadence, and cancellation. `worker_overloaded_test.go` adds two worker-level tests: a job leaves the queue while it is still running, and a failure waits once without putting the capacity refusals that follow it on the long delay. `go test -race ./orchestrator/...` is clean.