### PR TITLE
Overlap store reads and sends when tier1 streams cached execution output

### DIFF
--- a/app/tier1.go
+++ b/app/tier1.go
@@ -27,6 +27,7 @@ import (
 	"github.com/streamingfast/substreams/reqctx"
 	"github.com/streamingfast/substreams/service"
 	"github.com/streamingfast/substreams/service/active_requests"
+	"github.com/streamingfast/substreams/storage/execout"
 	"github.com/streamingfast/substreams/wasm"
 	_ "github.com/streamingfast/substreams/wasm/wasmtime"
 	"github.com/streamingfast/substreams/wasm/wazero"
@@ -62,6 +63,7 @@ func NewDefaultTier1Config() *Tier1Config {
 		MergedBlocksBundleSize: bstream.DefaultMergedBlocksBundleSize,
 		BlockExecutionTimeout:  1 * time.Minute,
 		OutputBufferSize:       100,
+		ExecOutPrefetch:        execout.PrefetchConfig{Depth: execout.MaxPrefetchDepth, BudgetBytes: 64 << 20},
 	}
 }
 
@@ -110,6 +112,12 @@ type Tier1Config struct {
 
 	SharedCacheSize  uint64
 	OutputBufferSize uint64 // Used to bundle execout messages within 'BlockScopedDatas' when using protocol V4
+
+	// ExecOutPrefetch bounds how far ahead a production-mode request downloads cached
+	// execution output files while streaming them: at most Depth segments (capped at
+	// execout.MaxPrefetchDepth), holding at most BudgetBytes of decompressed data per
+	// request. Zero disables prefetching.
+	ExecOutPrefetch execout.PrefetchConfig
 
 	// StoreSizeLimit, if non-zero, overrides the default store size limit (in bytes)
 	// used by tier2 stores. The value is forwarded to tier2 on each request.
@@ -298,6 +306,7 @@ func (a *Tier1App) Run() error {
 	if a.config.StoreSizeLimit != 0 {
 		opts = append(opts, service.WithStoreSizeLimit(a.config.StoreSizeLimit))
 	}
+	opts = append(opts, service.WithExecOutPrefetch(a.config.ExecOutPrefetch))
 
 	if a.config.TmpDir != "" {
 		wazero.SetTempDir(a.config.TmpDir)

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -42,6 +42,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `substreams-tier1` no longer copies each cached execution output payload once more while decoding it: the item
   now aliases the buffer it was read into instead of copying out of it.
 
+- `substreams-tier1` now writes the `substreams.spkg` and `last_used` cache markers in the background instead of
+  before the pipeline starts, so those object store round trips no longer delay the first block sent. The request
+  waits for them on its way out, and they run on a detached context with a 30 second timeout so a client that
+  disconnects early still leaves its usage marker behind.
+
 - `substreams-tier1` can now evict requests when its CPU is saturated. When its own cgroup reports CPU usage above
   90% of quota for 15 seconds, the pod advertises itself unready to the load balancer, refuses new requests, waits
   for the balancer to drain, then cancels enough of the heaviest requests with `Unavailable` to bring usage back

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -33,6 +33,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   existing retry loop, and the prefetcher stops looking ahead until the walker reaches them. Setting either bound
   to zero turns prefetching off.
 
+- `substreams-tier1` now sends each batch of cached execution output on a separate goroutine, so decoding the next
+  batch overlaps with compressing and writing the current one. Before, the walker built a batch, sent it, and only
+  then started decoding the next, so the client-facing write sat on the critical path of every batch. At most one
+  batch is being built while one is sent, and a segment is only reported done once every batch is out, so message
+  order is unchanged.
+
+- `substreams-tier1` no longer copies each cached execution output payload once more while decoding it: the item
+  now aliases the buffer it was read into instead of copying out of it.
+
 - `substreams-tier1` can now evict requests when its CPU is saturated. When its own cgroup reports CPU usage above
   90% of quota for 15 seconds, the pod advertises itself unready to the load balancer, refuses new requests, waits
   for the balancer to drain, then cancels enough of the heaviest requests with `Unavailable` to bring usage back

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -27,11 +27,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   was even requested from the object store, so every segment paid a full store round trip on the critical path.
   Prefetching is bounded per request by `Tier1Config.ExecOutPrefetch`: at most `Depth` segments ahead (default
   and hard cap 4) holding at most `BudgetBytes` of decompressed data (default 64 MiB). No size is ever asked of
-  the store: the first segment is downloaded alone against the whole budget and, if it overflows, prefetching is
-  turned off for the rest of the request; otherwise its decompressed size is the estimate for the next ones, and
-  as many segments download concurrently as that estimate says fit. Missing files are left to the walker's
-  existing retry loop, and the prefetcher stops looking ahead until the walker reaches them. Setting either bound
-  to zero turns prefetching off.
+  the store: the decompressed size of the last downloaded segment is the estimate for the next ones, and as many
+  download at once as estimate-sized files fit in the budget, each allowed to read an even share of it, so
+  in-flight reads never add up to more than the budget. A file bigger than its share is left to the walker and
+  the estimate is raised, so a chain going from quiet to busy shrinks the concurrency instead of overshooting.
+  A file bigger than the whole budget turns prefetching off for the rest of the request. Missing files are left
+  to the walker's existing retry loop, and the prefetcher stops looking ahead until the walker reaches them.
+  Setting either bound to zero turns prefetching off.
 
 - `substreams-tier1` now sends each batch of cached execution output on a separate goroutine, so decoding the next
   batch overlaps with compressing and writing the current one. Before, the walker built a batch, sent it, and only
@@ -43,9 +45,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   now aliases the buffer it was read into instead of copying out of it.
 
 - `substreams-tier1` now writes the `substreams.spkg` and `last_used` cache markers in the background instead of
-  before the pipeline starts, so those object store round trips no longer delay the first block sent. The request
-  waits for them on its way out, and they run on a detached context with a 30 second timeout so a client that
-  disconnects early still leaves its usage marker behind.
+  before the pipeline starts, so those object store round trips no longer delay the first block sent. They run
+  detached from the request on their own context with a 30 second timeout: the request neither starts nor exits
+  waiting for them, and a client that disconnects early still leaves its usage marker behind.
 
 - `substreams-tier1` can now evict requests when its CPU is saturated. When its own cgroup reports CPU usage above
   90% of quota for 15 seconds, the pod advertises itself unready to the load balancer, refuses new requests, waits

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -22,6 +22,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Server
 
+- `substreams-tier1` now downloads the next cached execution output files while it streams the current one to a
+  production-mode client. Before, each 1000-block segment was opened, decompressed and sent before the next one
+  was even requested from the object store, so every segment paid a full store round trip on the critical path.
+  Prefetching is bounded per request by `Tier1Config.ExecOutPrefetch`: at most `Depth` segments ahead (default
+  and hard cap 4) holding at most `BudgetBytes` of decompressed data (default 64 MiB). No size is ever asked of
+  the store: the first segment is downloaded alone against the whole budget and, if it overflows, prefetching is
+  turned off for the rest of the request; otherwise its decompressed size is the estimate for the next ones, and
+  as many segments download concurrently as that estimate says fit. Missing files are left to the walker's
+  existing retry loop, and the prefetcher stops looking ahead until the walker reaches them. Setting either bound
+  to zero turns prefetching off.
+
 - `substreams-tier1` can now evict requests when its CPU is saturated. When its own cgroup reports CPU usage above
   90% of quota for 15 seconds, the pod advertises itself unready to the load balancer, refuses new requests, waits
   for the balancer to drain, then cancels enough of the heaviest requests with `Unavailable` to bring usage back

--- a/orchestrator/execout/execout_walker.go
+++ b/orchestrator/execout/execout_walker.go
@@ -249,8 +249,20 @@ func computeNewWait(previousWait time.Duration, storeIsLocal bool) time.Duration
 	return newWait
 }
 
-func (r *Walker) sendItems(reader execout.FileReader) error {
+func (r *Walker) sendItems(reader execout.FileReader) (err error) {
 	defer reader.Close()
+
+	// Sends run on their own goroutine so decoding the next batch overlaps with
+	// compressing and writing the current one. Closing waits for every batch to be
+	// sent before this segment is reported done.
+	out := newAsyncStream(r.streamOut)
+	defer func() {
+		closeErr := out.close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+
 	itemCount := 0
 	flushingDuration := time.Duration(0)
 	iterationStartTime := time.Now()
@@ -277,7 +289,7 @@ func (r *Walker) sendItems(reader execout.FileReader) error {
 				zap.Bool("keep", false),
 			)
 			if r.supportBuffering {
-				if err := r.buffer.Flush(r.streamOut); err != nil {
+				if err := r.buffer.Flush(out); err != nil {
 					return fmt.Errorf("flushing buffer on end block: %w", err)
 				}
 			}
@@ -290,14 +302,14 @@ func (r *Walker) sendItems(reader execout.FileReader) error {
 		}
 
 		if r.supportBuffering {
-			d, err := r.buffer.AppendAndFlushWhenNeeded(blockScopedData, len(item.Payload), r.streamOut)
+			d, err := r.buffer.AppendAndFlushWhenNeeded(blockScopedData, len(item.Payload), out)
 			if err != nil {
 				return fmt.Errorf("flushing buffer on 'should flush': %w", err)
 			}
 			flushingDuration += d
 		} else {
 			s := time.Now()
-			err := r.streamOut.BlockScopedData(blockScopedData)
+			err := out.BlockScopedData(blockScopedData)
 			if err != nil {
 				return fmt.Errorf("sending block scoped data: %w", err)
 			}
@@ -319,7 +331,7 @@ func (r *Walker) sendItems(reader execout.FileReader) error {
 
 	s := time.Now()
 	if r.supportBuffering {
-		if err := r.buffer.Flush(r.streamOut); err != nil {
+		if err := r.buffer.Flush(out); err != nil {
 			return fmt.Errorf("flushing buffer on end of iteration: %w", err)
 		}
 	}

--- a/orchestrator/execout/execout_walker_test.go
+++ b/orchestrator/execout/execout_walker_test.go
@@ -132,6 +132,23 @@ func TestSendItems_SendErrorStopsTheSegment(t *testing.T) {
 	assert.LessOrEqual(t, messages, 2, "nothing is sent after the failed message")
 }
 
+func TestSendItems_PanicInSendFailsTheSegment(t *testing.T) {
+	calls := 0
+	panicking := func(substreams.ResponseFromAnyTier) error {
+		calls++
+		if calls == 2 {
+			panic("stream is gone")
+		}
+		return nil
+	}
+	module := &pbsubstreams.Module{Name: "map", Output: &pbsubstreams.Module_Output{Type: "proto:x.Y"}}
+	w := NewWalker(context.Background(), module, nil, block.NewRange(0, 1000), response.New(panicking), false, 10, true)
+
+	err := w.sendItems(&itemsReader{items: newItems(0, 250)})
+	require.ErrorContains(t, err, "panic while sending execout data: stream is gone")
+	assert.Equal(t, 2, calls, "nothing is sent after the panic")
+}
+
 func TestSendItems_StopsAtExclusiveEndBlock(t *testing.T) {
 	s := &sink{failAt: -1}
 	w := newTestWalker(t, s, true, 10)

--- a/orchestrator/execout/execout_walker_test.go
+++ b/orchestrator/execout/execout_walker_test.go
@@ -1,0 +1,146 @@
+package execout
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/substreams"
+	"github.com/streamingfast/substreams/block"
+	"github.com/streamingfast/substreams/orchestrator/response"
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreamsrpcv4 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v4"
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
+	"github.com/streamingfast/substreams/storage/execout"
+	pboutput "github.com/streamingfast/substreams/storage/execout/pb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// itemsReader is a FileReader over an in-memory list of items.
+type itemsReader struct {
+	items []*pboutput.Item
+	pos   int
+}
+
+func (r *itemsReader) ReadNext() (*pboutput.Item, error) {
+	if r.pos >= len(r.items) {
+		return nil, errors.New("eof")
+	}
+	item := r.items[r.pos]
+	r.pos++
+	return item, nil
+}
+
+func (r *itemsReader) Iter() iter.Seq2[*pboutput.Item, error] {
+	return func(yield func(*pboutput.Item, error) bool) {
+		for r.pos < len(r.items) {
+			item := r.items[r.pos]
+			r.pos++
+			if !yield(item, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (r *itemsReader) Get(context.Context, uint64) ([]byte, bool, error) { return nil, false, nil }
+func (r *itemsReader) ModuleName() string                                { return "map" }
+func (r *itemsReader) Filename() string                                  { return "test" }
+func (r *itemsReader) Close() error                                      { return nil }
+
+var _ execout.FileReader = (*itemsReader)(nil)
+
+func newItems(from, to uint64) []*pboutput.Item {
+	var out []*pboutput.Item
+	for i := from; i < to; i++ {
+		out = append(out, &pboutput.Item{BlockNum: i, BlockId: "id", Payload: []byte{byte(i)}})
+	}
+	return out
+}
+
+// sink records the blocks it receives and can fail or stall on demand.
+type sink struct {
+	mu       sync.Mutex
+	blocks   []uint64
+	messages int
+	failAt   int // message index whose send fails, -1 for never
+	delay    time.Duration
+}
+
+func (s *sink) respFunc(resp substreams.ResponseFromAnyTier) error {
+	time.Sleep(s.delay)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.messages == s.failAt {
+		s.messages++
+		return errors.New("client went away")
+	}
+	s.messages++
+	switch r := resp.(type) {
+	case *pbsubstreamsrpc.Response:
+		s.blocks = append(s.blocks, r.GetBlockScopedData().Clock.Number)
+	case *pbsubstreamsrpcv4.Response:
+		for _, d := range r.GetBlockScopedDatas().Items {
+			s.blocks = append(s.blocks, d.Clock.Number)
+		}
+	}
+	return nil
+}
+
+func (s *sink) received() (blocks []uint64, messages int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]uint64(nil), s.blocks...), s.messages
+}
+
+func newTestWalker(t *testing.T, s *sink, buffering bool, bufferSize int) *Walker {
+	t.Helper()
+	module := &pbsubstreams.Module{Name: "map", Output: &pbsubstreams.Module_Output{Type: "proto:x.Y"}}
+	return NewWalker(context.Background(), module, nil, block.NewRange(0, 1000), response.New(s.respFunc), false, bufferSize, buffering)
+}
+
+func TestSendItems_KeepsBlockOrderWhileSendsOverlap(t *testing.T) {
+	for _, buffering := range []bool{true, false} {
+		t.Run(map[bool]string{true: "buffered", false: "unbuffered"}[buffering], func(t *testing.T) {
+			s := &sink{failAt: -1, delay: 200 * time.Microsecond}
+			w := newTestWalker(t, s, buffering, 10)
+
+			require.NoError(t, w.sendItems(&itemsReader{items: newItems(0, 250)}))
+
+			blocks, _ := s.received()
+			require.Len(t, blocks, 250)
+			for i, b := range blocks {
+				assert.Equal(t, uint64(i), b, "block at position %d", i)
+			}
+		})
+	}
+}
+
+func TestSendItems_SendErrorStopsTheSegment(t *testing.T) {
+	s := &sink{failAt: 1}
+	w := newTestWalker(t, s, true, 10)
+
+	err := w.sendItems(&itemsReader{items: newItems(0, 250)})
+	require.ErrorContains(t, err, "client went away")
+
+	blocks, messages := s.received()
+	assert.Len(t, blocks, 11, "only the first batch made it to the client")
+	assert.LessOrEqual(t, messages, 2, "nothing is sent after the failed message")
+}
+
+func TestSendItems_StopsAtExclusiveEndBlock(t *testing.T) {
+	s := &sink{failAt: -1}
+	w := newTestWalker(t, s, true, 10)
+	w.Range = block.NewRange(5, 20)
+
+	require.NoError(t, w.sendItems(&itemsReader{items: newItems(0, 250)}))
+
+	blocks, _ := s.received()
+	require.Len(t, blocks, 15)
+	assert.Equal(t, uint64(5), blocks[0])
+	assert.Equal(t, uint64(19), blocks[14])
+}

--- a/orchestrator/execout/message_buffer.go
+++ b/orchestrator/execout/message_buffer.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/streamingfast/substreams/orchestrator/response"
 	pbsubstreamsrpcv2 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 	pbsubstreamsrpcv4 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v4"
 	"go.uber.org/zap"
@@ -96,7 +95,7 @@ func (b *MessageBuffer) shouldFlushLocked() bool {
 // it — append, flush-check and flush all happen under a single lock, so the output
 // hot path takes the buffer mutex exactly once per block. It returns the time spent
 // flushing (0 if no flush happened).
-func (b *MessageBuffer) AppendAndFlushWhenNeeded(msg *pbsubstreamsrpcv2.BlockScopedData, dataSize int, streamSrv *response.Stream) (time.Duration, error) {
+func (b *MessageBuffer) AppendAndFlushWhenNeeded(msg *pbsubstreamsrpcv2.BlockScopedData, dataSize int, streamSrv dataStream) (time.Duration, error) {
 	b.mut.Lock()
 	defer b.mut.Unlock()
 
@@ -114,14 +113,14 @@ func (b *MessageBuffer) AppendAndFlushWhenNeeded(msg *pbsubstreamsrpcv2.BlockSco
 	return time.Since(start), nil
 }
 
-func (b *MessageBuffer) Flush(streamSrv *response.Stream) error {
+func (b *MessageBuffer) Flush(streamSrv dataStream) error {
 	b.mut.Lock()
 	defer b.mut.Unlock()
 
 	return b.flushLocked(streamSrv)
 }
 
-func (b *MessageBuffer) flushLocked(streamSrv *response.Stream) error {
+func (b *MessageBuffer) flushLocked(streamSrv dataStream) error {
 	err := streamSrv.BlockScopedDatas(b.buf)
 	if err != nil {
 		return fmt.Errorf("flushing buffer: %w", err)

--- a/orchestrator/execout/sender.go
+++ b/orchestrator/execout/sender.go
@@ -1,0 +1,73 @@
+package execout
+
+import (
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreamsrpcv4 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v4"
+)
+
+// dataStream is where the walker and the message buffer send block data.
+type dataStream interface {
+	BlockScopedData(*pbsubstreamsrpc.BlockScopedData) error
+	BlockScopedDatas(*pbsubstreamsrpcv4.BlockScopedDatas) error
+}
+
+// asyncStream delivers messages to the underlying stream on its own goroutine, so
+// the walker decodes the next batch while the previous one is compressed and
+// written. The channel is unbuffered: at most one batch is being built while one
+// is being sent. Messages go out in the order they were handed in.
+//
+// Once a send fails, every later call returns that error and nothing else is
+// sent. close waits for the goroutine, so a walker that closes before reporting a
+// segment done never lets the linear pipeline send ahead of cached data.
+type asyncStream struct {
+	out  dataStream
+	jobs chan func() error
+	done chan struct{}
+	err  error // written by run before done is closed, read only after done
+}
+
+func newAsyncStream(out dataStream) *asyncStream {
+	s := &asyncStream{
+		out:  out,
+		jobs: make(chan func() error),
+		done: make(chan struct{}),
+	}
+	go s.run()
+	return s
+}
+
+func (s *asyncStream) run() {
+	defer close(s.done)
+	for send := range s.jobs {
+		if err := send(); err != nil {
+			s.err = err
+			return
+		}
+	}
+}
+
+func (s *asyncStream) enqueue(send func() error) error {
+	select {
+	case s.jobs <- send:
+		return nil
+	case <-s.done:
+		return s.err
+	}
+}
+
+func (s *asyncStream) BlockScopedData(msg *pbsubstreamsrpc.BlockScopedData) error {
+	return s.enqueue(func() error { return s.out.BlockScopedData(msg) })
+}
+
+func (s *asyncStream) BlockScopedDatas(msg *pbsubstreamsrpcv4.BlockScopedDatas) error {
+	return s.enqueue(func() error { return s.out.BlockScopedDatas(msg) })
+}
+
+// close stops accepting messages, waits for the ones already handed in to be sent
+// and returns the first send error, if any. It must be called exactly once, from
+// the goroutine that enqueues.
+func (s *asyncStream) close() error {
+	close(s.jobs)
+	<-s.done
+	return s.err
+}

--- a/orchestrator/execout/sender.go
+++ b/orchestrator/execout/sender.go
@@ -1,6 +1,8 @@
 package execout
 
 import (
+	"fmt"
+
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 	pbsubstreamsrpcv4 "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v4"
 )
@@ -36,8 +38,16 @@ func newAsyncStream(out dataStream) *asyncStream {
 	return s
 }
 
+// run sends until the channel is closed or a send fails. A panic in a send is
+// turned into an error, so it fails the request the same way it did when the
+// walker's own goroutine sent and recovered.
 func (s *asyncStream) run() {
 	defer close(s.done)
+	defer func() {
+		if rec := recover(); rec != nil {
+			s.err = fmt.Errorf("panic while sending execout data: %v", rec)
+		}
+	}()
 	for send := range s.jobs {
 		if err := send(); err != nil {
 			s.err = err

--- a/orchestrator/parallelprocessor.go
+++ b/orchestrator/parallelprocessor.go
@@ -39,6 +39,7 @@ func BuildParallelProcessor(
 	noopMode bool,
 	outputBufferSize int,
 	supportBuffering bool,
+	execOutPrefetch execout.PrefetchConfig,
 ) (*ParallelProcessor, error) {
 
 	// FIXME: Are all the progress messages properly sent? When we skip some stores and mark them complete,
@@ -66,6 +67,9 @@ func BuildParallelProcessor(
 			initialBlock := execGraph.ModulesInitBlocks()[requestedModule.Name]
 			if execOutSegmenter := reqPlan.ReadOutSegmenter(initialBlock, sched.StreamFirstTier2MapSegment); execOutSegmenter != nil {
 				walker := execoutStorage.NewFileWalker(requestedModule.Name, execOutSegmenter)
+				if !noopMode { // noop mode reads one item per file, prefetching whole files would be wasted
+					walker.WithPrefetch(execOutPrefetch)
+				}
 
 				sched.ExecOutWalker = orchestratorExecout.NewWalker(
 					ctx,

--- a/pipeline/options.go
+++ b/pipeline/options.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"github.com/streamingfast/substreams"
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	"github.com/streamingfast/substreams/storage/execout"
 )
 
 type Option func(p *Pipeline)
@@ -48,5 +49,13 @@ func WithHighestStage(stage uint32) Option {
 	return func(p *Pipeline) {
 		s := int(stage)
 		p.highestStage = &s
+	}
+}
+
+// WithExecOutPrefetch bounds how far ahead tier1 downloads cached execution
+// output files while streaming them to the client.
+func WithExecOutPrefetch(cfg execout.PrefetchConfig) Option {
+	return func(p *Pipeline) {
+		p.execOutPrefetch = cfg
 	}
 }

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -151,6 +151,7 @@ type Pipeline struct {
 	checkPendingShutdown func() bool
 	outputBufferSize     int
 	supportBuffering     bool
+	execOutPrefetch      execout.PrefetchConfig
 }
 
 func New(
@@ -638,6 +639,7 @@ func (p *Pipeline) runParallelProcess(ctx context.Context, reqPlan *plan.Request
 		noopMode,
 		p.outputBufferSize,
 		p.supportBuffering,
+		p.execOutPrefetch,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("building parallel processor: %w", err)

--- a/service/options.go
+++ b/service/options.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/streamingfast/substreams/storage/execout"
 	"github.com/streamingfast/substreams/wasm"
 )
 
@@ -153,6 +154,17 @@ func WithLiveBackFillerFinalBlockDelay(delay uint64) Option {
 	return func(a anyTierService) {
 		if s, ok := a.(*Tier1Service); ok {
 			s.liveBackFillerFinalBlockDelay = delay
+		}
+	}
+}
+
+// WithExecOutPrefetch bounds how far ahead a production-mode request downloads
+// cached execution output files while streaming them to the client. A zero
+// depth or budget turns prefetching off.
+func WithExecOutPrefetch(cfg execout.PrefetchConfig) Option {
+	return func(a anyTierService) {
+		if s, ok := a.(*Tier1Service); ok {
+			s.execOutPrefetch = cfg
 		}
 	}
 }

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -802,12 +802,10 @@ func (s *Tier1Service) blocks(
 	}
 
 	// Both writes are best effort and nothing in this request reads them back, so
-	// they run off the critical path and the request only waits for them on its
-	// way out. The context is detached from the request so a client that
-	// disconnects early still leaves its usage marker behind.
-	markersWritten := make(chan struct{})
+	// they run detached from the request: neither its start nor its exit waits for
+	// them, and a client that disconnects early still leaves its usage marker
+	// behind. The timeout is the only bound on how long they may run.
 	go func() {
-		defer close(markersWritten)
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheMarkerWriteTimeout)
 		defer cancel()
 		if err := s.writePackage(ctx, request, execGraph, cacheStore); err != nil {
@@ -817,7 +815,6 @@ func (s *Tier1Service) blocks(
 			logger.Warn("cannot write 'last_used' file", zap.Error(err))
 		}
 	}()
-	defer func() { <-markersWritten }()
 
 	execOutputConfigs, err := execout.NewConfigs(cacheStore, execGraph.UsedModules(), execGraph.ModuleHashes(), segmentSize, chainFirstStreamableBlock, logger)
 	if err != nil {

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -635,6 +635,10 @@ func (s *Tier1Service) writePackage(ctx context.Context, request *pbsubstreamsrp
 	return nil
 }
 
+// cacheMarkerWriteTimeout bounds the detached package and last_used writes so they
+// can never outlive a request by more than this.
+const cacheMarkerWriteTimeout = 30 * time.Second
+
 // lastUsedFilename names the usage marker written in every module's cache folder:
 // `last_used` for unauthenticated requests, `last_used_<plan>` (lowercase) otherwise.
 // `firecore tools substreams purge` reads the plan back from that name to apply a
@@ -797,13 +801,23 @@ func (s *Tier1Service) blocks(
 		cacheStore = cloned
 	}
 
-	if err := s.writePackage(ctx, request, execGraph, cacheStore); err != nil {
-		logger.Warn("cannot write package", zap.Error(err))
-	}
-
-	if err := s.writeLastUsed(ctx, execGraph, cacheStore); err != nil {
-		logger.Warn("cannot write 'last_used' file", zap.Error(err))
-	}
+	// Both writes are best effort and nothing in this request reads them back, so
+	// they run off the critical path and the request only waits for them on its
+	// way out. The context is detached from the request so a client that
+	// disconnects early still leaves its usage marker behind.
+	markersWritten := make(chan struct{})
+	go func() {
+		defer close(markersWritten)
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cacheMarkerWriteTimeout)
+		defer cancel()
+		if err := s.writePackage(ctx, request, execGraph, cacheStore); err != nil {
+			logger.Warn("cannot write package", zap.Error(err))
+		}
+		if err := s.writeLastUsed(ctx, execGraph, cacheStore); err != nil {
+			logger.Warn("cannot write 'last_used' file", zap.Error(err))
+		}
+	}()
+	defer func() { <-markersWritten }()
 
 	execOutputConfigs, err := execout.NewConfigs(cacheStore, execGraph.UsedModules(), execGraph.ModuleHashes(), segmentSize, chainFirstStreamableBlock, logger)
 	if err != nil {

--- a/service/tier1.go
+++ b/service/tier1.go
@@ -128,6 +128,7 @@ type Tier1Service struct {
 	activeRequestsManager    *active_requests.ActiveRequestsManager // we keep a list of current requests for the debugAPI and to manage memory
 	evictor                  *active_requests.Evictor               // nil unless CPU eviction is enabled and cgroup CPU signals are readable
 	execOutMessageBufferSize int
+	execOutPrefetch          execout.PrefetchConfig
 
 	// liveBackFillerFinalBlockDelay overrides the default 120-block delay the
 	// live backfiller waits past a segment end before concluding merged blocks
@@ -839,6 +840,7 @@ func (s *Tier1Service) blocks(
 	if s.getHeadBlock != nil {
 		opts = append(opts, pipeline.WithHeadBlockGetter(s.getHeadBlock))
 	}
+	opts = append(opts, pipeline.WithExecOutPrefetch(s.execOutPrefetch))
 
 	ctx, resolvedEndpoints, err := s.resolveFoundationalStores(ctx, execGraph, reqStats)
 	if err != nil {

--- a/storage/execout/filewalk.go
+++ b/storage/execout/filewalk.go
@@ -13,6 +13,7 @@ type FileWalker struct {
 	config    *Config
 	segmenter *block.Segmenter
 	segment   int
+	prefetch  *prefetcher
 
 	IsLocal bool
 	logger  *zap.Logger
@@ -28,11 +29,30 @@ func NewFileWalker(c *Config, segmenter *block.Segmenter, logger *zap.Logger) *F
 	}
 }
 
+// WithPrefetch makes FileReader download the segments following the current one in
+// the background, within the bounds of cfg. Prefetching starts on the first
+// FileReader call and lives as long as that call's context.
+func (fw *FileWalker) WithPrefetch(cfg PrefetchConfig) *FileWalker {
+	if cfg.enabled() {
+		fw.prefetch = newPrefetcher(cfg, fw)
+	}
+	return fw
+}
+
 // If the current segment is out of ranges, returns nil.
 func (fw *FileWalker) FileReader(ctx context.Context) (FileReader, error) {
 	rng := fw.segmenter.Range(fw.segment)
 	if rng == nil {
 		return nil, nil
+	}
+	if fw.prefetch != nil {
+		reader, err := fw.prefetch.take(ctx, fw.segment)
+		if err != nil {
+			return nil, err
+		}
+		if reader != nil {
+			return reader, nil
+		}
 	}
 	return fw.config.OpenFileReader(ctx, rng)
 }

--- a/storage/execout/prefetch.go
+++ b/storage/execout/prefetch.go
@@ -38,16 +38,22 @@ func (c PrefetchConfig) enabled() bool {
 // the prefetcher does not hold (never reached, skipped, or failed) is opened
 // directly by the walker.
 //
-// It never asks the store for a file's size. The first segment it downloads is
-// read alone against the whole budget; if that overflows, prefetching is turned
-// off for the rest of the request. Otherwise the decompressed size of the last
-// completed download is the estimate for the next ones, and as many segments run
-// ahead, concurrently, as that estimate says fit in the budget, up to Depth.
+// It never asks the store for a file's size. The decompressed size of the last
+// completed download is the estimate for the next ones, and as many downloads run
+// at once as estimate-sized files fit in the budget, at least one and at most
+// Depth. The budget is split evenly between them: each in-flight download reserves
+// its share and may read no more than that, so in-flight reads and held segments
+// never add up to more than the budget. Until a first download completes there is
+// no estimate, so that one runs alone against the whole budget.
+//
+// A file bigger than its share is dropped and left to the walker, and the estimate
+// doubles so fewer downloads share the budget next time. A file bigger than the
+// whole budget turns prefetching off for the rest of the request.
 //
 // A download that fails, including on a file tier2 has not written yet, is simply
 // dropped: the walker's own retry loop owns waiting for files to appear. The
 // prefetcher stops launching further segments until the walker has reached the
-// failed one, then resumes right after it.
+// dropped one, then resumes right after it.
 type prefetcher struct {
 	cfg    PrefetchConfig
 	config *Config
@@ -58,8 +64,8 @@ type prefetcher struct {
 	cond     *sync.Cond
 	started  bool
 	segments map[int]*prefetchedSegment
-	held     uint64 // bytes reserved by in-flight downloads plus bytes held by completed ones
-	estimate uint64 // decompressed size of the last completed download, 0 until one completes
+	held     uint64 // shares reserved by in-flight downloads plus bytes held by completed ones, never above the budget
+	estimate uint64 // decompressed size of the last completed download, raised by overflows, 0 until one completes
 	consumed int    // highest segment index the walker has asked for
 	failed   int    // lowest segment whose download failed and the walker has not reached, -1 if none
 	disabled bool   // a download overflowed the budget: no further segment is started
@@ -214,26 +220,35 @@ func (p *prefetcher) launchableLocked(next *int, last int) bool {
 	return p.canStartLocked()
 }
 
-// canStartLocked says whether one more download may begin. Until a first download
-// has completed there is no size estimate, so that one runs alone.
-func (p *prefetcher) canStartLocked() bool {
+// concurrencyLocked is how many downloads may run at once: as many estimate-sized
+// files as fit in the budget, at least one, at most Depth. Without an estimate,
+// one.
+func (p *prefetcher) concurrencyLocked() int {
 	if p.estimate == 0 {
-		return len(p.segments) == 0
+		return 1
 	}
-	return len(p.segments) < p.cfg.Depth && p.held+p.estimate <= p.cfg.BudgetBytes
+	return int(max(1, min(uint64(p.cfg.Depth), p.cfg.BudgetBytes/p.estimate)))
 }
 
-// reserveLocked registers the segment as in flight and returns how many bytes its
-// download may read: whatever is left of the budget.
+// shareLocked is the most one download may read: the budget split evenly between
+// the downloads allowed to run at once.
+func (p *prefetcher) shareLocked() uint64 {
+	return p.cfg.BudgetBytes / uint64(p.concurrencyLocked())
+}
+
+// canStartLocked says whether one more download may begin: a slot is free and its
+// full share still fits next to what is held.
+func (p *prefetcher) canStartLocked() bool {
+	return len(p.segments) < p.concurrencyLocked() && p.held+p.shareLocked() <= p.cfg.BudgetBytes
+}
+
+// reserveLocked registers the segment as in flight, holding its whole share until
+// the download completes, and returns that share as the read limit.
 func (p *prefetcher) reserveLocked(segment int) (seg *prefetchedSegment, limit uint64) {
-	limit = p.cfg.BudgetBytes - p.held
-	reserved := p.estimate
-	if reserved == 0 {
-		reserved = limit
-	}
-	seg = &prefetchedSegment{reserved: reserved, ready: make(chan struct{})}
+	limit = p.shareLocked()
+	seg = &prefetchedSegment{reserved: limit, ready: make(chan struct{})}
 	p.segments[segment] = seg
-	p.held += reserved
+	p.held += limit
 	return seg, limit
 }
 
@@ -248,12 +263,20 @@ func (p *prefetcher) complete(segment int, seg *prefetchedSegment, data []byte, 
 		p.held -= seg.reserved
 		seg.reserved = uint64(len(data))
 		p.held += seg.reserved
-		p.estimate = uint64(len(data))
-	case errors.Is(err, errPrefetchOverflow):
+		p.estimate = max(seg.reserved, 1)
+	case errors.Is(err, errPrefetchOverflow) && seg.reserved >= p.cfg.BudgetBytes:
 		p.releaseLocked(segment)
 		p.disabled = true
 		p.logger.Info("execout prefetching turned off for this request: a file exceeds the budget",
 			zap.Int("segment", segment), zap.Uint64("budget", p.cfg.BudgetBytes))
+	case errors.Is(err, errPrefetchOverflow):
+		p.releaseLocked(segment)
+		p.estimate = max(p.estimate, min(2*seg.reserved, p.cfg.BudgetBytes))
+		if p.failed < 0 || segment < p.failed {
+			p.failed = segment
+		}
+		p.logger.Debug("execout file exceeds its share of the prefetch budget, walker will open it directly",
+			zap.Int("segment", segment), zap.Uint64("share", seg.reserved), zap.Uint64("new_estimate", p.estimate))
 	default:
 		p.releaseLocked(segment)
 		if p.failed < 0 || segment < p.failed {

--- a/storage/execout/prefetch.go
+++ b/storage/execout/prefetch.go
@@ -188,12 +188,10 @@ func (p *prefetcher) run(ctx context.Context, from int) {
 		seg, limit := p.reserveLocked(segment)
 		next++
 
-		p.mu.Unlock()
 		go func() {
 			data, err := p.download(ctx, rng, limit)
 			p.complete(segment, seg, data, err)
 		}()
-		p.mu.Lock()
 	}
 }
 

--- a/storage/execout/prefetch.go
+++ b/storage/execout/prefetch.go
@@ -1,0 +1,298 @@
+package execout
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/streamingfast/dstore"
+	"github.com/streamingfast/substreams/block"
+	"go.uber.org/zap"
+)
+
+// MaxPrefetchDepth is the most segments a walker ever holds or downloads ahead,
+// whatever PrefetchConfig.Depth says.
+const MaxPrefetchDepth = 4
+
+// PrefetchConfig bounds how far ahead of the segment being streamed a FileWalker
+// downloads execution output files, and how much decompressed data it may hold
+// in memory while doing so. A zero Depth or BudgetBytes disables prefetching.
+type PrefetchConfig struct {
+	// Depth is the number of segments that may be held or in flight at once,
+	// capped at MaxPrefetchDepth.
+	Depth int
+	// BudgetBytes is the total decompressed size of the segments held in memory.
+	BudgetBytes uint64
+}
+
+func (c PrefetchConfig) enabled() bool {
+	return c.Depth > 0 && c.BudgetBytes > 0
+}
+
+// prefetcher downloads the segments following the one the walker is streaming, so
+// the store round trips and the decompression of the next segments overlap with
+// sending the current one. The walker asks it for each segment in order; a segment
+// the prefetcher does not hold (never reached, skipped, or failed) is opened
+// directly by the walker.
+//
+// It never asks the store for a file's size. The first segment it downloads is
+// read alone against the whole budget; if that overflows, prefetching is turned
+// off for the rest of the request. Otherwise the decompressed size of the last
+// completed download is the estimate for the next ones, and as many segments run
+// ahead, concurrently, as that estimate says fit in the budget, up to Depth.
+//
+// A download that fails, including on a file tier2 has not written yet, is simply
+// dropped: the walker's own retry loop owns waiting for files to appear. The
+// prefetcher stops launching further segments until the walker has reached the
+// failed one, then resumes right after it.
+type prefetcher struct {
+	cfg    PrefetchConfig
+	config *Config
+	walker *FileWalker
+	logger *zap.Logger
+
+	mu       sync.Mutex
+	cond     *sync.Cond
+	started  bool
+	segments map[int]*prefetchedSegment
+	held     uint64 // bytes reserved by in-flight downloads plus bytes held by completed ones
+	estimate uint64 // decompressed size of the last completed download, 0 until one completes
+	consumed int    // highest segment index the walker has asked for
+	failed   int    // lowest segment whose download failed and the walker has not reached, -1 if none
+	disabled bool   // a download overflowed the budget: no further segment is started
+	done     bool   // the launching goroutine has exited
+}
+
+type prefetchedSegment struct {
+	reserved uint64 // bytes counted against the budget
+	data     []byte
+	err      error
+	ready    chan struct{}
+}
+
+var errPrefetchOverflow = errors.New("execout file exceeds the prefetch budget")
+
+func newPrefetcher(cfg PrefetchConfig, walker *FileWalker) *prefetcher {
+	cfg.Depth = min(cfg.Depth, MaxPrefetchDepth)
+	p := &prefetcher{
+		cfg:      cfg,
+		config:   walker.config,
+		walker:   walker,
+		logger:   walker.logger.Named("execout_prefetch"),
+		segments: make(map[int]*prefetchedSegment),
+		consumed: walker.segmenter.FirstIndex() - 1,
+		failed:   -1,
+	}
+	p.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+// take hands the walker the segment it asks for, waiting for it if it is still
+// downloading. It returns (nil, nil) when the walker has to open the segment itself.
+func (p *prefetcher) take(ctx context.Context, segment int) (FileReader, error) {
+	p.mu.Lock()
+	if segment > p.consumed {
+		p.consumed = segment
+	}
+	if !p.started {
+		p.started = true
+		go p.run(ctx, segment+1)
+	}
+	seg := p.segments[segment]
+	p.cond.Broadcast()
+	p.mu.Unlock()
+
+	if seg == nil {
+		return nil, nil
+	}
+
+	select {
+	case <-seg.ready:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	if seg.err != nil {
+		return nil, nil
+	}
+
+	return &fileReader{
+		File:   p.config.NewFile(p.walker.segmenter.Range(segment)),
+		reader: &releaseOnClose{Reader: bytes.NewReader(seg.data), release: func() { p.release(segment) }},
+	}, nil
+}
+
+func (p *prefetcher) release(segment int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.releaseLocked(segment)
+	p.cond.Broadcast()
+}
+
+func (p *prefetcher) releaseLocked(segment int) {
+	if seg, found := p.segments[segment]; found {
+		p.held -= seg.reserved
+		delete(p.segments, segment)
+	}
+}
+
+// run launches downloads in segment order, each in its own goroutine, whenever the
+// budget and Depth allow one more.
+func (p *prefetcher) run(ctx context.Context, from int) {
+	defer func() {
+		p.mu.Lock()
+		p.done = true
+		p.cond.Broadcast()
+		p.mu.Unlock()
+	}()
+
+	stop := context.AfterFunc(ctx, func() {
+		p.mu.Lock()
+		p.cond.Broadcast()
+		p.mu.Unlock()
+	})
+	defer stop()
+
+	last := p.walker.segmenter.LastIndex()
+	next := from
+
+	// Picking the segment and reserving it happen under one hold of the lock, so the
+	// walker cannot ask for that segment in between and end up opening it itself
+	// while the download is launched anyway.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for {
+		for !p.launchableLocked(&next, last) {
+			if ctx.Err() != nil {
+				return
+			}
+			p.cond.Wait()
+		}
+		if p.disabled || next > last {
+			return
+		}
+		segment := next
+		rng := p.walker.segmenter.Range(segment)
+		if rng == nil {
+			return
+		}
+		seg, limit := p.reserveLocked(segment)
+		next++
+
+		p.mu.Unlock()
+		go func() {
+			data, err := p.download(ctx, rng, limit)
+			p.complete(segment, seg, data, err)
+		}()
+		p.mu.Lock()
+	}
+}
+
+// launchableLocked advances next past segments the walker already asked for or that
+// are already held, and says whether a download may be launched now, or whether
+// there is nothing left to do (next past last with nothing held, or disabled).
+func (p *prefetcher) launchableLocked(next *int, last int) bool {
+	if p.disabled {
+		return true
+	}
+	if p.failed >= 0 {
+		if p.consumed < p.failed {
+			return false
+		}
+		*next = min(*next, p.failed+1)
+		p.failed = -1
+	}
+	for *next <= p.consumed || p.segments[*next] != nil {
+		*next++
+	}
+	if *next > last {
+		return len(p.segments) == 0
+	}
+	return p.canStartLocked()
+}
+
+// canStartLocked says whether one more download may begin. Until a first download
+// has completed there is no size estimate, so that one runs alone.
+func (p *prefetcher) canStartLocked() bool {
+	if p.estimate == 0 {
+		return len(p.segments) == 0
+	}
+	return len(p.segments) < p.cfg.Depth && p.held+p.estimate <= p.cfg.BudgetBytes
+}
+
+// reserveLocked registers the segment as in flight and returns how many bytes its
+// download may read: whatever is left of the budget.
+func (p *prefetcher) reserveLocked(segment int) (seg *prefetchedSegment, limit uint64) {
+	limit = p.cfg.BudgetBytes - p.held
+	reserved := p.estimate
+	if reserved == 0 {
+		reserved = limit
+	}
+	seg = &prefetchedSegment{reserved: reserved, ready: make(chan struct{})}
+	p.segments[segment] = seg
+	p.held += reserved
+	return seg, limit
+}
+
+func (p *prefetcher) complete(segment int, seg *prefetchedSegment, data []byte, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	seg.data = data
+	seg.err = err
+	switch {
+	case err == nil:
+		p.held -= seg.reserved
+		seg.reserved = uint64(len(data))
+		p.held += seg.reserved
+		p.estimate = uint64(len(data))
+	case errors.Is(err, errPrefetchOverflow):
+		p.releaseLocked(segment)
+		p.disabled = true
+		p.logger.Info("execout prefetching turned off for this request: a file exceeds the budget",
+			zap.Int("segment", segment), zap.Uint64("budget", p.cfg.BudgetBytes))
+	default:
+		p.releaseLocked(segment)
+		if p.failed < 0 || segment < p.failed {
+			p.failed = segment
+		}
+		if !errors.Is(err, dstore.ErrNotFound) {
+			p.logger.Debug("execout file not prefetched, walker will open it directly", zap.Int("segment", segment), zap.Error(err))
+		}
+	}
+	close(seg.ready)
+	p.cond.Broadcast()
+}
+
+// download reads the whole segment, decompressed, into memory. It fails with
+// errPrefetchOverflow when the file does not fit in limit bytes.
+func (p *prefetcher) download(ctx context.Context, rng *block.Range, limit uint64) ([]byte, error) {
+	fr := &fileReader{File: p.config.NewFile(rng)}
+	if err := fr.open(ctx); err != nil {
+		return nil, err
+	}
+	defer fr.reader.Close()
+
+	data, err := io.ReadAll(io.LimitReader(fr.reader, int64(limit)+1))
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(data)) > limit {
+		return nil, fmt.Errorf("%w: more than %d bytes", errPrefetchOverflow, limit)
+	}
+	return data, nil
+}
+
+type releaseOnClose struct {
+	io.Reader
+	release func()
+	once    sync.Once
+}
+
+func (r *releaseOnClose) Close() error {
+	r.once.Do(r.release)
+	return nil
+}

--- a/storage/execout/prefetch.go
+++ b/storage/execout/prefetch.go
@@ -61,7 +61,7 @@ type prefetcher struct {
 	logger *zap.Logger
 
 	mu       sync.Mutex
-	cond     *sync.Cond
+	wake     chan struct{} // one pending wake-up for the launcher, see notify
 	started  bool
 	segments map[int]*prefetchedSegment
 	held     uint64 // shares reserved by in-flight downloads plus bytes held by completed ones, never above the budget
@@ -89,10 +89,10 @@ func newPrefetcher(cfg PrefetchConfig, walker *FileWalker) *prefetcher {
 		walker:   walker,
 		logger:   walker.logger.Named("execout_prefetch"),
 		segments: make(map[int]*prefetchedSegment),
+		wake:     make(chan struct{}, 1),
 		consumed: walker.segmenter.FirstIndex() - 1,
 		failed:   -1,
 	}
-	p.cond = sync.NewCond(&p.mu)
 	return p
 }
 
@@ -108,7 +108,7 @@ func (p *prefetcher) take(ctx context.Context, segment int) (FileReader, error) 
 		go p.run(ctx, segment+1)
 	}
 	seg := p.segments[segment]
-	p.cond.Broadcast()
+	p.notify()
 	p.mu.Unlock()
 
 	if seg == nil {
@@ -135,7 +135,7 @@ func (p *prefetcher) release(segment int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.releaseLocked(segment)
-	p.cond.Broadcast()
+	p.notify()
 }
 
 func (p *prefetcher) releaseLocked(segment int) {
@@ -151,47 +151,57 @@ func (p *prefetcher) run(ctx context.Context, from int) {
 	defer func() {
 		p.mu.Lock()
 		p.done = true
-		p.cond.Broadcast()
 		p.mu.Unlock()
 	}()
-
-	stop := context.AfterFunc(ctx, func() {
-		p.mu.Lock()
-		p.cond.Broadcast()
-		p.mu.Unlock()
-	})
-	defer stop()
 
 	last := p.walker.segmenter.LastIndex()
 	next := from
 
-	// Picking the segment and reserving it happen under one hold of the lock, so the
-	// walker cannot ask for that segment in between and end up opening it itself
-	// while the download is launched anyway.
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	for {
-		for !p.launchableLocked(&next, last) {
-			if ctx.Err() != nil {
+		// Checking, picking the segment and reserving it happen under one hold of
+		// the lock, so the walker cannot ask for that segment in between and end up
+		// opening it itself while the download is launched anyway.
+		p.mu.Lock()
+		launchable := p.launchableLocked(&next, last)
+		finished := launchable && (p.disabled || next > last)
+		if launchable && !finished {
+			segment := next
+			rng := p.walker.segmenter.Range(segment)
+			if rng == nil {
+				p.mu.Unlock()
 				return
 			}
-			p.cond.Wait()
+			seg, limit := p.reserveLocked(segment)
+			next++
+			p.mu.Unlock()
+			go func() {
+				data, err := p.download(ctx, rng, limit)
+				p.complete(segment, seg, data, err)
+			}()
+			continue
 		}
-		if p.disabled || next > last {
+		p.mu.Unlock()
+		if finished {
 			return
 		}
-		segment := next
-		rng := p.walker.segmenter.Range(segment)
-		if rng == nil {
-			return
-		}
-		seg, limit := p.reserveLocked(segment)
-		next++
 
-		go func() {
-			data, err := p.download(ctx, rng, limit)
-			p.complete(segment, seg, data, err)
-		}()
+		select {
+		case <-p.wake:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// notify wakes the launcher so it re-reads the state. Every change to what
+// launchableLocked looks at calls it, with the lock held. The channel holds one
+// pending wake-up and further ones are dropped, which is enough: a change can only
+// land once the launcher has released the lock, its token then makes the next
+// wait return at once, and the launcher reads all of the state on every pass.
+func (p *prefetcher) notify() {
+	select {
+	case p.wake <- struct{}{}:
+	default:
 	}
 }
 
@@ -285,7 +295,7 @@ func (p *prefetcher) complete(segment int, seg *prefetchedSegment, data []byte, 
 		}
 	}
 	close(seg.ready)
-	p.cond.Broadcast()
+	p.notify()
 }
 
 // download reads the whole segment, decompressed, into memory. It fails with

--- a/storage/execout/prefetch_test.go
+++ b/storage/execout/prefetch_test.go
@@ -1,0 +1,284 @@
+package execout
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/dstore"
+	"github.com/streamingfast/substreams/block"
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// prefetchStore is a MockStore safe to share between the walker and the prefetch
+// goroutines, that reports a missing file the way real stores do, records which
+// files were opened, and fails the test on any attributes lookup.
+type prefetchStore struct {
+	*dstore.MockStore
+	mu     sync.Mutex
+	opened []string
+}
+
+func newPrefetchStore(t *testing.T) *prefetchStore {
+	s := &prefetchStore{MockStore: dstore.NewMockStore(nil)}
+	s.MockStore.OpenObjectFunc = func(_ context.Context, name string) (io.ReadCloser, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		content, found := s.Files[name]
+		if !found {
+			return nil, dstore.ErrNotFound
+		}
+		s.opened = append(s.opened, name)
+		return io.NopCloser(bytes.NewReader(content)), nil
+	}
+	s.MockStore.ObjectAttributesFunc = func(_ context.Context, name string) (*dstore.ObjectAttributes, error) {
+		t.Errorf("unexpected attributes lookup of %q: the prefetcher must never ask the store for sizes", name)
+		return nil, fmt.Errorf("unexpected attributes lookup")
+	}
+	return s
+}
+
+func (s *prefetchStore) openedFiles() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.opened...)
+}
+
+// writeSegment writes one output file holding one item per block of rng, each with a
+// payload of payloadSize bytes.
+func (s *prefetchStore) writeSegment(t *testing.T, rng *block.Range, payloadSize int) {
+	t.Helper()
+	store := dstore.NewMockStore(nil)
+	store.SetMetadataFunc = func(context.Context, string, map[string]string) error { return nil }
+	fw := NewFileWriter(context.Background(), store, zap.NewNop(), rng, "mod")
+	for num := rng.StartBlock; num < rng.ExclusiveEndBlock; num++ {
+		payload := bytes.Repeat([]byte{byte(num)}, payloadSize)
+		require.NoError(t, fw.SetItem(&pbsubstreams.Clock{Number: num, Id: fmt.Sprintf("block-%d", num)}, payload))
+	}
+	require.NoError(t, fw.Close())
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Files[fw.Filename()] = store.Files[fw.Filename()]
+}
+
+func newPrefetchWalker(store *prefetchStore, segmenter *block.Segmenter, cfg PrefetchConfig) *FileWalker {
+	config := &Config{name: "mod", objStore: store, logger: zap.NewNop()}
+	return NewFileWalker(config, segmenter, zap.NewNop()).WithPrefetch(cfg)
+}
+
+// readCurrent streams the walker's current segment, appends its block numbers to
+// blocks and advances the walker.
+func readCurrent(t *testing.T, ctx context.Context, walker *FileWalker, blocks *[]uint64) error {
+	t.Helper()
+	reader, err := walker.FileReader(ctx)
+	if err != nil {
+		return err
+	}
+	for item, err := range reader.Iter() {
+		require.NoError(t, err)
+		*blocks = append(*blocks, item.BlockNum)
+	}
+	require.NoError(t, reader.Close())
+	walker.Next()
+	return nil
+}
+
+func walkAll(t *testing.T, ctx context.Context, walker *FileWalker) []uint64 {
+	t.Helper()
+	var blocks []uint64
+	for !walker.IsDone() {
+		require.NoError(t, readCurrent(t, ctx, walker, &blocks))
+	}
+	return blocks
+}
+
+func blockNums(from, to uint64) (out []uint64) {
+	for i := from; i < to; i++ {
+		out = append(out, i)
+	}
+	return out
+}
+
+func filename(segmenter *block.Segmenter, segment int) string {
+	rng := segmenter.Range(segment)
+	return computeDBinFilename(rng.StartBlock, rng.ExclusiveEndBlock)
+}
+
+func countOf(list []string, value string) (n int) {
+	for _, v := range list {
+		if v == value {
+			n++
+		}
+	}
+	return n
+}
+
+func assertNothingHeld(t *testing.T, p *prefetcher) {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	assert.Zero(t, p.held, "every segment released its bytes")
+	assert.Empty(t, p.segments)
+}
+
+func TestPrefetch_StreamsEverySegmentInOrder(t *testing.T) {
+	store := newPrefetchStore(t)
+	segmenter := block.NewSegmenter(10, 0, 60)
+	for i := 0; i < 6; i++ {
+		store.writeSegment(t, segmenter.Range(i), 8)
+	}
+	walker := newPrefetchWalker(store, segmenter, PrefetchConfig{Depth: 3, BudgetBytes: 1 << 20})
+
+	ctx := context.Background()
+	first, err := walker.FileReader(ctx)
+	require.NoError(t, err)
+
+	// Segment 1 is probed alone, then its size lets 2 and 3 download together, all
+	// while segment 0 is still being read.
+	require.Eventually(t, func() bool { return len(store.openedFiles()) == 4 }, 2*time.Second, time.Millisecond)
+	assert.Equal(t, filename(segmenter, 1), store.openedFiles()[1])
+	assert.ElementsMatch(t, []string{filename(segmenter, 2), filename(segmenter, 3)}, store.openedFiles()[2:])
+	require.NoError(t, first.Close())
+	walker.Next()
+
+	var blocks []uint64
+	for !walker.IsDone() {
+		require.NoError(t, readCurrent(t, ctx, walker, &blocks))
+	}
+	assert.Equal(t, blockNums(10, 60), blocks)
+	assert.Len(t, store.openedFiles(), 6, "every segment was opened exactly once")
+	assertNothingHeld(t, walker.prefetch)
+}
+
+func TestPrefetch_DepthIsCapped(t *testing.T) {
+	walker := newPrefetchWalker(newPrefetchStore(t), block.NewSegmenter(10, 0, 100), PrefetchConfig{Depth: 50, BudgetBytes: 1 << 20})
+	assert.Equal(t, MaxPrefetchDepth, walker.prefetch.cfg.Depth)
+}
+
+func TestPrefetch_BudgetBoundsHowManySegmentsRunAhead(t *testing.T) {
+	store := newPrefetchStore(t)
+	segmenter := block.NewSegmenter(10, 0, 60)
+	for i := 0; i < 6; i++ {
+		store.writeSegment(t, segmenter.Range(i), 8)
+	}
+	segmentSize := uint64(len(store.Files[filename(segmenter, 1)]))
+	// Room for two segments and a bit, so at most two are ever ahead of the walker.
+	walker := newPrefetchWalker(store, segmenter, PrefetchConfig{Depth: 4, BudgetBytes: segmentSize*2 + segmentSize/2})
+
+	ctx := context.Background()
+	first, err := walker.FileReader(ctx)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return len(store.openedFiles()) == 3 }, 2*time.Second, time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
+	assert.Len(t, store.openedFiles(), 3, "segment 3 waits for the budget")
+	require.NoError(t, first.Close())
+	walker.Next()
+
+	var blocks []uint64
+	for !walker.IsDone() {
+		require.NoError(t, readCurrent(t, ctx, walker, &blocks))
+	}
+	assert.Equal(t, blockNums(10, 60), blocks)
+	assertNothingHeld(t, walker.prefetch)
+}
+
+func TestPrefetch_OverflowTurnsPrefetchingOff(t *testing.T) {
+	store := newPrefetchStore(t)
+	segmenter := block.NewSegmenter(10, 0, 40)
+	store.writeSegment(t, segmenter.Range(0), 8)
+	store.writeSegment(t, segmenter.Range(1), 100) // over the budget
+	store.writeSegment(t, segmenter.Range(2), 8)
+	store.writeSegment(t, segmenter.Range(3), 8)
+	walker := newPrefetchWalker(store, segmenter, PrefetchConfig{Depth: 4, BudgetBytes: 500})
+
+	ctx := context.Background()
+	first, err := walker.FileReader(ctx)
+	require.NoError(t, err)
+	p := walker.prefetch
+	require.Eventually(t, func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return p.disabled
+	}, 2*time.Second, time.Millisecond, "the probe of segment 1 overflows and turns prefetching off")
+	require.NoError(t, first.Close())
+	walker.Next()
+
+	blocks := blockNums(0, 10)
+	for !walker.IsDone() {
+		require.NoError(t, readCurrent(t, ctx, walker, &blocks))
+	}
+	assert.Equal(t, blockNums(0, 40), blocks)
+
+	// Segment 1 was probed by the prefetcher, dropped, then opened by the walker.
+	// Nothing after it was prefetched.
+	opened := store.openedFiles()
+	assert.Equal(t, 2, countOf(opened, filename(segmenter, 1)))
+	assert.Equal(t, 1, countOf(opened, filename(segmenter, 2)))
+	assert.Equal(t, 1, countOf(opened, filename(segmenter, 3)))
+	assertNothingHeld(t, p)
+}
+
+func TestPrefetch_MissingSegmentIsLeftToTheWalker(t *testing.T) {
+	store := newPrefetchStore(t)
+	segmenter := block.NewSegmenter(10, 0, 80)
+	for i := 0; i < 8; i++ {
+		if i != 2 {
+			store.writeSegment(t, segmenter.Range(i), 8)
+		}
+	}
+	walker := newPrefetchWalker(store, segmenter, PrefetchConfig{Depth: 4, BudgetBytes: 1 << 20})
+
+	ctx := context.Background()
+	var blocks []uint64
+	require.NoError(t, readCurrent(t, ctx, walker, &blocks))
+	require.NoError(t, readCurrent(t, ctx, walker, &blocks))
+
+	// Segment 2 failed to open. Up to a depth's worth of segments after it may already
+	// have been launched alongside it and are held, but the launcher then stops until
+	// the walker reaches the gap, so the far end of the range is never touched.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 0, countOf(store.openedFiles(), filename(segmenter, 7)))
+
+	require.ErrorIs(t, readCurrent(t, ctx, walker, &blocks), dstore.ErrNotFound)
+	store.writeSegment(t, segmenter.Range(2), 8)
+	for !walker.IsDone() {
+		require.NoError(t, readCurrent(t, ctx, walker, &blocks))
+	}
+	assert.Equal(t, blockNums(0, 80), blocks)
+	assert.Equal(t, 1, countOf(store.openedFiles(), filename(segmenter, 7)), "the far end was prefetched once the walker passed the gap")
+	assertNothingHeld(t, walker.prefetch)
+}
+
+func TestPrefetch_CancelStopsTheGoroutine(t *testing.T) {
+	store := newPrefetchStore(t)
+	segmenter := block.NewSegmenter(10, 0, 30)
+	for i := 0; i < 3; i++ {
+		store.writeSegment(t, segmenter.Range(i), 8)
+	}
+	walker := newPrefetchWalker(store, segmenter, PrefetchConfig{Depth: 1, BudgetBytes: 1 << 20})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reader, err := walker.FileReader(ctx)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	// Depth 1 keeps the launcher waiting on segment 1's release before it can fetch 2.
+	require.Eventually(t, func() bool { return countOf(store.openedFiles(), filename(segmenter, 1)) == 1 }, 2*time.Second, time.Millisecond)
+	cancel()
+
+	p := walker.prefetch
+	require.Eventually(t, func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return p.done
+	}, 2*time.Second, time.Millisecond)
+	assert.Equal(t, 0, countOf(store.openedFiles(), filename(segmenter, 2)))
+}

--- a/storage/execout/prefetch_test.go
+++ b/storage/execout/prefetch_test.go
@@ -226,6 +226,64 @@ func TestPrefetch_OverflowTurnsPrefetchingOff(t *testing.T) {
 	assertNothingHeld(t, p)
 }
 
+// Files jump from small to big mid-range. Small files set a small estimate, so the
+// prefetcher launches Depth downloads with a quarter of the budget each; the big
+// files overflow their share, go to the walker, and raise the estimate until one
+// download at a time gets the whole budget and fits. Held bytes never pass the
+// budget at any point.
+func TestPrefetch_FileOverItsShareShrinksConcurrency(t *testing.T) {
+	store := newPrefetchStore(t)
+	segmenter := block.NewSegmenter(10, 0, 100)
+	for i := 0; i < 10; i++ {
+		payload := 8
+		if i >= 2 && i <= 8 {
+			payload = 100
+		}
+		store.writeSegment(t, segmenter.Range(i), payload)
+	}
+	small := uint64(len(store.Files[filename(segmenter, 0)]))
+	big := uint64(len(store.Files[filename(segmenter, 2)]))
+	budget := big + big/2 // one big file fits, two do not, and a quarter share is far too small
+	require.Greater(t, budget/4, small)
+	require.Less(t, budget/2, big)
+	walker := newPrefetchWalker(store, segmenter, PrefetchConfig{Depth: 4, BudgetBytes: budget})
+	p := walker.prefetch
+
+	stop := make(chan struct{})
+	var maxHeld uint64
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			p.mu.Lock()
+			maxHeld = max(maxHeld, p.held)
+			p.mu.Unlock()
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+
+	blocks := walkAll(t, context.Background(), walker)
+	close(stop)
+
+	assert.Equal(t, blockNums(0, 100), blocks)
+	p.mu.Lock()
+	assert.False(t, p.disabled, "a big file fits the whole budget, so prefetching stays on")
+	p.mu.Unlock()
+	assert.LessOrEqual(t, maxHeld, budget)
+	opened := store.openedFiles()
+	prefetchedBig := 0
+	for i := 2; i <= 8; i++ {
+		if countOf(opened, filename(segmenter, i)) == 1 {
+			prefetchedBig++
+		}
+	}
+	assert.GreaterOrEqual(t, prefetchedBig, 2, "once the estimate caught up, big files were prefetched in one read")
+	assertNothingHeld(t, p)
+}
+
 func TestPrefetch_MissingSegmentIsLeftToTheWalker(t *testing.T) {
 	store := newPrefetchStore(t)
 	segmenter := block.NewSegmenter(10, 0, 80)

--- a/storage/execout/streamproto/protostream.go
+++ b/storage/execout/streamproto/protostream.go
@@ -78,8 +78,10 @@ func ReadNextItem(reader io.Reader) (item *pb.Item, err error) {
 		return nil, fmt.Errorf("failed to read item data: %w", err)
 	}
 
+	// itemData is a fresh allocation nothing else reads, so the item aliases it
+	// instead of copying the payload out.
 	item = &pb.Item{}
-	if err := item.UnmarshalVT(itemData); err != nil {
+	if err := item.UnmarshalVTUnsafe(itemData); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal item: %w", err)
 	}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -647,7 +647,25 @@ func listFiles(t *testing.T, tempDir string) (storedFiles []string, emptyFiles [
 	return
 }
 
+// waitForPartialSpkg waits for the package marker, which tier1 writes detached from
+// the request and may still be writing when the request has returned.
+func waitForPartialSpkg(t *testing.T, tempDir string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		produced, _ := listFiles(t, tempDir)
+		for _, f := range produced {
+			if strings.HasSuffix(f, "substreams.partial.spkg.zst") {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "substreams.partial.spkg should be produced")
+}
+
 func assertFiles(t *testing.T, tempDir string, expectPartialSpkg bool, expectNonEmpty bool, wantedFiles ...string) {
+	if expectPartialSpkg {
+		waitForPartialSpkg(t, tempDir)
+	}
 	producedFiles, emptyFiles := listFiles(t, tempDir)
 
 	if !expectNonEmpty {

--- a/test/tier2_integration_test.go
+++ b/test/tier2_integration_test.go
@@ -568,6 +568,9 @@ func TestTier2Call(t *testing.T) {
 }
 
 func assertFilesWithEmpty(t *testing.T, tempDir string, expectPartialSpkg bool, expectNonEmpty bool, wantedFiles []string, expectedEmptyFiles []string) {
+	if expectPartialSpkg {
+		waitForPartialSpkg(t, tempDir)
+	}
 	producedFiles, emptyFiles := listFiles(t, tempDir)
 
 	if !expectNonEmpty {


### PR DESCRIPTION
Four tier1 changes to the production-mode streaming path.

**Prefetch cached execution output files.** Each 1000-block segment was opened, decompressed and sent before the next one was requested from the object store, so every segment paid a full store round trip on the critical path. Tier1 now downloads the next segments while streaming the current one, bounded per request by `Tier1Config.ExecOutPrefetch`: at most 4 segments ahead holding at most 64 MiB of decompressed data, and that budget is a hard cap. No size is asked of the store: the decompressed size of the last downloaded segment is the estimate for the next ones, as many download at once as estimate-sized files fit in the budget, and each in-flight download reserves an even share of the budget as its read limit, so in-flight reads never add up to more than the budget. A file over its share is left to the walker and doubles the estimate, so a chain going from quiet to busy shrinks the concurrency instead of overshooting. A file over the whole budget turns prefetching off for that request. Missing files are left to the walker's existing retry loop. Off in noop mode.

**Send batches on their own goroutine.** The walker built a batch, sent it, then decoded the next one, so gRPC compression and the socket write sat on the critical path of every batch. Sends now go through an unbuffered channel to a sender goroutine, so one batch is compressed and written while the next is decoded. A failed send is sticky and nothing goes out after it. A panic inside a send is recovered into a send error, as the walker's own goroutine did before. The walker drains the sender before a segment is reported done, so the linear pipeline can never send ahead of cached data and message order is unchanged. Measured on a synthetic 10 MiB segment: decode 1.3 ms, marshal plus zstd 5.9 ms, serial 7.2 ms, overlapped 6.5 ms. The send side dominates, and most of it is zstd.

**Stop copying payloads while decoding.** `ReadNextItem` reads each item into a fresh buffer nothing else touches, so the item now aliases it instead of copying the payload out.

**Write cache markers off the critical path.** The `substreams.spkg` and `last_used` writes ran synchronously before the pipeline started. They now run fire and forget on a detached context with a 30 s timeout. The request neither starts nor exits waiting for them, so a hanging store cannot hold a cancelled request's slot. The integration tests poll for the spkg marker instead of expecting it the moment the request returns.

Ordering is preserved at every step: the walker still asks for one segment at a time and only advances on a completed send, the prefetcher only answers for the segment asked, and the segmenter is immutable. Files are created atomically and never overwritten, so reading them earlier cannot pick up different content.

Tests: prefetch tests cover ordering, depth and budget bounds, the share overflow path with a held-bytes probe that never exceeds the budget, overflow of the whole budget, a missing segment and cancellation. The walker had no tests before; new ones cover block order under a slow sink in buffered and unbuffered modes, a send error stopping the segment, a panic in a send, and the exclusive end block. All pass under the race detector, 20 repetitions for the prefetch suite.

One measured non-change: egress accounting calls `proto.Size` before `SendMsg`, which looked like a double marshal. On a 100-block, 10 MiB batch it costs 11 µs against 812 µs for the marshal, so it was left alone.
