### PR TITLE
Stop rescanning the job backlog when picking the next tier2 job

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -22,6 +22,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Server
 
+- `substreams-tier1` scheduling no longer slows down as a large backprocessing range progresses. Picking the next
+  tier2 job walked every segment between the squasher and the job frontier on every call, re-checking
+  dependencies that could not have changed, so a run over N segments cost O(N²) in scheduling. The scheduler now
+  keeps, per stage, the lowest segment that may still be pending and the highest segment completed so far, and
+  only looks at the handful of segments those point at. On a 3-stage graph with 4 workers and a squasher three
+  times slower than the jobs, scheduling 8000 segments went from 1.18 s to 2.7 ms, and now grows linearly with
+  the range. Job order is unchanged.
+
 - `substreams-tier1` now downloads the next cached execution output files while it streams the current one to a
   production-mode client. Before, each 1000-block segment was opened, decompressed and sent before the next one
   was even requested from the object store, so every segment paid a full store round trip on the critical path.

--- a/orchestrator/stage/nextjob_scaling_test.go
+++ b/orchestrator/stage/nextjob_scaling_test.go
@@ -94,7 +94,7 @@ func TestNextJob_CursorFollowsTheJobFrontierNotTheSquasher(t *testing.T) {
 	_, r, _ := stages.NextJob(math.MaxInt)
 	require.Nil(t, r)
 	require.GreaterOrEqual(t, stages.pendingFrom[0], segments-1, "stage 0 cursor stuck behind the unsquashed backlog")
-	require.LessOrEqual(t, len(stages.candidates), len(stages.stages)*2, "a call visits a bounded number of segments")
+	require.LessOrEqual(t, len(stages.candidateSegments(stages.nextJobCursor, segments-1)), len(stages.stages)*2, "a call visits a bounded number of segments")
 
 	// A squash that finds no partial sends the unit back to Pending, and the cursor
 	// must come back with it or the job would never be re-scheduled.

--- a/orchestrator/stage/nextjob_scaling_test.go
+++ b/orchestrator/stage/nextjob_scaling_test.go
@@ -1,0 +1,131 @@
+package stage
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/streamingfast/substreams/orchestrator/plan"
+	"github.com/streamingfast/substreams/pipeline/exec"
+	"github.com/stretchr/testify/require"
+)
+
+// scheduleRun drives Stages the way the scheduler does, without workers or a
+// store: up to `workers` jobs in flight, each job succeeding in the order it was
+// handed out, and one squash per `squashEvery` job completions so that the
+// squasher lags far behind the jobs. It returns how many NextJob calls it took.
+func scheduleRun(t testing.TB, segments, workers, squashEvery int) (stages *Stages, nextJobCalls int) {
+	t.Helper()
+	interval := uint64(10)
+	end := uint64(segments) * interval
+	reqPlan, err := plan.BuildTier1RequestPlan(true, interval, 0, 0, 0, end, end, true)
+	require.NoError(t, err)
+	stages = NewStages(context.Background(), exec.TestGraphStagedModules(0, 0, 0, 0, 0), reqPlan, nil, nil)
+
+	squashOne := func() bool {
+		for idx, stage := range stages.stages {
+			if stage.kind != KindStore {
+				continue
+			}
+			u := stage.nextUnit()
+			if u.Segment > stage.segmenter.LastIndex() || stages.getState(u) != UnitPartialPresent || !stages.previousUnitComplete(u) {
+				continue
+			}
+			stages.MarkSegmentMerging(u)
+			stages.MergeCompleted(u)
+			_ = idx
+			return true
+		}
+		return false
+	}
+
+	var inflight []Unit
+	completions := 0
+	for {
+		for len(inflight) < workers {
+			nextJobCalls++
+			u, r, _ := stages.NextJob(math.MaxInt)
+			if r == nil {
+				break
+			}
+			inflight = append(inflight, u)
+		}
+		if len(inflight) == 0 {
+			if !squashOne() {
+				break
+			}
+			continue
+		}
+		u := inflight[0]
+		inflight = inflight[1:]
+		stages.MarkJobSuccess(u)
+		completions++
+		if completions%squashEvery == 0 {
+			squashOne()
+		}
+	}
+	require.True(t, stages.AllStoresCompleted(), "every store segment squashed")
+	require.True(t, stages.LastStageCompleted(), "every map segment produced")
+	return stages, nextJobCalls
+}
+
+func TestNextJob_CursorFollowsTheJobFrontierNotTheSquasher(t *testing.T) {
+	interval := uint64(10)
+	segments := 200
+	end := uint64(segments) * interval
+	reqPlan, err := plan.BuildTier1RequestPlan(true, interval, 0, 0, 0, end, end, true)
+	require.NoError(t, err)
+	stages := NewStages(context.Background(), exec.TestGraphStagedModules(0, 0, 0, 0, 0), reqPlan, nil, nil)
+
+	// Run every stage-0 job to completion without squashing anything: the whole
+	// first stage is PartialPresent, waiting on the squasher.
+	for {
+		u, r, _ := stages.NextJob(math.MaxInt)
+		if r == nil {
+			break
+		}
+		stages.MarkJobSuccess(u)
+	}
+	require.Equal(t, UnitPartialPresent, stages.getState(Unit{Segment: segments - 1, Stage: 0}))
+
+	// The next call has nothing to hand out. It must not rescan the backlog: the
+	// first stage's pending cursor sits at the frontier, not at segment 0 where the
+	// squasher is, and the higher stages cannot reach past the squasher.
+	_, r, _ := stages.NextJob(math.MaxInt)
+	require.Nil(t, r)
+	require.GreaterOrEqual(t, stages.pendingFrom[0], segments-1, "stage 0 cursor stuck behind the unsquashed backlog")
+	require.LessOrEqual(t, len(stages.candidates), len(stages.stages)*2, "a call visits a bounded number of segments")
+
+	// A squash that finds no partial sends the unit back to Pending, and the cursor
+	// must come back with it or the job would never be re-scheduled.
+	stages.MarkSegmentMerging(Unit{Segment: 0, Stage: 0})
+	stages.MarkSegmentPending(Unit{Segment: 0, Stage: 0})
+	u, r, _ := stages.NextJob(math.MaxInt)
+	require.NotNil(t, r)
+	require.Equal(t, Unit{Segment: 0, Stage: 0}, u)
+}
+
+func TestNextJob_FullRunCompletes(t *testing.T) {
+	scheduleRun(t, 300, 4, 3)
+}
+
+func BenchmarkNextJob_SlowSquasher(b *testing.B) {
+	for _, segments := range []int{1000, 2000, 4000, 8000} {
+		b.Run(itoa(segments), func(b *testing.B) {
+			var calls int
+			for i := 0; i < b.N; i++ {
+				_, calls = scheduleRun(b, segments, 4, 3)
+			}
+			b.ReportMetric(float64(calls), "nextjob_calls")
+		})
+	}
+}
+
+func itoa(i int) string {
+	out := ""
+	for i > 0 {
+		out = string(rune('0'+i%10)) + out
+		i /= 10
+	}
+	return out
+}

--- a/orchestrator/stage/nextjob_scaling_test.go
+++ b/orchestrator/stage/nextjob_scaling_test.go
@@ -109,6 +109,27 @@ func TestNextJob_FullRunCompletes(t *testing.T) {
 	scheduleRun(t, 300, 4, 3)
 }
 
+// An execout file found missing long after its segment was done sends the map unit
+// back to Pending. The cursors have all moved to the end of the range by then, and
+// the job must still come back out of NextJob.
+func TestNextJob_ReschedulesAMapSegmentWhoseFileWentMissing(t *testing.T) {
+	stages, _ := scheduleRun(t, 300, 4, 3)
+	_, r, _ := stages.NextJob(math.MaxInt)
+	require.Nil(t, r, "everything is done")
+
+	mapStage := len(stages.stages) - 1
+	require.True(t, stages.ReprocessMapSegment(150))
+
+	u, r, _ := stages.NextJob(math.MaxInt)
+	require.NotNil(t, r)
+	require.Equal(t, Unit{Segment: 150, Stage: mapStage}, u)
+
+	stages.MarkJobSuccess(u)
+	_, r, _ = stages.NextJob(math.MaxInt)
+	require.Nil(t, r)
+	require.True(t, stages.LastStageCompleted())
+}
+
 func BenchmarkNextJob_SlowSquasher(b *testing.B) {
 	for _, segments := range []int{1000, 2000, 4000, 8000} {
 		b.Run(itoa(segments), func(b *testing.B) {

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -84,7 +84,6 @@ type Stages struct {
 	// candidateSegments.
 	pendingFrom     []int
 	completedPrefix []int
-	candidates      []int // scratch for candidateSegments
 }
 type stageStates []UnitState
 
@@ -615,7 +614,7 @@ func (s *Stages) rewindNextJobCursor(u Unit) {
 // Everything else is either done, in flight, or blocked on a lower stage, and
 // walking it would only re-check dependencies that cannot have changed.
 func (s *Stages) candidateSegments(from, lastSegment int) []int {
-	out := s.candidates[:0]
+	var out []int
 
 	if len(s.stages) >= 2 {
 		windowEnd := min(lastSegment, s.shadowableSegment+len(s.stages)-1)
@@ -636,8 +635,7 @@ func (s *Stages) candidateSegments(from, lastSegment int) []int {
 	}
 
 	slices.Sort(out)
-	s.candidates = slices.Compact(out)
-	return s.candidates
+	return slices.Compact(out)
 }
 
 // advancePendingFrom moves pendingFrom[stageIdx] up to the first Pending unit at or

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -3,6 +3,7 @@ package stage
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -74,6 +75,16 @@ type Stages struct {
 	// longer re-walks the (ever-growing) prefix of finished segments on every
 	// call. See NextJob / segmentMayYieldJob.
 	nextJobCursor int
+
+	// pendingFrom[stage] is the lowest segment that may hold a Pending unit of that
+	// stage, and completedPrefix[stage] the highest segment up to which every unit
+	// of that stage is Completed or NoOp. Both only move forward, except through
+	// rewindNextJobCursor. NextJob visits only the segments they point at instead of
+	// walking every segment between the squasher and the job frontier. See
+	// candidateSegments.
+	pendingFrom     []int
+	completedPrefix []int
+	candidates      []int // scratch for candidateSegments
 }
 type stageStates []UnitState
 
@@ -151,6 +162,12 @@ func NewStages(
 
 	out.initSegmentsOffset(reqPlan)
 	out.nextJobCursor = out.globalSegmenter.FirstIndex()
+	out.pendingFrom = make([]int, len(out.stages))
+	out.completedPrefix = make([]int, len(out.stages))
+	for idx, stage := range out.stages {
+		out.pendingFrom[idx] = stage.segmenter.FirstIndex()
+		out.completedPrefix[idx] = stage.segmenter.FirstIndex() - 1
+	}
 
 	return out
 }
@@ -546,11 +563,12 @@ func (s *Stages) WaitAsyncWork() error {
 // segmentMayYieldJob reports whether NextJob could ever still return a job for
 // this segment. It is used to advance nextJobCursor over the finished prefix.
 //
-// A segment can no longer yield a job once every in-range stage's unit is in a
-// state that never transitions back to UnitPending:
-//   - Completed / NoOp are terminal for any stage;
-//   - PartialPresent is terminal only for map stages (maps are never squashed);
-//     a store partial can revert to Pending if a squash fails, so it still counts.
+// A segment can no longer yield a job once every in-range stage's unit has had its
+// job run: Completed, NoOp, PartialPresent or Merging. The last two are not
+// terminal for a store, a squash that finds no partial sends the unit back to
+// Pending, but every transition back to Pending goes through rewindNextJobCursor,
+// so the cursor is allowed past them. This keeps the cursor at the job frontier
+// rather than at the squasher, which can lag thousands of segments behind it.
 //
 // Out-of-range stages (segment before the stage's first index or after its last)
 // never schedule there, matching the skip/break in NextJob's main loop. Being
@@ -563,18 +581,90 @@ func (s *Stages) segmentMayYieldJob(segmentIdx int) bool {
 			continue
 		}
 		switch s.getState(Unit{Segment: segmentIdx, Stage: stageIdx}) {
-		case UnitCompleted, UnitNoOp:
-			// permanently done for this stage
-		case UnitPartialPresent:
-			if stage.kind != KindMap {
-				return true
-			}
+		case UnitCompleted, UnitNoOp, UnitPartialPresent, UnitMerging:
+			// the job ran; only rewindNextJobCursor can bring it back
 		default:
-			// Pending, Scheduled, Merging, Shadowed: may still (re)schedule
+			// Pending, Scheduled, Shadowed: may still (re)schedule
 			return true
 		}
 	}
 	return false
+}
+
+// rewindNextJobCursor brings the NextJob cursors back to u. Every transition that
+// puts a unit back to Pending must call it: NextJob only looks at what the cursors
+// point at, and they have moved past a segment whose jobs all ran.
+func (s *Stages) rewindNextJobCursor(u Unit) {
+	s.nextJobCursor = min(s.nextJobCursor, u.Segment)
+	s.pendingFrom[u.Stage] = min(s.pendingFrom[u.Stage], u.Segment)
+	s.completedPrefix[u.Stage] = min(s.completedPrefix[u.Stage], u.Segment-1)
+}
+
+// candidateSegments returns, in ascending order and starting at from, the only
+// segments at which NextJob can find a job:
+//
+//   - every segment of the shadow window, where NextJob also marks lower-stage
+//     units shadowed as it passes;
+//   - for each stage, its lowest Pending segment, when it lies within reach of the
+//     lower stages. A job of stage k at segment N loads the lower stages' stores as
+//     of N's start block, which exist only once every stage below k has completed
+//     N-1. Stages complete in segment order, so no unit of stage k above
+//     min(completedPrefix of the stages below)+1 can run yet, and no unit of stage
+//     k below its lowest Pending segment is Pending.
+//
+// Everything else is either done, in flight, or blocked on a lower stage, and
+// walking it would only re-check dependencies that cannot have changed.
+func (s *Stages) candidateSegments(from, lastSegment int) []int {
+	out := s.candidates[:0]
+
+	if len(s.stages) >= 2 {
+		windowEnd := min(lastSegment, s.shadowableSegment+len(s.stages)-1)
+		for seg := from; seg <= windowEnd; seg++ {
+			out = append(out, seg)
+		}
+	}
+
+	reach := lastSegment
+	for idx, stage := range s.stages {
+		if idx > 0 {
+			reach = min(reach, s.advanceCompletedPrefix(idx-1, lastSegment)+1)
+		}
+		upTo := min(reach, stage.segmenter.LastIndex())
+		if pending := s.advancePendingFrom(idx, from, upTo); pending <= upTo {
+			out = append(out, pending)
+		}
+	}
+
+	slices.Sort(out)
+	s.candidates = slices.Compact(out)
+	return s.candidates
+}
+
+// advancePendingFrom moves pendingFrom[stageIdx] up to the first Pending unit at or
+// above from, without looking past upTo, and returns it. The states it skips only
+// come back to Pending through rewindNextJobCursor.
+func (s *Stages) advancePendingFrom(stageIdx, from, upTo int) int {
+	p := max(s.pendingFrom[stageIdx], from)
+	for p <= upTo && s.getState(Unit{Segment: p, Stage: stageIdx}) != UnitPending {
+		p++
+	}
+	s.pendingFrom[stageIdx] = p
+	return p
+}
+
+// advanceCompletedPrefix moves completedPrefix[stageIdx] over every unit that is
+// Completed or NoOp and returns it.
+func (s *Stages) advanceCompletedPrefix(stageIdx, lastSegment int) int {
+	p := s.completedPrefix[stageIdx]
+	for p < lastSegment {
+		state := s.getState(Unit{Segment: p + 1, Stage: stageIdx})
+		if state != UnitCompleted && state != UnitNoOp {
+			break
+		}
+		p++
+	}
+	s.completedPrefix[stageIdx] = p
+	return p
 }
 
 // Returns the unit, its block range and a boolean indicating if we are backing off because of 'notAbove'
@@ -602,7 +692,7 @@ func (s *Stages) NextJob(notAboveSegment int) (Unit, *block.Range, bool) {
 		s.nextJobCursor++
 	}
 
-	for segmentIdx := s.nextJobCursor; segmentIdx <= lastSegment; segmentIdx++ {
+	for _, segmentIdx := range s.candidateSegments(s.nextJobCursor, lastSegment) {
 		someShadowed := s.markShadowedUnits(segmentIdx)
 		for stageIdx := lastStage; stageIdx >= 0; stageIdx-- {
 			stage := s.stages[stageIdx]

--- a/orchestrator/stage/transitions.go
+++ b/orchestrator/stage/transitions.go
@@ -112,6 +112,7 @@ func (s *Stages) MarkSegmentPending(u Unit) {
 	s.transition(u, UnitPending,
 		UnitMerging, // Squasher didn't find the partials, so asking for the job to re-run
 	)
+	s.rewindNextJobCursor(u)
 }
 
 // ReprocessMapSegment sends a map-stage unit back to Pending so its job runs again,
@@ -129,11 +130,7 @@ func (s *Stages) ReprocessMapSegment(segmentIdx int) bool {
 		return false
 	}
 	s.setState(u, UnitPending)
-	// NextJob only scans from nextJobCursor; the cursor had moved past this segment
-	// when the unit was done.
-	if segmentIdx < s.nextJobCursor {
-		s.nextJobCursor = segmentIdx
-	}
+	s.rewindNextJobCursor(u)
 	return true
 }
 
@@ -163,6 +160,7 @@ func (s *Stages) ReleaseJob(u Unit) {
 	s.transition(u, UnitPending,
 		UnitScheduled,
 	)
+	s.rewindNextJobCursor(u)
 }
 
 func (s *Stages) markSegmentScheduled(u Unit) {


### PR DESCRIPTION
Picking the next tier2 job walked every segment between the squasher and the job frontier on every call, re-checking dependencies that could not have changed: every stage above 0 holds Pending units across that whole backlog, each waiting on the stage below to squash the previous segment. The scheduler now keeps, per stage, the lowest segment that may be Pending and the completed prefix, and a stage can only run at or below the prefix of the stages under it, so a call visits one segment per stage plus the shadow window. Every transition back to Pending rewinds the cursors, so a map output found missing is still re-scheduled. Job order is unchanged.

Measured, 3 stages, 4 workers, squasher 3x slower than the jobs, whole run:

| segments | before | after |
|---|---|---|
| 1000 | 19.7 ms | 0.34 ms |
| 8000 | 1181 ms | 2.73 ms |

Before grew 3.9x per doubling of the range, after 2x. Per call at 8000 segments: 27 µs to 62 ns.

In perspective, with 1000-block segments: at 400M blocks (Solana, Arbitrum) a call cost about 3 ms with 3 stages, about 6 ms with 5, and the scheduler loop makes 5 to 9 calls per job. That is a few percent of one core on a normal full-history run, and only became the bottleneck in noop or store-only mode with fast jobs and many workers, where the loop saturated while tier2 waited. In production mode the walker already bounds the backlog to a few hundred segments, so nothing changes there.
