### PR TITLE
Count requests that are still setting up in the eviction autoscaler metric

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -37,8 +37,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   horizontal autoscaler input on tier1: the higher of the plain active-request count and the number of requests the
   CPU budget is being spent at (`nominal_capacity * cpu_usage_ratio / cpu_eviction_target_ratio`). A pod full of
   expensive requests, or one holding its CPU down by eviction, reports itself at capacity, so the autoscaler will
-  add more pods. `CPUEviction.NominalCapacity` should be set to the autoscaler's per-pod request target; it defaults
-  to the active-requests soft limit.
+  add more pods. Its active-request count is the one admission uses, so it includes requests still setting up and
+  never reads below `substreams_active_requests`. `CPUEviction.NominalCapacity` should be set to the autoscaler's
+  per-pod request target; it defaults to the active-requests soft limit.
 
 - Trimmed tier2's per-segment logging: a large backfill fans out into tens of thousands of `ProcessRange` calls,
   and each one was logging ~10 `Info` lines with no steady-state diagnostic value, which could spike a pod's log

--- a/go.mod
+++ b/go.mod
@@ -316,7 +316,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.45.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -842,8 +842,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 h1:SbTAbRFnd5kjQXbczszQ0hdk3ctwYf3qBNH9jIsGclE=

--- a/service/active_requests/evictor.go
+++ b/service/active_requests/evictor.go
@@ -145,8 +145,9 @@ type Evictor struct {
 	reader  *CPUReader
 	logger  *zap.Logger
 
-	overloaded atomic.Bool
-	onEvaluate func()
+	overloaded          atomic.Bool
+	onEvaluate          func()
+	countActiveRequests func() int
 
 	// zero time = condition not currently holding
 	overloadSince time.Time
@@ -193,6 +194,22 @@ func (ev *Evictor) OnEvaluate(fn func()) {
 	ev.onEvaluate = fn
 }
 
+// CountActiveRequestsWith overrides how the evictor counts the pod's active
+// requests when it publishes substreams_tier1_effective_active_requests. The
+// manager's map only holds requests that finished setting up, while admission
+// and substreams_active_requests count them from the moment they arrive, and
+// the autoscaler metric has to agree with those. Must be called before Run.
+func (ev *Evictor) CountActiveRequestsWith(fn func() int) {
+	ev.countActiveRequests = fn
+}
+
+func (ev *Evictor) activeRequests(inManager int) int {
+	if ev.countActiveRequests == nil {
+		return inManager
+	}
+	return ev.countActiveRequests()
+}
+
 func (ev *Evictor) notify() {
 	if ev.onEvaluate != nil {
 		ev.onEvaluate()
@@ -227,9 +244,9 @@ func (ev *Evictor) tick(now time.Time) {
 		ev.clearOverload()
 		return
 	}
-	candidates, totalActive := ev.sampleBurnRates(now)
+	candidates, inManager := ev.sampleBurnRates(now)
 	firing := ev.classify(signals, now)
-	ev.publishMetrics(signals, totalActive)
+	ev.publishMetrics(signals, ev.activeRequests(inManager))
 	ev.notify()
 
 	if !ev.overloaded.Load() {

--- a/service/active_requests/evictor_test.go
+++ b/service/active_requests/evictor_test.go
@@ -205,3 +205,14 @@ func TestTick_UnreadableCgroupClearsOverload(t *testing.T) {
 	assert.False(t, ev.IsOverloaded())
 	assert.Equal(t, 2, evaluations)
 }
+
+func TestActiveRequests_PrefersTheHostCount(t *testing.T) {
+	ev := newTestEvictor(DefaultEvictorConfig())
+
+	// without an override the manager's own count is used
+	assert.Equal(t, 3, ev.activeRequests(3))
+
+	// the host counts requests still setting up, which the manager does not hold yet
+	ev.CountActiveRequestsWith(func() int { return 7 })
+	assert.Equal(t, 7, ev.activeRequests(3))
+}

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -294,6 +294,7 @@ func NewTier1(
 			}
 			evictor := active_requests.NewEvictor(evictorConfig, s.activeRequestsManager, reader, logger)
 			evictor.OnEvaluate(s.refreshReadiness)
+			evictor.CountActiveRequestsWith(s.getActiveRequestCount)
 			s.evictor = evictor
 			go evictor.Run(s.Terminating())
 		}


### PR DESCRIPTION
`substreams_tier1_effective_active_requests` could read *below* `substreams_active_requests`, the metric it is meant to replace as the horizontal autoscaler input. It is a `max()` of the active-request count and the CPU-derived count, so that should not be possible.

The two were counting different sets of requests. `substreams_active_requests` increments early in `blocks()`, while a request only enters the evictor's manager map after session acquisition, the deterministic-error check against the cache store and store cloning. Every request still in setup was counted by one and invisible to the other. Teardown has the same shape: the deferred `manager.Remove` is registered later than the deferred `Tier1ActiveRequests.Dec()`, so it runs first.

The evictor now takes its active-request count from the same accessor admission uses (`getActiveRequestCount`), through a `CountActiveRequestsWith` hook, falling back to the manager map when unset. The manager map is still the source of eviction candidates — a request in setup has no stats to sample and nothing worth cancelling.

Effect: a pod with requests queued in setup no longer looks emptier to the autoscaler than it is, and the eviction metric agrees with the soft and hard admission limits about how many requests exist.