### PR TITLE
Webhook sink: auth, signature, resumable delivery, reorg notifications, batching

### DIFF
--- a/cmd/substreams/sink_webhook.go
+++ b/cmd/substreams/sink_webhook.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/streamingfast/cli"
 	"github.com/streamingfast/cli/sflags"
 	"github.com/streamingfast/derr"
 	"github.com/streamingfast/substreams/sink"
@@ -28,6 +31,9 @@ func init() {
 	sinkWebhookCmd.Flags().Int("webhook-max-retries", 3, "Maximum number of retries for webhook calls (0 disables retries, -1 for infinite retries)")
 	sinkWebhookCmd.Flags().Duration("webhook-timeout", 30*time.Second, "Timeout for individual webhook calls")
 	sinkWebhookCmd.Flags().Duration("webhook-max-retry-interval", 30*time.Second, "Maximum interval between webhook retries (exponential backoff cap)")
+	sinkWebhookCmd.Flags().String("webhook-auth-header-name", webhook.DefaultAuthHeaderName, "Name of the header carrying the value read from --webhook-auth-header-value-envvar")
+	sinkWebhookCmd.Flags().String("webhook-auth-header-value-envvar", "WEBHOOK_AUTH_HEADER_VALUE", "Environment variable holding the auth header value sent on every call, for example 'Bearer <token>'. No header is sent when the variable is empty")
+	sinkWebhookCmd.Flags().String("webhook-signing-secret-envvar", "WEBHOOK_SIGNING_SECRET", fmt.Sprintf("Environment variable holding the secret used to sign every call body with HMAC-SHA256 in the %s header. No signature is sent when the variable is empty", webhook.SignatureHeader))
 
 	SinkCmd.AddCommand(sinkWebhookCmd)
 }
@@ -36,8 +42,23 @@ func init() {
 var sinkWebhookCmd = &cobra.Command{
 	Use:   "webhook <url> [<manifest> [<module_name>]]",
 	Short: "Trigger a webhook call for each event from a substreams module",
-	RunE:  sinkWebhookE,
-	Args:  cobra.RangeArgs(1, 3),
+	Long: cli.Dedent(`
+		POST the output of a substreams module to <url>, one call per block, as JSON:
+
+		  {"clock": {"number": ..., "id": "...", "timestamp": "..."},
+		   "manifest": {"moduleName": "...", "type": "..."},
+		   "data": {...}}
+
+		Calls carry the header named by --webhook-auth-header-name when the variable named by
+		--webhook-auth-header-value-envvar is set, and an ` + webhook.SignatureHeader + ` header when the
+		variable named by --webhook-signing-secret-envvar is set. The signature value is
+		"t=<unix seconds>,v1=<hex>" where <hex> is HMAC-SHA256 over "<t>.<body>" keyed with the secret.
+
+		Network errors and 5xx responses are retried with exponential backoff up to --webhook-max-retries.
+		A 4xx response is not retried.
+	`),
+	RunE: sinkWebhookE,
+	Args: cobra.RangeArgs(1, 3),
 }
 
 func sinkWebhookE(cmd *cobra.Command, args []string) error {
@@ -60,21 +81,17 @@ func sinkWebhookE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Get webhook configuration from flags
-	stateFileStr := sflags.MustGetString(cmd, "state-file")
-	webhookTimeout := sflags.MustGetDuration(cmd, "webhook-timeout")
-	webhookMaxRetries := sflags.MustGetInt(cmd, "webhook-max-retries")
-	webhookMaxRetryInterval := sflags.MustGetDuration(cmd, "webhook-max-retry-interval")
-
-	// Create webhook sink configuration
 	sinkConfig := webhook.SinkConfig{
 		WebhookURL:   webhookURL,
-		StateFile:    stateFileStr,
+		StateFile:    sflags.MustGetString(cmd, "state-file"),
 		SinkerConfig: sinkerConfig,
 		ClientConfig: webhook.Config{
-			Timeout:     webhookTimeout,
-			MaxRetries:  webhookMaxRetries,
-			MaxInterval: webhookMaxRetryInterval,
+			Timeout:         sflags.MustGetDuration(cmd, "webhook-timeout"),
+			MaxRetries:      sflags.MustGetInt(cmd, "webhook-max-retries"),
+			MaxInterval:     sflags.MustGetDuration(cmd, "webhook-max-retry-interval"),
+			AuthHeaderName:  sflags.MustGetString(cmd, "webhook-auth-header-name"),
+			AuthHeaderValue: os.Getenv(sflags.MustGetString(cmd, "webhook-auth-header-value-envvar")),
+			SigningSecret:   os.Getenv(sflags.MustGetString(cmd, "webhook-signing-secret-envvar")),
 		},
 		Logger: zlog,
 	}

--- a/cmd/substreams/sink_webhook.go
+++ b/cmd/substreams/sink_webhook.go
@@ -34,6 +34,8 @@ func init() {
 	sinkWebhookCmd.Flags().Duration("webhook-timeout", 30*time.Second, "Timeout for individual webhook calls")
 	sinkWebhookCmd.Flags().Duration("webhook-max-retry-interval", 30*time.Second, "Maximum interval between webhook retries (exponential backoff cap)")
 	sinkWebhookCmd.Flags().String("webhook-on-failure", string(webhook.OnFailureSkip), fmt.Sprintf("What to do once every retry for a block has failed: %q drops the block and continues, %q keeps the block on disk, writes the reason to the termination log and exits with status %d; the next start delivers that block before it connects to Substreams", webhook.OnFailureSkip, webhook.OnFailureExit, webhook.ExitCodeDeliveryFailed))
+	sinkWebhookCmd.Flags().Int("webhook-batch-max-blocks", 0, "Send up to this many blocks per call, in the batch payload shape (see below). 0 sends one block per call in the single-block shape")
+	sinkWebhookCmd.Flags().Duration("webhook-batch-max-wait", time.Second, "Longest a batch waits for more blocks before it is sent, checked when the next block arrives. A batch is also sent when the chain is live, before an undo notification, and when the stream ends")
 	sinkWebhookCmd.Flags().String("webhook-undo-url", "", "URL that receives a POST for each chain reorganization, with body {\"lastValidBlock\": {\"number\": ..., \"id\": \"...\"}, \"manifest\": {\"moduleName\": \"...\"}}. Empty disables the notification; the blocks that replace the undone ones are still delivered to <url>")
 	sinkWebhookCmd.Flags().String("webhook-termination-log", "/dev/termination-log", "File that receives the reason for a delivery-failure exit, written only when the file already exists (Kubernetes creates it)")
 	sinkWebhookCmd.Flags().String("webhook-auth-header-name", webhook.DefaultAuthHeaderName, "Name of the header carrying the value read from --webhook-auth-header-value-envvar")
@@ -46,13 +48,21 @@ func init() {
 // sinkWebhookCmd represents the command to run substreams webhook sink
 var sinkWebhookCmd = &cobra.Command{
 	Use:   "webhook <url> [<manifest> [<module_name>]]",
-	Short: "Trigger a webhook call for each event from a substreams module",
+	Short: "POST the output of a substreams module to a webhook, one call per block or per batch of blocks",
 	Long: cli.Dedent(`
 		POST the output of a substreams module to <url>, one call per block, as JSON:
 
 		  {"clock": {"number": ..., "id": "...", "timestamp": "..."},
 		   "manifest": {"moduleName": "...", "type": "..."},
 		   "data": {...}}
+
+		With --webhook-batch-max-blocks=N every call carries up to N blocks, a batch of one included, as:
+
+		  {"manifest": {"moduleName": "...", "type": "..."},
+		   "blocks": [{"clock": {...}, "data": {...}}, ...]}
+
+		Blocks are in ascending order. Switching batching on or off while the sink is stopped discards a
+		pending payload of the other shape; its blocks come back through the stream in the new shape.
 
 		Calls carry the header named by --webhook-auth-header-name when the variable named by
 		--webhook-auth-header-value-envvar is set, and an ` + webhook.SignatureHeader + ` header when the
@@ -105,11 +115,13 @@ func sinkWebhookE(cmd *cobra.Command, args []string) error {
 	}
 
 	sinkConfig := webhook.SinkConfig{
-		WebhookURL:   webhookURL,
-		UndoURL:      sflags.MustGetString(cmd, "webhook-undo-url"),
-		StateFile:    sflags.MustGetString(cmd, "state-file"),
-		OnFailure:    onFailure,
-		SinkerConfig: sinkerConfig,
+		WebhookURL:     webhookURL,
+		UndoURL:        sflags.MustGetString(cmd, "webhook-undo-url"),
+		StateFile:      sflags.MustGetString(cmd, "state-file"),
+		OnFailure:      onFailure,
+		SinkerConfig:   sinkerConfig,
+		BatchMaxBlocks: sflags.MustGetInt(cmd, "webhook-batch-max-blocks"),
+		BatchMaxWait:   sflags.MustGetDuration(cmd, "webhook-batch-max-wait"),
 		ClientConfig: webhook.Config{
 			Timeout:         sflags.MustGetDuration(cmd, "webhook-timeout"),
 			MaxRetries:      sflags.MustGetInt(cmd, "webhook-max-retries"),

--- a/cmd/substreams/sink_webhook.go
+++ b/cmd/substreams/sink_webhook.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/streamingfast/derr"
 	"github.com/streamingfast/substreams/sink"
 	"github.com/streamingfast/substreams/sink/webhook"
+	"go.uber.org/zap"
 )
 
 func init() {
@@ -27,10 +29,12 @@ func init() {
 			sink.FlagMaxRetries,
 		))
 
-	sinkWebhookCmd.Flags().String("state-file", "./state.cursor", "File where the sink will store its cursor. If empty, no cursor will be saved or used, only the start-block.")
+	sinkWebhookCmd.Flags().String("state-file", "./state.cursor", "File where the sink will store its cursor, a payload that could not be delivered is kept next to it in '<state-file>.pending'. If empty, no cursor will be saved or used, only the start-block, and a failed delivery cannot be resumed.")
 	sinkWebhookCmd.Flags().Int("webhook-max-retries", 3, "Maximum number of retries for webhook calls (0 disables retries, -1 for infinite retries)")
 	sinkWebhookCmd.Flags().Duration("webhook-timeout", 30*time.Second, "Timeout for individual webhook calls")
 	sinkWebhookCmd.Flags().Duration("webhook-max-retry-interval", 30*time.Second, "Maximum interval between webhook retries (exponential backoff cap)")
+	sinkWebhookCmd.Flags().String("webhook-on-failure", string(webhook.OnFailureSkip), fmt.Sprintf("What to do once every retry for a block has failed: %q drops the block and continues, %q keeps the block on disk, writes the reason to the termination log and exits with status %d; the next start delivers that block before it connects to Substreams", webhook.OnFailureSkip, webhook.OnFailureExit, webhook.ExitCodeDeliveryFailed))
+	sinkWebhookCmd.Flags().String("webhook-termination-log", "/dev/termination-log", "File that receives the reason for a delivery-failure exit, written only when the file already exists (Kubernetes creates it)")
 	sinkWebhookCmd.Flags().String("webhook-auth-header-name", webhook.DefaultAuthHeaderName, "Name of the header carrying the value read from --webhook-auth-header-value-envvar")
 	sinkWebhookCmd.Flags().String("webhook-auth-header-value-envvar", "WEBHOOK_AUTH_HEADER_VALUE", "Environment variable holding the auth header value sent on every call, for example 'Bearer <token>'. No header is sent when the variable is empty")
 	sinkWebhookCmd.Flags().String("webhook-signing-secret-envvar", "WEBHOOK_SIGNING_SECRET", fmt.Sprintf("Environment variable holding the secret used to sign every call body with HMAC-SHA256 in the %s header. No signature is sent when the variable is empty", webhook.SignatureHeader))
@@ -55,7 +59,13 @@ var sinkWebhookCmd = &cobra.Command{
 		"t=<unix seconds>,v1=<hex>" where <hex> is HMAC-SHA256 over "<t>.<body>" keyed with the secret.
 
 		Network errors and 5xx responses are retried with exponential backoff up to --webhook-max-retries.
-		A 4xx response is not retried.
+		A 4xx response is not retried. --webhook-on-failure decides what happens after the last retry.
+
+		With --webhook-on-failure=exit the payload that could not be delivered is written to
+		'<state-file>.pending', and the next start delivers it before it opens a Substreams stream. The headers
+		are recomputed from the current environment, so a rotated secret or a new URL applies to the retry. A
+		kill in the middle of a call leaves no pending file: the cursor was not saved, so the stream re-sends
+		that block.
 	`),
 	RunE: sinkWebhookE,
 	Args: cobra.RangeArgs(1, 3),
@@ -81,9 +91,15 @@ func sinkWebhookE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	onFailure, err := webhook.ParseOnFailure(sflags.MustGetString(cmd, "webhook-on-failure"))
+	if err != nil {
+		return err
+	}
+
 	sinkConfig := webhook.SinkConfig{
 		WebhookURL:   webhookURL,
 		StateFile:    sflags.MustGetString(cmd, "state-file"),
+		OnFailure:    onFailure,
 		SinkerConfig: sinkerConfig,
 		ClientConfig: webhook.Config{
 			Timeout:         sflags.MustGetDuration(cmd, "webhook-timeout"),
@@ -93,7 +109,8 @@ func sinkWebhookE(cmd *cobra.Command, args []string) error {
 			AuthHeaderValue: os.Getenv(sflags.MustGetString(cmd, "webhook-auth-header-value-envvar")),
 			SigningSecret:   os.Getenv(sflags.MustGetString(cmd, "webhook-signing-secret-envvar")),
 		},
-		Logger: zlog,
+		TerminationLogPath: sflags.MustGetString(cmd, "webhook-termination-log"),
+		Logger:             zlog,
 	}
 
 	// Create and run the webhook sink
@@ -112,6 +129,12 @@ func sinkWebhookE(cmd *cobra.Command, args []string) error {
 
 	// Print final statistics
 	webhookSink.PrintStats()
+
+	var deliveryFailed *webhook.DeliveryFailedError
+	if errors.As(err, &deliveryFailed) {
+		zlog.Error("stopping: webhook delivery failed, the block is kept on disk and will be delivered first on the next start", zap.Error(err))
+		os.Exit(webhook.ExitCodeDeliveryFailed)
+	}
 
 	return err
 }

--- a/cmd/substreams/sink_webhook.go
+++ b/cmd/substreams/sink_webhook.go
@@ -34,6 +34,7 @@ func init() {
 	sinkWebhookCmd.Flags().Duration("webhook-timeout", 30*time.Second, "Timeout for individual webhook calls")
 	sinkWebhookCmd.Flags().Duration("webhook-max-retry-interval", 30*time.Second, "Maximum interval between webhook retries (exponential backoff cap)")
 	sinkWebhookCmd.Flags().String("webhook-on-failure", string(webhook.OnFailureSkip), fmt.Sprintf("What to do once every retry for a block has failed: %q drops the block and continues, %q keeps the block on disk, writes the reason to the termination log and exits with status %d; the next start delivers that block before it connects to Substreams", webhook.OnFailureSkip, webhook.OnFailureExit, webhook.ExitCodeDeliveryFailed))
+	sinkWebhookCmd.Flags().String("webhook-undo-url", "", "URL that receives a POST for each chain reorganization, with body {\"lastValidBlock\": {\"number\": ..., \"id\": \"...\"}, \"manifest\": {\"moduleName\": \"...\"}}. Empty disables the notification; the blocks that replace the undone ones are still delivered to <url>")
 	sinkWebhookCmd.Flags().String("webhook-termination-log", "/dev/termination-log", "File that receives the reason for a delivery-failure exit, written only when the file already exists (Kubernetes creates it)")
 	sinkWebhookCmd.Flags().String("webhook-auth-header-name", webhook.DefaultAuthHeaderName, "Name of the header carrying the value read from --webhook-auth-header-value-envvar")
 	sinkWebhookCmd.Flags().String("webhook-auth-header-value-envvar", "WEBHOOK_AUTH_HEADER_VALUE", "Environment variable holding the auth header value sent on every call, for example 'Bearer <token>'. No header is sent when the variable is empty")
@@ -66,6 +67,13 @@ var sinkWebhookCmd = &cobra.Command{
 		are recomputed from the current environment, so a rotated secret or a new URL applies to the retry. A
 		kill in the middle of a call leaves no pending file: the cursor was not saved, so the stream re-sends
 		that block.
+
+		Reorganizations: with --final-blocks-only the sink only delivers blocks past finality and never sees
+		one. With --undo-buffer-size=N it holds the last N blocks back and absorbs any reorganization that fits
+		in them. Otherwise, or for a reorganization deeper than the buffer, the receiver has already been sent
+		blocks that are no longer on the chain: --webhook-undo-url receives a notification naming the last valid
+		block, then the replacement blocks arrive as regular calls. Undo notifications follow the same retry,
+		on-failure and pending-file rules as blocks.
 	`),
 	RunE: sinkWebhookE,
 	Args: cobra.RangeArgs(1, 3),
@@ -98,6 +106,7 @@ func sinkWebhookE(cmd *cobra.Command, args []string) error {
 
 	sinkConfig := webhook.SinkConfig{
 		WebhookURL:   webhookURL,
+		UndoURL:      sflags.MustGetString(cmd, "webhook-undo-url"),
 		StateFile:    sflags.MustGetString(cmd, "state-file"),
 		OnFailure:    onFailure,
 		SinkerConfig: sinkerConfig,

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -20,6 +20,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   Receivers can verify with `webhook.VerifySignature`. Once every retry has failed, `Client.Call` returns a
   `*webhook.DeliveryError` carrying the last HTTP status and the attempt count.
 
+- Add `--webhook-on-failure=exit` to `substreams sink webhook`. Once every retry for a block has failed the
+  sink keeps that block in `<state-file>.pending`, writes a JSON reason (URL, block, status, attempts,
+  `first_attempt_at`) to `--webhook-termination-log` when that file exists, and exits with status 75. The next
+  start delivers the pending block before it opens a Substreams stream, so retrying against a dead endpoint costs
+  no egress. The default `skip` keeps the old behaviour of dropping the block. A changed URL or secret resets
+  `first_attempt_at`. A kill in the middle of a call leaves no pending file: the cursor was not saved, so the
+  stream re-sends that block. The sink now also exposes `substreams_sink_progress_block`, the last delivered
+  block.
+
 ### Docs
 
 - Document `Feed.Delete` on the Remote Feed Hosted Store guide: remote-feed clients can

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Sink
+
+- Add authentication to `substreams sink webhook` calls. The value of the environment variable named by
+  `--webhook-auth-header-value-envvar` is sent in the header named by `--webhook-auth-header-name`
+  (`Authorization` by default), and the secret named by `--webhook-signing-secret-envvar` signs every body
+  with HMAC-SHA256 in the `X-Substreams-Signature` header as `t=<unix seconds>,v1=<hex>` over `<t>.<body>`.
+  Receivers can verify with `webhook.VerifySignature`. Once every retry has failed, `Client.Call` returns a
+  `*webhook.DeliveryError` carrying the last HTTP status and the attempt count.
+
 ### Docs
 
 - Document `Feed.Delete` on the Remote Feed Hosted Store guide: remote-feed clients can

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   stream re-sends that block. The sink now also exposes `substreams_sink_progress_block`, the last delivered
   block.
 
+- Sinks running with `--undo-buffer-size` now receive an undo signal that reaches below the buffer when the buffer
+  has emitted nothing yet, which is what a restart from a cursor sitting on a fork produces. Before, the buffer
+  swallowed it and the handler never rolled back blocks the previous run had emitted.
+
 ### Docs
 
 - Document `Feed.Delete` on the Remote Feed Hosted Store guide: remote-feed clients can

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   has emitted nothing yet, which is what a restart from a cursor sitting on a fork produces. Before, the buffer
   swallowed it and the handler never rolled back blocks the previous run had emitted.
 
+- Add `--webhook-undo-url` to `substreams sink webhook`. When set, every undo signal is POSTed there as
+  `{"lastValidBlock": {"number", "id"}, "manifest": {"moduleName"}}` so the receiver can drop the blocks above
+  the last valid one before the replacements arrive. The notification carries the same auth header and
+  signature as blocks and follows the same retry, `--webhook-on-failure` and pending-file rules. Without it the
+  cursor still moves back and only the replacement blocks are delivered, as before. Pair with
+  `--undo-buffer-size` to hold back a few blocks and absorb shallow reorganizations without any notification.
+
 ### Docs
 
 - Document `Feed.Delete` on the Remote Feed Hosted Store guide: remote-feed clients can

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -40,6 +40,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   cursor still moves back and only the replacement blocks are delivered, as before. Pair with
   `--undo-buffer-size` to hold back a few blocks and absorb shallow reorganizations without any notification.
 
+- Add `--webhook-batch-max-blocks=N` to `substreams sink webhook`. Every call then carries up to N blocks in a
+  batch shape, `{"manifest": {...}, "blocks": [{"clock", "data"}, ...]}`, a batch of one included. A batch is sent
+  when it is full, when `--webhook-batch-max-wait` (1s) has passed and the next block arrives, when the chain is
+  live, before an undo notification, and when the stream ends. A failed batch is kept and resumed as one
+  payload. Switching batching on or off while the sink is stopped discards a pending payload of the other
+  shape; its blocks come back through the stream. Default is off, one block per call as before.
+
 ### Docs
 
 - Document `Feed.Delete` on the Remote Feed Hosted Store guide: remote-feed clients can

--- a/sink/buffer.go
+++ b/sink/buffer.go
@@ -83,25 +83,36 @@ func (b *blockDataBuffer) HandleBlockScopedData(blockData *pbsubstreamsrpc.Block
 	return finalBlocks, nil
 }
 
-func (b *blockDataBuffer) HandleBlockUndoSignal(undoSignal *pbsubstreamsrpc.BlockUndoSignal) error {
+// HandleBlockUndoSignal drops the buffered blocks after the last valid block.
+//
+// The returned absorbed flag is false when the buffer cannot vouch that the
+// undo touched only blocks it held: it has emitted nothing yet in this process
+// and holds no block at or below the last valid one. A previous process may
+// have emitted blocks after the last valid block, which happens when a sink
+// restarts from a cursor that sits on a fork. Only the downstream handler
+// knows what was emitted before, so the caller must forward the signal to it.
+func (b *blockDataBuffer) HandleBlockUndoSignal(undoSignal *pbsubstreamsrpc.BlockUndoSignal) (absorbed bool, err error) {
 	lastValidBlock := asBlockRef(undoSignal.LastValidBlock)
 
 	if b.lastEmittedBlock != nil && b.lastEmittedBlock.Num() >= lastValidBlock.Num() {
 		// We might have actually sent exactly the last valid block, in which case no error should occur since the chain
 		// ordering is respected
 		if !bstream.EqualsBlockRefs(b.lastEmittedBlock, lastValidBlock) {
-			return fmt.Errorf("cannot undo down to last valid Block %s because we already sent you Block %s which is after last valid block", lastValidBlock, b.lastEmittedBlock)
+			return false, fmt.Errorf("cannot undo down to last valid Block %s because we already sent you Block %s which is after last valid block", lastValidBlock, b.lastEmittedBlock)
 		}
 	}
 
+	newestValidBlockAt := b.findNewestValidBlockIndex(lastValidBlock.Num())
+	absorbed = b.lastEmittedBlock != nil || newestValidBlockAt != -1
+
 	// There is nothing to do, we are already emptied due to a previous undo signal
 	if b.dataEmptyAt == 0 {
-		return nil
+		return absorbed, nil
 	}
 
 	// If last valid block is not found, `dataEmptyAt` will become 0 (-1 + 1) which "clears" all our block
-	b.dataEmptyAt = b.findNewestValidBlockIndex(lastValidBlock.Num()) + 1
-	return nil
+	b.dataEmptyAt = newestValidBlockAt + 1
+	return absorbed, nil
 }
 
 func (b *blockDataBuffer) findNewestValidBlockIndex(lastValidBlockHeight uint64) int {

--- a/sink/buffer_test.go
+++ b/sink/buffer_test.go
@@ -17,6 +17,8 @@ import (
 func TestBlockBuffer(t *testing.T) {
 	type messageToResult map[*substreamsMessage]any
 	type finalBlocks []*pbsubstreamsrpc.BlockScopedData
+	// undoAbsorbed is the expected `absorbed` result of an undo signal
+	type undoAbsorbed bool
 
 	tests := []struct {
 		name     string
@@ -76,6 +78,56 @@ func TestBlockBuffer(t *testing.T) {
 				{msgBlockScopedData("1a", 0): nil},
 				{msgBlockScopedData("2a", 0): nil},
 				{msgBlockUndoSignal("1a"): nil},
+			},
+		},
+		{
+			name:     "undo_within_buffer_is_absorbed",
+			undoSize: 3,
+			messages: []messageToResult{
+				{msgBlockScopedData("1a", 0): nil},
+				{msgBlockScopedData("2a", 0): nil},
+				{msgBlockScopedData("3a", 0): nil},
+				{msgBlockUndoSignal("2a"): undoAbsorbed(true)},
+			},
+		},
+		{
+			name:     "undo_below_buffer_before_anything_emitted_is_not_absorbed",
+			undoSize: 3,
+			messages: []messageToResult{
+				{msgBlockScopedData("2a", 0): nil},
+				{msgBlockScopedData("3a", 0): nil},
+				{msgBlockUndoSignal("1a"): undoAbsorbed(false)},
+				{msgBlockScopedData("2b", 0): nil},
+			},
+		},
+		{
+			name:     "undo_on_empty_buffer_before_anything_emitted_is_not_absorbed",
+			undoSize: 3,
+			messages: []messageToResult{
+				{msgBlockUndoSignal("5a"): undoAbsorbed(false)},
+				{msgBlockScopedData("6b", 0): nil},
+			},
+		},
+		{
+			name:     "undo_below_buffer_after_emission_is_absorbed",
+			undoSize: 2,
+			messages: []messageToResult{
+				{msgBlockScopedData("1a", 0): nil},
+				{msgBlockScopedData("2a", 0): nil},
+				{msgBlockScopedData("3a", 0): blockScopedData("1a", 0)},
+				{msgBlockUndoSignal("1a"): undoAbsorbed(true)},
+				{msgBlockScopedData("2b", 0): nil},
+			},
+		},
+		{
+			name:     "undo_between_emitted_and_buffer_is_absorbed",
+			undoSize: 2,
+			messages: []messageToResult{
+				{msgBlockScopedData("1a", 0): nil},
+				{msgBlockScopedData("2a", 0): nil},
+				{msgBlockScopedData("3a", 0): blockScopedData("1a", 0)},
+				{msgBlockScopedData("5a", 0): blockScopedData("2a", 0)},
+				{msgBlockUndoSignal("4a"): undoAbsorbed(true)},
 			},
 		},
 		{
@@ -267,11 +319,15 @@ func TestBlockBuffer(t *testing.T) {
 			}
 
 			handleBlockUndoSignal := func(blockUndoSignal *pbsubstreamsrpc.BlockUndoSignal, expectedResult any) {
-				err := b.HandleBlockUndoSignal(blockUndoSignal)
+				absorbed, err := b.HandleBlockUndoSignal(blockUndoSignal)
 
 				switch v := expectedResult.(type) {
 				case error:
 					require.EqualError(t, err, v.Error())
+
+				case undoAbsorbed:
+					require.NoError(t, err)
+					require.Equal(t, bool(v), absorbed, "absorbed")
 
 				default:
 					if v == nil {

--- a/sink/sinker.go
+++ b/sink/sinker.go
@@ -757,14 +757,20 @@ func (s *Sinker) doRequest(
 					return activeCursor, receivedDataMessage, fmt.Errorf("handle BlockUndoSignal: %w", err)
 				}
 			} else {
-				// In the case of dealing with an undo buffer, it's expected that a fork will never
-				// go beyond the first block in the buffer because if it does, `s.buffer.HandleBlockUndoSignal` here
-				// returns an error.
-				//
-				// This means ultimately that we expect to never call the downstream `BlockUndoSignalHandler` function.
-				err = s.buffer.HandleBlockUndoSignal(r.BlockUndoSignal)
+				// A fork within the buffer is handled by dropping buffered blocks and the
+				// downstream handler never hears about it. A fork below what this process
+				// emitted is an error. What is left is a fork below blocks a previous process
+				// emitted, typically a restart from a cursor that sits on a fork: the buffer
+				// cannot absorb that one, so the handler gets the signal as it would without
+				// a buffer.
+				absorbed, err := s.buffer.HandleBlockUndoSignal(r.BlockUndoSignal)
 				if err != nil {
 					return activeCursor, receivedDataMessage, fmt.Errorf("buffer undo block: %w", err)
+				}
+				if !absorbed {
+					if err := handler.HandleBlockUndoSignal(ctx, r.BlockUndoSignal, activeCursor); err != nil {
+						return activeCursor, receivedDataMessage, fmt.Errorf("handle BlockUndoSignal: %w", err)
+					}
 				}
 			}
 

--- a/sink/webhook/client.go
+++ b/sink/webhook/client.go
@@ -3,22 +3,43 @@ package webhook
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"go.uber.org/zap"
 )
 
+// SignatureHeader carries the HMAC signature of the request body when a
+// signing secret is configured. Its value has the form
+// "t=<unix seconds>,v1=<hex>", where <hex> is HMAC-SHA256 over the string
+// "<t>.<body>" keyed with the signing secret. Receivers recompute the HMAC
+// over the raw body bytes they read and compare with a constant-time
+// comparison; the timestamp lets them reject replays older than they accept.
+const SignatureHeader = "X-Substreams-Signature"
+
+// DefaultAuthHeaderName is the header the auth value is sent under when no
+// name is configured.
+const DefaultAuthHeaderName = "Authorization"
+
 // Client holds the HTTP client and retry configuration for webhook calls.
 // It implements exponential backoff retry logic for transient failures while
 // avoiding retries for permanent client errors (4xx status codes).
 type Client struct {
-	httpClient  *http.Client  // HTTP client with configured timeout
-	maxRetries  int           // Maximum number of retry attempts
-	maxInterval time.Duration // Maximum interval between retries
-	logger      *zap.Logger   // Logger for webhook operations
+	httpClient      *http.Client  // HTTP client with configured timeout
+	maxRetries      int           // Maximum number of retry attempts
+	maxInterval     time.Duration // Maximum interval between retries
+	authHeaderName  string
+	authHeaderValue string
+	signingSecret   []byte
+	logger          *zap.Logger // Logger for webhook operations
 }
 
 // Config holds configuration for the webhook client
@@ -26,25 +47,122 @@ type Config struct {
 	Timeout     time.Duration // HTTP request timeout for individual calls
 	MaxRetries  int           // Maximum number of retry attempts for transient failures (-1 for infinite retries)
 	MaxInterval time.Duration // Maximum interval between retries (exponential backoff cap)
+
+	// AuthHeaderName and AuthHeaderValue are sent verbatim on every request
+	// when AuthHeaderValue is not empty. AuthHeaderName defaults to
+	// DefaultAuthHeaderName.
+	AuthHeaderName  string
+	AuthHeaderValue string
+
+	// SigningSecret, when not empty, adds a SignatureHeader to every request.
+	SigningSecret string
 }
+
+// DeliveryError is returned by Client.Call once every attempt for a payload
+// has failed. It carries what a receiver's operator needs to see: the last
+// HTTP status (0 when no response was received), how many attempts were made,
+// and the last underlying error.
+type DeliveryError struct {
+	URL         string
+	BlockNumber uint64
+	StatusCode  int
+	Attempts    int
+	Err         error
+}
+
+func (e *DeliveryError) Error() string {
+	return fmt.Sprintf("webhook delivery of block %d to %s failed after %d attempt(s): %v", e.BlockNumber, e.URL, e.Attempts, e.Err)
+}
+
+func (e *DeliveryError) Unwrap() error { return e.Err }
 
 // NewClient creates a new webhook client with retry configuration.
 func NewClient(config Config, logger *zap.Logger) *Client {
+	authHeaderName := config.AuthHeaderName
+	if authHeaderName == "" {
+		authHeaderName = DefaultAuthHeaderName
+	}
+
+	var signingSecret []byte
+	if config.SigningSecret != "" {
+		signingSecret = []byte(config.SigningSecret)
+	}
+
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: config.Timeout,
 		},
-		maxRetries:  config.MaxRetries,
-		maxInterval: config.MaxInterval,
-		logger:      logger,
+		maxRetries:      config.MaxRetries,
+		maxInterval:     config.MaxInterval,
+		authHeaderName:  authHeaderName,
+		authHeaderValue: config.AuthHeaderValue,
+		signingSecret:   signingSecret,
+		logger:          logger,
 	}
+}
+
+// Sign computes the SignatureHeader value for body at the given time. It
+// returns an empty string when no signing secret is configured.
+func (c *Client) Sign(body []byte, at time.Time) string {
+	if len(c.signingSecret) == 0 {
+		return ""
+	}
+	return "t=" + strconv.FormatInt(at.Unix(), 10) + ",v1=" + signPayload(c.signingSecret, body, at.Unix())
+}
+
+func signPayload(secret []byte, body []byte, timestamp int64) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(strconv.FormatInt(timestamp, 10)))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifySignature checks a SignatureHeader value against body using secret.
+// It returns the timestamp embedded in the header so callers can apply their
+// own tolerance window. Exposed for receivers written in Go and for tests.
+func VerifySignature(secret []byte, body []byte, header string) (time.Time, error) {
+	var timestamp int64
+	var haveTimestamp bool
+	var v1 string
+	for field := range strings.SplitSeq(header, ",") {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			return time.Time{}, errors.New("malformed signature header")
+		}
+		switch key {
+		case "t":
+			parsed, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return time.Time{}, fmt.Errorf("malformed signature timestamp: %w", err)
+			}
+			timestamp, haveTimestamp = parsed, true
+		case "v1":
+			v1 = value
+		}
+	}
+	if !haveTimestamp || v1 == "" {
+		return time.Time{}, errors.New("signature header needs both t and v1")
+	}
+
+	if !hmac.Equal([]byte(signPayload(secret, body, timestamp)), []byte(v1)) {
+		return time.Time{}, errors.New("signature mismatch")
+	}
+	return time.Unix(timestamp, 0), nil
 }
 
 // Call makes a webhook call with exponential backoff retry logic.
 // It retries on network errors and server errors (5xx), but not on client errors (4xx).
 // The function respects context cancellation and implements proper error classification.
+// When every attempt fails the returned error is a *DeliveryError.
 func (c *Client) Call(ctx context.Context, url string, payload []byte, blockNumber uint64) error {
+	attempts := 0
+	lastStatus := 0
+
 	operation := func() error {
+		attempts++
+		lastStatus = 0
+
 		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(payload))
 		if err != nil {
 			// Request creation errors are permanent (bad URL, etc.)
@@ -52,6 +170,12 @@ func (c *Client) Call(ctx context.Context, url string, payload []byte, blockNumb
 		}
 
 		req.Header.Set("Content-Type", "application/json")
+		if c.authHeaderValue != "" {
+			req.Header.Set(c.authHeaderName, c.authHeaderValue)
+		}
+		if signature := c.Sign(payload, time.Now()); signature != "" {
+			req.Header.Set(SignatureHeader, signature)
+		}
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
@@ -60,6 +184,7 @@ func (c *Client) Call(ctx context.Context, url string, payload []byte, blockNumb
 		}
 		defer resp.Body.Close()
 
+		lastStatus = resp.StatusCode
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			// Client errors (4xx) are permanent - bad request, auth, etc.
 			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
@@ -91,8 +216,10 @@ func (c *Client) Call(ctx context.Context, url string, payload []byte, blockNumb
 		c.logger.Warn("webhook call failed after all retries",
 			zap.Error(err),
 			zap.Uint64("block", blockNumber),
+			zap.Int("attempts", attempts),
+			zap.Int("last_status", lastStatus),
 			zap.String("url", url))
-		return err
+		return &DeliveryError{URL: url, BlockNumber: blockNumber, StatusCode: lastStatus, Attempts: attempts, Err: err}
 	}
 
 	c.logger.Info("webhook call successful",

--- a/sink/webhook/client_auth_test.go
+++ b/sink/webhook/client_auth_test.go
@@ -1,0 +1,159 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type capturedRequest struct {
+	header http.Header
+	body   []byte
+}
+
+func captureServer(t *testing.T, status int) (*httptest.Server, func() []capturedRequest) {
+	t.Helper()
+	var mu sync.Mutex
+	var requests []capturedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		mu.Lock()
+		requests = append(requests, capturedRequest{header: r.Header.Clone(), body: body})
+		mu.Unlock()
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+	return server, func() []capturedRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]capturedRequest(nil), requests...)
+	}
+}
+
+func TestClient_Call_SendsAuthHeaderAndSignature(t *testing.T) {
+	server, requests := captureServer(t, http.StatusOK)
+
+	client := NewClient(Config{
+		Timeout:         time.Second,
+		MaxRetries:      0,
+		MaxInterval:     time.Second,
+		AuthHeaderValue: "Bearer sekret",
+		SigningSecret:   "whsec_test",
+	}, zap.NewNop())
+
+	payload := []byte(`{"clock":{"number":42}}`)
+	require.NoError(t, client.Call(context.Background(), server.URL, payload, 42))
+
+	got := requests()
+	require.Len(t, got, 1)
+	assert.Equal(t, "Bearer sekret", got[0].header.Get("Authorization"))
+	assert.Equal(t, "application/json", got[0].header.Get("Content-Type"))
+
+	signature := got[0].header.Get(SignatureHeader)
+	require.NotEmpty(t, signature)
+	at, err := VerifySignature([]byte("whsec_test"), got[0].body, signature)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), at, 5*time.Second)
+}
+
+func TestClient_Call_CustomAuthHeaderName(t *testing.T) {
+	server, requests := captureServer(t, http.StatusOK)
+
+	client := NewClient(Config{
+		Timeout:         time.Second,
+		AuthHeaderName:  "X-Api-Key",
+		AuthHeaderValue: "k123",
+	}, zap.NewNop())
+
+	require.NoError(t, client.Call(context.Background(), server.URL, []byte(`{}`), 1))
+
+	got := requests()
+	require.Len(t, got, 1)
+	assert.Equal(t, "k123", got[0].header.Get("X-Api-Key"))
+	assert.Empty(t, got[0].header.Get("Authorization"))
+}
+
+func TestClient_Call_NoAuthByDefault(t *testing.T) {
+	server, requests := captureServer(t, http.StatusOK)
+
+	client := NewClient(Config{Timeout: time.Second}, zap.NewNop())
+	require.NoError(t, client.Call(context.Background(), server.URL, []byte(`{}`), 1))
+
+	got := requests()
+	require.Len(t, got, 1)
+	assert.Empty(t, got[0].header.Get("Authorization"))
+	assert.Empty(t, got[0].header.Get(SignatureHeader))
+}
+
+func TestVerifySignature(t *testing.T) {
+	secret := []byte("s3cr3t")
+	body := []byte(`{"a":1}`)
+	at := time.Unix(1_700_000_000, 0)
+
+	client := NewClient(Config{SigningSecret: string(secret)}, zap.NewNop())
+	header := client.Sign(body, at)
+	assert.Equal(t, "t=1700000000,v1=", header[:len("t=1700000000,v1=")])
+
+	got, err := VerifySignature(secret, body, header)
+	require.NoError(t, err)
+	assert.Equal(t, at, got)
+
+	_, err = VerifySignature([]byte("other"), body, header)
+	assert.EqualError(t, err, "signature mismatch")
+
+	_, err = VerifySignature(secret, []byte(`{"a":2}`), header)
+	assert.EqualError(t, err, "signature mismatch")
+
+	_, err = VerifySignature(secret, body, "v1=abc")
+	assert.EqualError(t, err, "signature header needs both t and v1")
+
+	_, err = VerifySignature(secret, body, "garbage")
+	assert.EqualError(t, err, "malformed signature header")
+
+	assert.Empty(t, NewClient(Config{}, zap.NewNop()).Sign(body, at))
+}
+
+func TestClient_Call_ReturnsDeliveryError(t *testing.T) {
+	server, requests := captureServer(t, http.StatusServiceUnavailable)
+
+	client := NewClient(Config{
+		Timeout:     time.Second,
+		MaxRetries:  1,
+		MaxInterval: 10 * time.Millisecond,
+	}, zap.NewNop())
+
+	err := client.Call(context.Background(), server.URL, []byte(`{}`), 7)
+	require.Error(t, err)
+
+	var deliveryErr *DeliveryError
+	require.ErrorAs(t, err, &deliveryErr)
+	assert.Equal(t, server.URL, deliveryErr.URL)
+	assert.Equal(t, uint64(7), deliveryErr.BlockNumber)
+	assert.Equal(t, http.StatusServiceUnavailable, deliveryErr.StatusCode)
+	assert.Equal(t, 2, deliveryErr.Attempts)
+	assert.Len(t, requests(), 2)
+	assert.True(t, errors.Is(err, deliveryErr.Err))
+}
+
+func TestClient_Call_ClientErrorIsNotRetried(t *testing.T) {
+	server, requests := captureServer(t, http.StatusUnauthorized)
+
+	client := NewClient(Config{Timeout: time.Second, MaxRetries: 5, MaxInterval: 10 * time.Millisecond}, zap.NewNop())
+
+	err := client.Call(context.Background(), server.URL, []byte(`{}`), 7)
+	var deliveryErr *DeliveryError
+	require.ErrorAs(t, err, &deliveryErr)
+	assert.Equal(t, http.StatusUnauthorized, deliveryErr.StatusCode)
+	assert.Equal(t, 1, deliveryErr.Attempts)
+	assert.Len(t, requests(), 1)
+}

--- a/sink/webhook/delivery_test.go
+++ b/sink/webhook/delivery_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"time"
 
 	"github.com/streamingfast/bstream"
+	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 	"github.com/streamingfast/substreams/sink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,7 +59,7 @@ func newTestSink(t *testing.T, url string, onFailure OnFailure) *Sink {
 		pendingFile:    pendingFilePath(stateFile),
 		onFailure:      onFailure,
 		terminationLog: terminationLog,
-		fingerprint:    configFingerprint(url, cfg),
+		fingerprint:    configFingerprint(url, "", cfg),
 		client:         NewClient(cfg, zap.NewNop()),
 		logger:         zap.NewNop(),
 	}
@@ -259,14 +262,100 @@ func TestRecoverPending_ConfigChangeResetsFirstAttempt(t *testing.T) {
 	assert.WithinDuration(t, time.Now(), kept.FirstAttemptAt, 5*time.Second)
 }
 
-func TestConfigFingerprint_CoversURLAndSecrets(t *testing.T) {
+func TestConfigFingerprint_CoversURLsAndSecrets(t *testing.T) {
 	base := Config{AuthHeaderValue: "a", SigningSecret: "s"}
-	fp := configFingerprint("https://example.com/hook", base)
-	assert.Equal(t, fp, configFingerprint("https://example.com/hook", base))
-	assert.NotEqual(t, fp, configFingerprint("https://example.com/other", base))
-	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", Config{AuthHeaderValue: "b", SigningSecret: "s"}))
-	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", Config{AuthHeaderValue: "a", SigningSecret: "t"}))
-	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", Config{AuthHeaderName: "X", AuthHeaderValue: "a", SigningSecret: "s"}))
+	fp := configFingerprint("https://example.com/hook", "", base)
+	assert.Equal(t, fp, configFingerprint("https://example.com/hook", "", base))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/other", "", base))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", "https://example.com/undo", base))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", "", Config{AuthHeaderValue: "b", SigningSecret: "s"}))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", "", Config{AuthHeaderValue: "a", SigningSecret: "t"}))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", "", Config{AuthHeaderName: "X", AuthHeaderValue: "a", SigningSecret: "s"}))
+}
+
+func TestUndoPayload_JSON(t *testing.T) {
+	out, err := NewUndoPayload("map_events", &pbsubstreams.BlockRef{Number: 41, Id: "0xabc"}).ToJSON()
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"lastValidBlock":{"number":41,"id":"0xabc"},"manifest":{"moduleName":"map_events"}}`, string(out))
+
+	out, err = NewUndoPayload("map_events", nil).ToJSON()
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"lastValidBlock":{"number":0,"id":""},"manifest":{"moduleName":"map_events"}}`, string(out))
+}
+
+func TestUndo_WithoutUndoURLOnlyMovesCursorBack(t *testing.T) {
+	server := newTogglingServer(t, http.StatusOK)
+	s := newTestSink(t, server.URL, OnFailureExit)
+	require.NoError(t, sink.WriteCursor(s.stateFile, sink.MustNewCursor(opaqueCursor(12))))
+
+	undo := &pbsubstreamsrpc.BlockUndoSignal{LastValidBlock: &pbsubstreams.BlockRef{Number: 10, Id: "aa"}, LastValidCursor: opaqueCursor(10)}
+	require.NoError(t, s.handleBlockUndoSignal(context.Background(), undo, sink.MustNewCursor(opaqueCursor(10))))
+
+	assert.Equal(t, int32(0), server.calls.Load())
+	assert.Equal(t, opaqueCursor(10), readStateCursor(t, s))
+	assert.NoFileExists(t, s.pendingFile)
+}
+
+func TestUndo_GoesToUndoURLAndCommitsCursor(t *testing.T) {
+	blocks := newTogglingServer(t, http.StatusOK)
+	var undoBodies [][]byte
+	undos := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		undoBodies = append(undoBodies, body)
+		assert.Equal(t, "Bearer x", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(undos.Close)
+
+	s := newTestSink(t, blocks.URL, OnFailureExit)
+	s.undoURL = undos.URL
+	s.moduleName = "map_events"
+	require.NoError(t, sink.WriteCursor(s.stateFile, sink.MustNewCursor(opaqueCursor(12))))
+
+	undo := &pbsubstreamsrpc.BlockUndoSignal{LastValidBlock: &pbsubstreams.BlockRef{Number: 10, Id: "aa"}}
+	require.NoError(t, s.handleBlockUndoSignal(context.Background(), undo, sink.MustNewCursor(opaqueCursor(10))))
+
+	assert.Equal(t, int32(0), blocks.calls.Load(), "undo must not hit the block URL")
+	require.Len(t, undoBodies, 1)
+	assert.JSONEq(t, `{"lastValidBlock":{"number":10,"id":"aa"},"manifest":{"moduleName":"map_events"}}`, string(undoBodies[0]))
+	assert.Equal(t, opaqueCursor(10), readStateCursor(t, s))
+	assert.NoFileExists(t, s.pendingFile)
+}
+
+func TestUndo_FailureFollowsOnFailurePolicy(t *testing.T) {
+	blocks := newTogglingServer(t, http.StatusOK)
+	undos := newTogglingServer(t, http.StatusServiceUnavailable)
+
+	s := newTestSink(t, blocks.URL, OnFailureExit)
+	s.undoURL = undos.URL
+	require.NoError(t, sink.WriteCursor(s.stateFile, sink.MustNewCursor(opaqueCursor(12))))
+
+	undo := &pbsubstreamsrpc.BlockUndoSignal{LastValidBlock: &pbsubstreams.BlockRef{Number: 10, Id: "aa"}}
+	err := s.handleBlockUndoSignal(context.Background(), undo, sink.MustNewCursor(opaqueCursor(10)))
+
+	var failed *DeliveryFailedError
+	require.ErrorAs(t, err, &failed)
+	assert.Equal(t, pendingKindUndo, failed.Kind)
+	assert.Equal(t, undos.URL, failed.Delivery.URL)
+	assert.Equal(t, opaqueCursor(12), readStateCursor(t, s), "cursor stays until the receiver knows about the reorg")
+
+	kept, err := readPending(s.pendingFile)
+	require.NoError(t, err)
+	assert.Equal(t, pendingKindUndo, kept.Kind)
+
+	msg, err := os.ReadFile(s.terminationLog)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(msg, &decoded))
+	assert.Equal(t, "undo", decoded["kind"])
+
+	// Recovery routes the pending undo to the undo URL once it accepts.
+	undos.status.Store(http.StatusOK)
+	got, err := s.recoverPending(context.Background(), sink.MustNewCursor(opaqueCursor(12)))
+	require.NoError(t, err)
+	assert.Equal(t, opaqueCursor(10), got.String())
+	assert.Equal(t, int32(0), blocks.calls.Load())
+	assert.Equal(t, int32(3), undos.calls.Load())
 }
 
 func TestParseOnFailure(t *testing.T) {

--- a/sink/webhook/delivery_test.go
+++ b/sink/webhook/delivery_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func opaqueCursor(num uint64) string {
@@ -356,6 +357,154 @@ func TestUndo_FailureFollowsOnFailurePolicy(t *testing.T) {
 	assert.Equal(t, opaqueCursor(10), got.String())
 	assert.Equal(t, int32(0), blocks.calls.Load())
 	assert.Equal(t, int32(3), undos.calls.Load())
+}
+
+func protoClock(num uint64) *pbsubstreams.Clock {
+	return &pbsubstreams.Clock{Number: num, Id: "id" + jsonNumber(num)}
+}
+
+func addBlock(t *testing.T, s *Sink, num uint64, live bool, now time.Time) {
+	t.Helper()
+	data := json.RawMessage(`{"n":` + jsonNumber(num) + `}`)
+	require.NoError(t, s.addToBatch(context.Background(), "map_events", "type.googleapis.com/sf.test.v1.Out", protoClock(num), data, sink.MustNewCursor(opaqueCursor(num)), live, now))
+}
+
+func TestBatch_FlushesWhenFull(t *testing.T) {
+	server, requests := captureServer(t, http.StatusOK)
+	s := newTestSink(t, server.URL, OnFailureExit)
+	s.batchMaxBlocks, s.batchMaxWait = 2, time.Minute
+
+	now := time.Now()
+	addBlock(t, s, 10, false, now)
+	assert.Empty(t, requests(), "one block below the max waits")
+	addBlock(t, s, 11, false, now)
+
+	got := requests()
+	require.Len(t, got, 1)
+	assert.JSONEq(t, `{"manifest":{"moduleName":"map_events","type":"sf.test.v1.Out"},"blocks":[{"clock":{"number":10,"id":"id10","timestamp":""},"data":{"n":10}},{"clock":{"number":11,"id":"id11","timestamp":""},"data":{"n":11}}]}`, string(got[0].body))
+	assert.Equal(t, opaqueCursor(11), readStateCursor(t, s), "cursor is the last block of the batch")
+	assert.Nil(t, s.batch)
+	assert.NoFileExists(t, s.pendingFile)
+}
+
+func TestBatch_FlushesWhenLiveOrWaited(t *testing.T) {
+	server, requests := captureServer(t, http.StatusOK)
+	s := newTestSink(t, server.URL, OnFailureExit)
+	s.batchMaxBlocks, s.batchMaxWait = 100, time.Second
+
+	now := time.Now()
+	addBlock(t, s, 10, true, now)
+	require.Len(t, requests(), 1, "a live block goes out on its own")
+
+	addBlock(t, s, 11, false, now)
+	addBlock(t, s, 12, false, now.Add(2*time.Second))
+	got := requests()
+	require.Len(t, got, 2, "waited past the max wait")
+	var batch BatchPayload
+	require.NoError(t, json.Unmarshal(got[1].body, &batch))
+	assert.Len(t, batch.Blocks, 2)
+}
+
+func TestBatch_SparseModuleFlushesOnEmptyBlock(t *testing.T) {
+	server, requests := captureServer(t, http.StatusOK)
+	s := newTestSink(t, server.URL, OnFailureExit)
+	s.batchMaxBlocks, s.batchMaxWait = 100, time.Second
+
+	addBlock(t, s, 10, false, time.Now().Add(-2*time.Second))
+	empty := &pbsubstreamsrpc.BlockScopedData{Clock: protoClock(11), Output: &pbsubstreamsrpc.MapModuleOutput{Name: "map_events", MapOutput: &anypb.Any{}}}
+	require.NoError(t, s.handleBlockScopedData(context.Background(), empty, nil, sink.MustNewCursor(opaqueCursor(11))))
+
+	require.Len(t, requests(), 1)
+	assert.Equal(t, opaqueCursor(10), readStateCursor(t, s), "an empty block does not join the batch")
+}
+
+func TestBatch_FlushedBeforeUndo(t *testing.T) {
+	var order []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		order = append(order, r.URL.Path+":"+string(body[:12]))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	s := newTestSink(t, server.URL+"/blocks", OnFailureExit)
+	s.undoURL = server.URL + "/undo"
+	s.batchMaxBlocks, s.batchMaxWait = 100, time.Minute
+	addBlock(t, s, 10, false, time.Now())
+
+	undo := &pbsubstreamsrpc.BlockUndoSignal{LastValidBlock: &pbsubstreams.BlockRef{Number: 9, Id: "aa"}}
+	require.NoError(t, s.handleBlockUndoSignal(context.Background(), undo, sink.MustNewCursor(opaqueCursor(9))))
+
+	require.Equal(t, []string{`/blocks:{"manifest":`, `/undo:{"lastValidB`}, order)
+	assert.Equal(t, opaqueCursor(9), readStateCursor(t, s))
+}
+
+func TestBatch_FailureKeepsBatchPendingAndRecovers(t *testing.T) {
+	server := newTogglingServer(t, http.StatusServiceUnavailable)
+	s := newTestSink(t, server.URL, OnFailureExit)
+	s.batchMaxBlocks, s.batchMaxWait = 2, time.Minute
+
+	now := time.Now()
+	addBlock(t, s, 10, false, now)
+	err := s.addToBatch(context.Background(), "map_events", "t", protoClock(11), json.RawMessage(`{}`), sink.MustNewCursor(opaqueCursor(11)), false, now)
+	var failed *DeliveryFailedError
+	require.ErrorAs(t, err, &failed)
+	assert.Equal(t, uint64(11), failed.Delivery.BlockNumber)
+	assert.Nil(t, s.batch)
+
+	kept, err := readPending(s.pendingFile)
+	require.NoError(t, err)
+	assert.True(t, kept.Batched)
+
+	server.status.Store(http.StatusOK)
+	got, err := s.recoverPending(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, opaqueCursor(11), got.String())
+}
+
+func TestRecoverPending_DiscardsOtherBatchingMode(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		pendingBatched bool
+		maxBlocks      int
+	}{
+		{"batched pending, single mode", true, 0},
+		{"single pending, batched mode", false, 10},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTogglingServer(t, http.StatusOK)
+			s := newTestSink(t, server.URL, OnFailureExit)
+			s.batchMaxBlocks = tc.maxBlocks
+
+			p := newPending(10)
+			p.Batched = tc.pendingBatched
+			p.Fingerprint = s.fingerprint
+			require.NoError(t, writePending(s.pendingFile, p))
+
+			start := sink.MustNewCursor(opaqueCursor(9))
+			got, err := s.recoverPending(context.Background(), start)
+			require.NoError(t, err)
+			assert.Same(t, start, got, "stream resumes from the saved cursor")
+			assert.Equal(t, int32(0), server.calls.Load(), "nothing is sent in the old shape")
+			assert.NoFileExists(t, s.pendingFile)
+		})
+	}
+
+	t.Run("undo pending is kept in either mode", func(t *testing.T) {
+		server := newTogglingServer(t, http.StatusOK)
+		s := newTestSink(t, server.URL, OnFailureExit)
+		s.undoURL = server.URL
+		s.batchMaxBlocks = 10
+
+		p := newPending(10)
+		p.Kind = pendingKindUndo
+		p.Fingerprint = s.fingerprint
+		require.NoError(t, writePending(s.pendingFile, p))
+
+		_, err := s.recoverPending(context.Background(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), server.calls.Load())
+	})
 }
 
 func TestParseOnFailure(t *testing.T) {

--- a/sink/webhook/delivery_test.go
+++ b/sink/webhook/delivery_test.go
@@ -1,0 +1,281 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/bstream"
+	"github.com/streamingfast/substreams/sink"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func opaqueCursor(num uint64) string {
+	ref := bstream.NewBlockRef("aa", num)
+	return (&bstream.Cursor{Step: bstream.StepNew, Block: ref, HeadBlock: ref, LIB: bstream.NewBlockRef("00", 1)}).ToOpaque()
+}
+
+// togglingServer answers with the status held in status, and counts calls.
+type togglingServer struct {
+	*httptest.Server
+	status atomic.Int32
+	calls  atomic.Int32
+}
+
+func newTogglingServer(t *testing.T, status int) *togglingServer {
+	t.Helper()
+	s := &togglingServer{}
+	s.status.Store(int32(status))
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.calls.Add(1)
+		w.WriteHeader(int(s.status.Load()))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func newTestSink(t *testing.T, url string, onFailure OnFailure) *Sink {
+	t.Helper()
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "state.cursor")
+	terminationLog := filepath.Join(dir, "termination-log")
+	require.NoError(t, os.WriteFile(terminationLog, nil, 0o644))
+
+	cfg := Config{Timeout: time.Second, MaxRetries: 1, MaxInterval: 5 * time.Millisecond, AuthHeaderValue: "Bearer x"}
+	return &Sink{
+		webhookURL:     url,
+		stateFile:      stateFile,
+		pendingFile:    pendingFilePath(stateFile),
+		onFailure:      onFailure,
+		terminationLog: terminationLog,
+		fingerprint:    configFingerprint(url, cfg),
+		client:         NewClient(cfg, zap.NewNop()),
+		logger:         zap.NewNop(),
+	}
+}
+
+func newPending(num uint64) *pendingDelivery {
+	return &pendingDelivery{
+		Cursor:         opaqueCursor(num),
+		BlockNumber:    num,
+		Payload:        json.RawMessage(`{"clock":{"number":` + jsonNumber(num) + `}}`),
+		FirstAttemptAt: time.Now().Add(-time.Hour),
+	}
+}
+
+func jsonNumber(n uint64) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+func readStateCursor(t *testing.T, s *Sink) string {
+	t.Helper()
+	c, err := sink.ReadCursor(s.stateFile)
+	require.NoError(t, err)
+	if c == nil {
+		return ""
+	}
+	return c.String()
+}
+
+func TestPendingFile_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.cursor.pending")
+
+	got, err := readPending(path)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	p := newPending(10)
+	p.Fingerprint = "fp"
+	require.NoError(t, writePending(path, p))
+
+	got, err = readPending(path)
+	require.NoError(t, err)
+	assert.Equal(t, p.Cursor, got.Cursor)
+	assert.Equal(t, uint64(10), got.BlockNumber)
+	assert.JSONEq(t, string(p.Payload), string(got.Payload))
+	assert.Equal(t, "fp", got.Fingerprint)
+	assert.WithinDuration(t, p.FirstAttemptAt, got.FirstAttemptAt, time.Second)
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "no temp file left behind")
+
+	require.NoError(t, removePending(path))
+	require.NoError(t, removePending(path), "removing twice is fine")
+	assert.Empty(t, pendingFilePath(""))
+}
+
+func TestSend_SuccessCommitsCursorAndClearsPending(t *testing.T) {
+	server := newTogglingServer(t, http.StatusOK)
+	s := newTestSink(t, server.URL, OnFailureExit)
+
+	p := newPending(10)
+	s.fingerprint = "fp"
+	p.Fingerprint = "fp"
+	require.NoError(t, s.send(context.Background(), p))
+
+	assert.Equal(t, int32(1), server.calls.Load())
+	assert.Equal(t, opaqueCursor(10), readStateCursor(t, s))
+	assert.NoFileExists(t, s.pendingFile)
+}
+
+func TestSend_ExitModeKeepsPendingAndWritesTerminationMessage(t *testing.T) {
+	server := newTogglingServer(t, http.StatusServiceUnavailable)
+	s := newTestSink(t, server.URL, OnFailureExit)
+
+	p := newPending(10)
+	err := s.send(context.Background(), p)
+
+	var failed *DeliveryFailedError
+	require.ErrorAs(t, err, &failed)
+	assert.Equal(t, uint64(10), failed.Delivery.BlockNumber)
+	assert.Equal(t, http.StatusServiceUnavailable, failed.Delivery.StatusCode)
+	assert.Equal(t, 2, failed.Delivery.Attempts)
+	assert.Equal(t, p.FirstAttemptAt, failed.FirstAttemptAt)
+
+	assert.Empty(t, readStateCursor(t, s), "cursor must not move past an undelivered block")
+
+	kept, err := readPending(s.pendingFile)
+	require.NoError(t, err)
+	require.NotNil(t, kept)
+	assert.Equal(t, uint64(10), kept.BlockNumber)
+
+	msg, err := os.ReadFile(s.terminationLog)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(msg, &decoded))
+	assert.Equal(t, "webhook_delivery_failed", decoded["reason"])
+	assert.Equal(t, server.URL, decoded["url"])
+	assert.Equal(t, float64(10), decoded["block"])
+	assert.Equal(t, float64(http.StatusServiceUnavailable), decoded["status"])
+	assert.Equal(t, float64(2), decoded["attempts"])
+	assert.Equal(t, p.FirstAttemptAt.UTC().Format(time.RFC3339), decoded["first_attempt_at"])
+	assert.NotEmpty(t, decoded["error"])
+}
+
+func TestSend_SkipModeDropsBlock(t *testing.T) {
+	server := newTogglingServer(t, http.StatusServiceUnavailable)
+	s := newTestSink(t, server.URL, OnFailureSkip)
+
+	require.NoError(t, s.send(context.Background(), newPending(10)))
+	assert.NoFileExists(t, s.pendingFile)
+	assert.Empty(t, readStateCursor(t, s))
+
+	msg, err := os.ReadFile(s.terminationLog)
+	require.NoError(t, err)
+	assert.Empty(t, msg, "skip mode is not an exit, nothing to report")
+}
+
+func TestTerminationMessage_OnlyWrittenWhenFileExists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent")
+	require.NoError(t, writeTerminationMessage(path, []byte("x")))
+	assert.NoFileExists(t, path)
+	require.NoError(t, writeTerminationMessage("", []byte("x")))
+}
+
+func TestRecoverPending_NothingPending(t *testing.T) {
+	server := newTogglingServer(t, http.StatusOK)
+	s := newTestSink(t, server.URL, OnFailureExit)
+
+	start := sink.MustNewCursor(opaqueCursor(9))
+	got, err := s.recoverPending(context.Background(), start)
+	require.NoError(t, err)
+	assert.Same(t, start, got)
+	assert.Equal(t, int32(0), server.calls.Load())
+}
+
+func TestRecoverPending_DeliversBeforeStreaming(t *testing.T) {
+	server := newTogglingServer(t, http.StatusOK)
+	s := newTestSink(t, server.URL, OnFailureExit)
+
+	p := newPending(10)
+	p.Fingerprint = s.fingerprint
+	require.NoError(t, writePending(s.pendingFile, p))
+	require.NoError(t, sink.WriteCursor(s.stateFile, sink.MustNewCursor(opaqueCursor(9))))
+
+	got, err := s.recoverPending(context.Background(), sink.MustNewCursor(opaqueCursor(9)))
+	require.NoError(t, err)
+	assert.Equal(t, opaqueCursor(10), got.String(), "stream resumes after the recovered block")
+	assert.Equal(t, int32(1), server.calls.Load())
+	assert.Equal(t, opaqueCursor(10), readStateCursor(t, s))
+	assert.NoFileExists(t, s.pendingFile)
+}
+
+func TestRecoverPending_StillFailingExitsWithOriginalFirstAttempt(t *testing.T) {
+	server := newTogglingServer(t, http.StatusServiceUnavailable)
+	s := newTestSink(t, server.URL, OnFailureExit)
+
+	p := newPending(10)
+	p.Fingerprint = s.fingerprint
+	require.NoError(t, writePending(s.pendingFile, p))
+
+	_, err := s.recoverPending(context.Background(), nil)
+	var failed *DeliveryFailedError
+	require.ErrorAs(t, err, &failed)
+	assert.WithinDuration(t, p.FirstAttemptAt, failed.FirstAttemptAt, time.Second, "a retry never moves the first attempt forward")
+	assert.FileExists(t, s.pendingFile)
+}
+
+func TestRecoverPending_SkipModeDropsAndContinues(t *testing.T) {
+	server := newTogglingServer(t, http.StatusServiceUnavailable)
+	s := newTestSink(t, server.URL, OnFailureSkip)
+
+	p := newPending(10)
+	p.Fingerprint = s.fingerprint
+	require.NoError(t, writePending(s.pendingFile, p))
+
+	start := sink.MustNewCursor(opaqueCursor(9))
+	got, err := s.recoverPending(context.Background(), start)
+	require.NoError(t, err)
+	assert.Same(t, start, got)
+	assert.NoFileExists(t, s.pendingFile)
+}
+
+func TestRecoverPending_ConfigChangeResetsFirstAttempt(t *testing.T) {
+	server := newTogglingServer(t, http.StatusServiceUnavailable)
+	s := newTestSink(t, server.URL, OnFailureExit)
+
+	p := newPending(10)
+	p.Fingerprint = "written-under-the-old-url"
+	require.NoError(t, writePending(s.pendingFile, p))
+
+	_, err := s.recoverPending(context.Background(), nil)
+	var failed *DeliveryFailedError
+	require.ErrorAs(t, err, &failed)
+	assert.WithinDuration(t, time.Now(), failed.FirstAttemptAt, 5*time.Second)
+
+	kept, err := readPending(s.pendingFile)
+	require.NoError(t, err)
+	assert.Equal(t, s.fingerprint, kept.Fingerprint)
+	assert.WithinDuration(t, time.Now(), kept.FirstAttemptAt, 5*time.Second)
+}
+
+func TestConfigFingerprint_CoversURLAndSecrets(t *testing.T) {
+	base := Config{AuthHeaderValue: "a", SigningSecret: "s"}
+	fp := configFingerprint("https://example.com/hook", base)
+	assert.Equal(t, fp, configFingerprint("https://example.com/hook", base))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/other", base))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", Config{AuthHeaderValue: "b", SigningSecret: "s"}))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", Config{AuthHeaderValue: "a", SigningSecret: "t"}))
+	assert.NotEqual(t, fp, configFingerprint("https://example.com/hook", Config{AuthHeaderName: "X", AuthHeaderValue: "a", SigningSecret: "s"}))
+}
+
+func TestParseOnFailure(t *testing.T) {
+	got, err := ParseOnFailure("exit")
+	require.NoError(t, err)
+	assert.Equal(t, OnFailureExit, got)
+	got, err = ParseOnFailure("skip")
+	require.NoError(t, err)
+	assert.Equal(t, OnFailureSkip, got)
+	_, err = ParseOnFailure("pause")
+	assert.Error(t, err)
+}

--- a/sink/webhook/payload.go
+++ b/sink/webhook/payload.go
@@ -68,3 +68,36 @@ func NewWebhookPayload(moduleName string, clock *pbsubstreams.Clock, msgType str
 func (p *WebhookPayload) ToJSON() ([]byte, error) {
 	return json.Marshal(p)
 }
+
+// BlockRef identifies a block in an undo payload.
+type BlockRef struct {
+	Number uint64 `json:"number"`
+	ID     string `json:"id"`
+}
+
+// UndoManifest names the module whose blocks are being undone.
+type UndoManifest struct {
+	ModuleName string `json:"moduleName"`
+}
+
+// UndoPayload is sent to the undo URL when the chain reorganizes. Every block
+// the receiver got with a number above LastValidBlock is no longer on the
+// chain; the blocks that replace them follow as regular payloads.
+type UndoPayload struct {
+	LastValidBlock BlockRef     `json:"lastValidBlock"`
+	Manifest       UndoManifest `json:"manifest"`
+}
+
+// NewUndoPayload creates the payload for an undo signal.
+func NewUndoPayload(moduleName string, lastValidBlock *pbsubstreams.BlockRef) *UndoPayload {
+	p := &UndoPayload{Manifest: UndoManifest{ModuleName: moduleName}}
+	if lastValidBlock != nil {
+		p.LastValidBlock = BlockRef{Number: lastValidBlock.Number, ID: lastValidBlock.Id}
+	}
+	return p
+}
+
+// ToJSON serializes the undo payload to JSON bytes
+func (p *UndoPayload) ToJSON() ([]byte, error) {
+	return json.Marshal(p)
+}

--- a/sink/webhook/payload.go
+++ b/sink/webhook/payload.go
@@ -30,42 +30,61 @@ type WebhookPayload struct {
 
 // NewWebhookPayload creates a new webhook payload with the desired format
 func NewWebhookPayload(moduleName string, clock *pbsubstreams.Clock, msgType string, data json.RawMessage) (*WebhookPayload, error) {
-	var timestampStr string
-	if clock != nil && clock.Timestamp != nil {
-		timestampStr = clock.Timestamp.AsTime().Format(time.RFC3339)
-	}
-
-	// Strip the "type.googleapis.com/" prefix from the type
-	cleanType := msgType
-	if strings.HasPrefix(msgType, "type.googleapis.com/") {
-		cleanType = strings.TrimPrefix(msgType, "type.googleapis.com/")
-	}
-
-	clockInfo := Clock{
-		Timestamp: timestampStr,
-		Number:    0,
-		ID:        "",
-	}
-
-	if clock != nil {
-		clockInfo.Number = clock.Number
-		clockInfo.ID = clock.Id
-	}
-
-	manifest := Manifest{
-		ModuleName: moduleName,
-		Type:       cleanType,
-	}
-
 	return &WebhookPayload{
-		Clock:    clockInfo,
-		Manifest: manifest,
+		Clock:    newClock(clock),
+		Manifest: newManifest(moduleName, msgType),
 		Data:     data,
 	}, nil
 }
 
 // ToJSON serializes the webhook payload to JSON bytes
 func (p *WebhookPayload) ToJSON() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+func newClock(clock *pbsubstreams.Clock) Clock {
+	if clock == nil {
+		return Clock{}
+	}
+	var timestampStr string
+	if clock.Timestamp != nil {
+		timestampStr = clock.Timestamp.AsTime().Format(time.RFC3339)
+	}
+	return Clock{Timestamp: timestampStr, Number: clock.Number, ID: clock.Id}
+}
+
+func newManifest(moduleName string, msgType string) Manifest {
+	// Strip the "type.googleapis.com/" prefix from the type
+	return Manifest{ModuleName: moduleName, Type: strings.TrimPrefix(msgType, "type.googleapis.com/")}
+}
+
+// BlockEntry is one block inside a BatchPayload.
+type BlockEntry struct {
+	Clock Clock           `json:"clock"`
+	Data  json.RawMessage `json:"data"`
+}
+
+// BatchPayload is sent instead of WebhookPayload when batching is on. The
+// manifest is the same for every block so it is carried once; blocks are in
+// ascending order. Every call in batch mode uses this shape, a batch of one
+// included, so a receiver only ever parses one format.
+type BatchPayload struct {
+	Manifest Manifest     `json:"manifest"`
+	Blocks   []BlockEntry `json:"blocks"`
+}
+
+// NewBatchPayload creates an empty batch for the given module.
+func NewBatchPayload(moduleName string, msgType string) *BatchPayload {
+	return &BatchPayload{Manifest: newManifest(moduleName, msgType)}
+}
+
+// Append adds one block to the batch.
+func (p *BatchPayload) Append(clock *pbsubstreams.Clock, data json.RawMessage) {
+	p.Blocks = append(p.Blocks, BlockEntry{Clock: newClock(clock), Data: data})
+}
+
+// ToJSON serializes the batch payload to JSON bytes
+func (p *BatchPayload) ToJSON() ([]byte, error) {
 	return json.Marshal(p)
 }
 

--- a/sink/webhook/pending.go
+++ b/sink/webhook/pending.go
@@ -1,0 +1,114 @@
+package webhook
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// pendingDelivery is a payload that could not be delivered, kept on disk next
+// to the cursor file. It is written when every attempt has failed in
+// OnFailureExit mode and removed once the payload goes through, so the next
+// start delivers it before a Substreams stream is opened. A kill in the
+// middle of a call leaves no file: the cursor was not advanced, so the stream
+// re-sends that block.
+type pendingDelivery struct {
+	Cursor      string `json:"cursor"`
+	BlockNumber uint64 `json:"block_number"`
+	// Payload holds the exact bytes that were attempted, so a retry is
+	// byte-identical and a signature computed over it still verifies.
+	Payload json.RawMessage `json:"payload"`
+	// FirstAttemptAt is set when the file is created and is never moved
+	// forward by a retry. It is the start of the current outage.
+	FirstAttemptAt time.Time `json:"first_attempt_at"`
+	// Fingerprint identifies the delivery configuration (URL and secrets) in
+	// effect when the file was created. A different fingerprint on restart
+	// means the user changed the configuration, which resets FirstAttemptAt.
+	Fingerprint string `json:"fingerprint"`
+}
+
+// pendingFilePath derives the pending file from the state file. Both must
+// live on the same persistent volume, so one setting places the two.
+func pendingFilePath(stateFile string) string {
+	if stateFile == "" {
+		return ""
+	}
+	return stateFile + ".pending"
+}
+
+// configFingerprint hashes what the delivery depends on. The secrets are
+// hashed rather than stored so the pending file never holds them.
+func configFingerprint(url string, cfg Config) string {
+	h := sha256.New()
+	for _, part := range []string{url, cfg.AuthHeaderName, cfg.AuthHeaderValue, cfg.SigningSecret} {
+		h.Write([]byte(part))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// readPending returns nil, nil when there is no pending file.
+func readPending(path string) (*pendingDelivery, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var p pendingDelivery
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("decoding pending file %q: %w", path, err)
+	}
+	return &p, nil
+}
+
+// writePending writes the file through a temp file and a rename so a reader
+// never sees a partial file.
+func writePending(path string, p *pendingDelivery) error {
+	if path == "" {
+		return nil
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+
+	tempFile, err := os.CreateTemp(filepath.Dir(path), ".pending_*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	defer os.Remove(tempPath)
+
+	if _, err := tempFile.Write(data); err != nil {
+		tempFile.Close()
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}
+
+func removePending(path string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/sink/webhook/pending.go
+++ b/sink/webhook/pending.go
@@ -20,7 +20,11 @@ import (
 type pendingDelivery struct {
 	// Kind is pendingKindBlock or pendingKindUndo and selects the URL the
 	// payload goes to. Empty reads as pendingKindBlock.
-	Kind        string `json:"kind,omitempty"`
+	Kind string `json:"kind,omitempty"`
+	// Batched marks a block payload in the BatchPayload shape. A pending
+	// payload whose shape does not match the mode the sink now runs in is
+	// discarded on start and its blocks come back through the stream.
+	Batched     bool   `json:"batched,omitempty"`
 	Cursor      string `json:"cursor"`
 	BlockNumber uint64 `json:"block_number"`
 	// Payload holds the exact bytes that were attempted, so a retry is

--- a/sink/webhook/pending.go
+++ b/sink/webhook/pending.go
@@ -18,6 +18,9 @@ import (
 // middle of a call leaves no file: the cursor was not advanced, so the stream
 // re-sends that block.
 type pendingDelivery struct {
+	// Kind is pendingKindBlock or pendingKindUndo and selects the URL the
+	// payload goes to. Empty reads as pendingKindBlock.
+	Kind        string `json:"kind,omitempty"`
 	Cursor      string `json:"cursor"`
 	BlockNumber uint64 `json:"block_number"`
 	// Payload holds the exact bytes that were attempted, so a retry is
@@ -32,6 +35,13 @@ type pendingDelivery struct {
 	Fingerprint string `json:"fingerprint"`
 }
 
+const (
+	pendingKindBlock = "block"
+	pendingKindUndo  = "undo"
+)
+
+func (p *pendingDelivery) isUndo() bool { return p.Kind == pendingKindUndo }
+
 // pendingFilePath derives the pending file from the state file. Both must
 // live on the same persistent volume, so one setting places the two.
 func pendingFilePath(stateFile string) string {
@@ -43,9 +53,9 @@ func pendingFilePath(stateFile string) string {
 
 // configFingerprint hashes what the delivery depends on. The secrets are
 // hashed rather than stored so the pending file never holds them.
-func configFingerprint(url string, cfg Config) string {
+func configFingerprint(url, undoURL string, cfg Config) string {
 	h := sha256.New()
-	for _, part := range []string{url, cfg.AuthHeaderName, cfg.AuthHeaderValue, cfg.SigningSecret} {
+	for _, part := range []string{url, undoURL, cfg.AuthHeaderName, cfg.AuthHeaderValue, cfg.SigningSecret} {
 		h.Write([]byte(part))
 		h.Write([]byte{0})
 	}

--- a/sink/webhook/sink.go
+++ b/sink/webhook/sink.go
@@ -2,8 +2,11 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/streamingfast/substreams/protodecode"
@@ -13,27 +16,96 @@ import (
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
 )
 
+// OnFailure selects what the sink does once every attempt to deliver a block
+// has failed.
+type OnFailure string
+
+const (
+	// OnFailureSkip logs the failure, drops the block and moves on to the next
+	// one. The cursor is not advanced past the dropped block, so a later
+	// restart replays it.
+	OnFailureSkip OnFailure = "skip"
+	// OnFailureExit keeps the block in the pending file, writes a termination
+	// message and stops the sink with ExitCodeDeliveryFailed. The next start
+	// delivers the pending block before it opens a Substreams stream.
+	OnFailureExit OnFailure = "exit"
+)
+
+func ParseOnFailure(value string) (OnFailure, error) {
+	switch OnFailure(value) {
+	case OnFailureSkip, OnFailureExit:
+		return OnFailure(value), nil
+	default:
+		return "", fmt.Errorf("invalid on-failure value %q, expected %q or %q", value, OnFailureSkip, OnFailureExit)
+	}
+}
+
+// ExitCodeDeliveryFailed is the process exit status for a delivery failure in
+// OnFailureExit mode. It is EX_TEMPFAIL from sysexits: the input was fine,
+// try again later.
+const ExitCodeDeliveryFailed = 75
+
+// DeliveryFailedError is returned from Sink.Run in OnFailureExit mode. The
+// pending block stays on disk for the next start.
+type DeliveryFailedError struct {
+	Delivery       *DeliveryError
+	FirstAttemptAt time.Time
+}
+
+func (e *DeliveryFailedError) Error() string {
+	return fmt.Sprintf("%v (failing since %s)", e.Delivery, e.FirstAttemptAt.Format(time.RFC3339))
+}
+
+func (e *DeliveryFailedError) Unwrap() error { return e.Delivery }
+
+// TerminationMessage is the one-line JSON written to the termination log so
+// an orchestrator can read why the process stopped and since when.
+func (e *DeliveryFailedError) TerminationMessage() []byte {
+	msg, _ := json.Marshal(map[string]any{
+		"reason":           "webhook_delivery_failed",
+		"url":              e.Delivery.URL,
+		"block":            e.Delivery.BlockNumber,
+		"status":           e.Delivery.StatusCode,
+		"attempts":         e.Delivery.Attempts,
+		"first_attempt_at": e.FirstAttemptAt.UTC().Format(time.RFC3339),
+		"error":            e.Delivery.Err.Error(),
+	})
+	return msg
+}
+
 // Sink represents a webhook sink that sends substream data to HTTP endpoints
 type Sink struct {
-	webhookURL string
-	stateFile  string
-	client     *Client
-	sinker     *sink.Sinker
-	decoder    *protodecode.Decoder
-	logger     *zap.Logger
+	webhookURL     string
+	stateFile      string
+	pendingFile    string
+	onFailure      OnFailure
+	terminationLog string
+	fingerprint    string
+	client         *Client
+	sinker         *sink.Sinker
+	decoder        *protodecode.Decoder
+	logger         *zap.Logger
 }
 
 // SinkConfig holds configuration for the webhook sink
 type SinkConfig struct {
-	WebhookURL   string
+	WebhookURL string
+	// StateFile holds the cursor of the last delivered block. The pending
+	// block lives next to it in "<StateFile>.pending". Empty disables both.
 	StateFile    string
+	OnFailure    OnFailure
 	SinkerConfig *sink.SinkerConfig
 	ClientConfig Config
-	Logger       *zap.Logger
+	// TerminationLogPath receives the reason for a delivery-failure exit. It
+	// is written only when the file already exists, which is the case under
+	// Kubernetes, so the default of /dev/termination-log is safe elsewhere.
+	TerminationLogPath string
+	Logger             *zap.Logger
 }
 
 var WebhookCallsCounter = sink.Metrics.NewCounter("webhook_calls", "Number of calls made to the webhook")
 var WebhookSizeBytes = sink.Metrics.NewCounter("webhook_bytes_sent", "Number of bytes sent via webhook")
+var WebhookProgressBlock = sink.Metrics.NewGauge("substreams_sink_progress_block", "Last block number delivered to the webhook")
 
 // NewSink creates a new webhook sink
 func NewSink(config SinkConfig) (*Sink, error) {
@@ -47,21 +119,29 @@ func NewSink(config SinkConfig) (*Sink, error) {
 		return nil, fmt.Errorf("creating decoder: %w", err)
 	}
 
-	client := NewClient(config.ClientConfig, config.Logger)
+	onFailure := config.OnFailure
+	if onFailure == "" {
+		onFailure = OnFailureSkip
+	}
 
 	return &Sink{
-		webhookURL: config.WebhookURL,
-		stateFile:  config.StateFile,
-		client:     client,
-		sinker:     sinker,
-		decoder:    decoder,
-		logger:     config.Logger,
+		webhookURL:     config.WebhookURL,
+		stateFile:      config.StateFile,
+		pendingFile:    pendingFilePath(config.StateFile),
+		onFailure:      onFailure,
+		terminationLog: config.TerminationLogPath,
+		fingerprint:    configFingerprint(config.WebhookURL, config.ClientConfig),
+		client:         NewClient(config.ClientConfig, config.Logger),
+		sinker:         sinker,
+		decoder:        decoder,
+		logger:         config.Logger,
 	}, nil
 }
 
-// Run starts the webhook sink
+// Run delivers the pending block left by a previous run, if any, then streams
+// from the cursor. A Substreams stream is never opened while a pending block
+// is undelivered, so retrying against a dead endpoint costs no egress.
 func (s *Sink) Run(ctx context.Context) error {
-	// Load existing cursor if state file exists
 	var startCursor *sink.Cursor
 	var err error
 	if s.stateFile != "" {
@@ -69,6 +149,10 @@ func (s *Sink) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("reading cursor: %w", err)
 		}
+	}
+
+	if startCursor, err = s.recoverPending(ctx, startCursor); err != nil {
+		return err
 	}
 
 	handlers := sink.NewSinkerFullHandlersWithPartial(
@@ -83,6 +167,112 @@ func (s *Sink) Run(ctx context.Context) error {
 
 	s.sinker.Run(ctx, startCursor, handlers)
 	return s.sinker.Err()
+}
+
+// recoverPending delivers the pending block from a previous run and returns
+// the cursor to stream from afterwards.
+func (s *Sink) recoverPending(ctx context.Context, startCursor *sink.Cursor) (*sink.Cursor, error) {
+	pending, err := readPending(s.pendingFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading pending delivery: %w", err)
+	}
+	if pending == nil {
+		return startCursor, nil
+	}
+
+	if pending.Fingerprint != s.fingerprint {
+		// The user changed the URL or a secret since the failure began. What
+		// follows is a fresh outage, if it is one at all.
+		s.logger.Info("delivery configuration changed since the pending block was written, resetting its first attempt time", zap.Uint64("block", pending.BlockNumber))
+		pending.FirstAttemptAt = time.Now()
+		pending.Fingerprint = s.fingerprint
+		if err := writePending(s.pendingFile, pending); err != nil {
+			return nil, fmt.Errorf("updating pending delivery: %w", err)
+		}
+	}
+
+	s.logger.Info("delivering pending block before connecting to substreams",
+		zap.Uint64("block", pending.BlockNumber),
+		zap.Time("first_attempt_at", pending.FirstAttemptAt))
+
+	if err := s.deliver(ctx, pending); err != nil {
+		if s.onFailure == OnFailureExit {
+			return nil, s.deliveryFailed(pending, err)
+		}
+		s.logger.Warn("dropping pending block after failed delivery", zap.Uint64("block", pending.BlockNumber), zap.Error(err))
+		return startCursor, removePending(s.pendingFile)
+	}
+
+	cursor, err := sink.NewCursor(pending.Cursor)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cursor in pending delivery: %w", err)
+	}
+	return cursor, nil
+}
+
+// deliver POSTs the pending block and, on success, commits it: cursor written,
+// pending file removed, progress metric updated. The returned error is the
+// *DeliveryError from the client.
+func (s *Sink) deliver(ctx context.Context, pending *pendingDelivery) error {
+	WebhookCallsCounter.Inc()
+	WebhookSizeBytes.AddInt(len(pending.Payload))
+
+	if err := s.client.Call(ctx, s.webhookURL, pending.Payload, pending.BlockNumber); err != nil {
+		return err
+	}
+
+	if s.stateFile != "" && pending.Cursor != "" {
+		cursor, err := sink.NewCursor(pending.Cursor)
+		if err != nil {
+			return fmt.Errorf("invalid cursor for block %d: %w", pending.BlockNumber, err)
+		}
+		if err := sink.WriteCursor(s.stateFile, cursor); err != nil {
+			return fmt.Errorf("saving cursor to state file %q: %w", s.stateFile, err)
+		}
+	}
+	if err := removePending(s.pendingFile); err != nil {
+		return fmt.Errorf("removing pending delivery: %w", err)
+	}
+
+	WebhookProgressBlock.SetUint64(pending.BlockNumber)
+	return nil
+}
+
+// deliveryFailed keeps the payload on disk for the next start and turns the
+// failure into the error Run returns in exit mode, after writing the
+// termination message.
+func (s *Sink) deliveryFailed(pending *pendingDelivery, err error) error {
+	if writeErr := writePending(s.pendingFile, pending); writeErr != nil {
+		// Not fatal for the data: the cursor was not advanced, so the stream
+		// re-sends this block on the next start. Only the egress saving is lost.
+		s.logger.Error("failed to keep the undelivered payload on disk", zap.String("file", s.pendingFile), zap.Error(writeErr))
+	}
+
+	var deliveryErr *DeliveryError
+	if !errors.As(err, &deliveryErr) {
+		deliveryErr = &DeliveryError{URL: s.webhookURL, BlockNumber: pending.BlockNumber, Attempts: 1, Err: err}
+	}
+	failed := &DeliveryFailedError{Delivery: deliveryErr, FirstAttemptAt: pending.FirstAttemptAt}
+
+	if err := writeTerminationMessage(s.terminationLog, failed.TerminationMessage()); err != nil {
+		s.logger.Warn("failed to write termination message", zap.String("path", s.terminationLog), zap.Error(err))
+	}
+	return failed
+}
+
+// writeTerminationMessage writes msg to path when path already exists. Under
+// Kubernetes the kubelet creates the file; anywhere else nothing is written.
+func writeTerminationMessage(path string, msg []byte) error {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return os.WriteFile(path, msg, 0o644)
 }
 
 // handleBlockScopedData processes a block of data and sends it to the webhook
@@ -104,29 +294,33 @@ func (s *Sink) handleBlockScopedData(ctx context.Context, data *pbsubstreamsrpc.
 		return fmt.Errorf("failed to serialize webhook payload: %w", err)
 	}
 
-	WebhookCallsCounter.Inc()
-	WebhookSizeBytes.AddInt(len(wrappedOut))
+	pending := &pendingDelivery{
+		BlockNumber:    data.Clock.Number,
+		Payload:        wrappedOut,
+		FirstAttemptAt: time.Now(),
+		Fingerprint:    s.fingerprint,
+	}
+	if cursor != nil {
+		pending.Cursor = cursor.String()
+	}
 
-	s.logger.Info("calling webhook",
-		zap.Uint64("block", data.Clock.Number),
-	)
+	return s.send(ctx, pending)
+}
 
-	// Make the webhook call with automatic retries for transient failures
-	err = s.client.Call(ctx, s.webhookURL, wrappedOut, data.Clock.Number)
-	if err != nil {
-		// Continue processing even if webhook fails to avoid blocking the stream
+// send delivers the payload and applies the on-failure policy.
+func (s *Sink) send(ctx context.Context, pending *pendingDelivery) error {
+	s.logger.Info("calling webhook", zap.Uint64("block", pending.BlockNumber))
+
+	err := s.deliver(ctx, pending)
+	if err == nil {
 		return nil
 	}
 
-	// Save cursor to state file
-	if s.stateFile != "" && cursor != nil {
-		if err := sink.WriteCursor(s.stateFile, cursor); err != nil {
-			s.logger.Warn("failed to save cursor to state file",
-				zap.Error(err),
-				zap.String("file", s.stateFile))
-		}
+	if s.onFailure == OnFailureExit {
+		return s.deliveryFailed(pending, err)
 	}
 
+	s.logger.Warn("dropping block after failed delivery", zap.Uint64("block", pending.BlockNumber), zap.Error(err))
 	return nil
 }
 

--- a/sink/webhook/sink.go
+++ b/sink/webhook/sink.go
@@ -48,7 +48,9 @@ const ExitCodeDeliveryFailed = 75
 // DeliveryFailedError is returned from Sink.Run in OnFailureExit mode. The
 // pending block stays on disk for the next start.
 type DeliveryFailedError struct {
-	Delivery       *DeliveryError
+	Delivery *DeliveryError
+	// Kind is "block" for a block payload and "undo" for a reorg notification.
+	Kind           string
 	FirstAttemptAt time.Time
 }
 
@@ -63,6 +65,7 @@ func (e *DeliveryFailedError) Unwrap() error { return e.Delivery }
 func (e *DeliveryFailedError) TerminationMessage() []byte {
 	msg, _ := json.Marshal(map[string]any{
 		"reason":           "webhook_delivery_failed",
+		"kind":             e.Kind,
 		"url":              e.Delivery.URL,
 		"block":            e.Delivery.BlockNumber,
 		"status":           e.Delivery.StatusCode,
@@ -76,6 +79,8 @@ func (e *DeliveryFailedError) TerminationMessage() []byte {
 // Sink represents a webhook sink that sends substream data to HTTP endpoints
 type Sink struct {
 	webhookURL     string
+	undoURL        string
+	moduleName     string
 	stateFile      string
 	pendingFile    string
 	onFailure      OnFailure
@@ -90,6 +95,10 @@ type Sink struct {
 // SinkConfig holds configuration for the webhook sink
 type SinkConfig struct {
 	WebhookURL string
+	// UndoURL receives an UndoPayload for every undo signal the sink sees.
+	// Empty disables the notification; the cursor still moves back so the
+	// blocks that replace the undone ones are delivered as usual.
+	UndoURL string
 	// StateFile holds the cursor of the last delivered block. The pending
 	// block lives next to it in "<StateFile>.pending". Empty disables both.
 	StateFile    string
@@ -126,11 +135,13 @@ func NewSink(config SinkConfig) (*Sink, error) {
 
 	return &Sink{
 		webhookURL:     config.WebhookURL,
+		undoURL:        config.UndoURL,
+		moduleName:     sinker.OutputModuleName(),
 		stateFile:      config.StateFile,
 		pendingFile:    pendingFilePath(config.StateFile),
 		onFailure:      onFailure,
 		terminationLog: config.TerminationLogPath,
-		fingerprint:    configFingerprint(config.WebhookURL, config.ClientConfig),
+		fingerprint:    configFingerprint(config.WebhookURL, config.UndoURL, config.ClientConfig),
 		client:         NewClient(config.ClientConfig, config.Logger),
 		sinker:         sinker,
 		decoder:        decoder,
@@ -210,14 +221,19 @@ func (s *Sink) recoverPending(ctx context.Context, startCursor *sink.Cursor) (*s
 	return cursor, nil
 }
 
-// deliver POSTs the pending block and, on success, commits it: cursor written,
-// pending file removed, progress metric updated. The returned error is the
-// *DeliveryError from the client.
+// deliver POSTs the pending payload and, on success, commits it: cursor
+// written, pending file removed, progress metric updated. The returned error
+// is the *DeliveryError from the client.
 func (s *Sink) deliver(ctx context.Context, pending *pendingDelivery) error {
+	url := s.webhookURL
+	if pending.isUndo() {
+		url = s.undoURL
+	}
+
 	WebhookCallsCounter.Inc()
 	WebhookSizeBytes.AddInt(len(pending.Payload))
 
-	if err := s.client.Call(ctx, s.webhookURL, pending.Payload, pending.BlockNumber); err != nil {
+	if err := s.client.Call(ctx, url, pending.Payload, pending.BlockNumber); err != nil {
 		return err
 	}
 
@@ -252,7 +268,11 @@ func (s *Sink) deliveryFailed(pending *pendingDelivery, err error) error {
 	if !errors.As(err, &deliveryErr) {
 		deliveryErr = &DeliveryError{URL: s.webhookURL, BlockNumber: pending.BlockNumber, Attempts: 1, Err: err}
 	}
-	failed := &DeliveryFailedError{Delivery: deliveryErr, FirstAttemptAt: pending.FirstAttemptAt}
+	kind := pending.Kind
+	if kind == "" {
+		kind = pendingKindBlock
+	}
+	failed := &DeliveryFailedError{Delivery: deliveryErr, Kind: kind, FirstAttemptAt: pending.FirstAttemptAt}
 
 	if err := writeTerminationMessage(s.terminationLog, failed.TerminationMessage()); err != nil {
 		s.logger.Warn("failed to write termination message", zap.String("path", s.terminationLog), zap.Error(err))
@@ -295,6 +315,7 @@ func (s *Sink) handleBlockScopedData(ctx context.Context, data *pbsubstreamsrpc.
 	}
 
 	pending := &pendingDelivery{
+		Kind:           pendingKindBlock,
 		BlockNumber:    data.Clock.Number,
 		Payload:        wrappedOut,
 		FirstAttemptAt: time.Now(),
@@ -309,7 +330,7 @@ func (s *Sink) handleBlockScopedData(ctx context.Context, data *pbsubstreamsrpc.
 
 // send delivers the payload and applies the on-failure policy.
 func (s *Sink) send(ctx context.Context, pending *pendingDelivery) error {
-	s.logger.Info("calling webhook", zap.Uint64("block", pending.BlockNumber))
+	s.logger.Info("calling webhook", zap.String("kind", pending.Kind), zap.Uint64("block", pending.BlockNumber))
 
 	err := s.deliver(ctx, pending)
 	if err == nil {
@@ -324,17 +345,39 @@ func (s *Sink) send(ctx context.Context, pending *pendingDelivery) error {
 	return nil
 }
 
-// handleBlockUndoSignal handles undo signals
+// handleBlockUndoSignal moves the cursor back to the last valid block and, when
+// an undo URL is configured, tells the receiver which blocks are gone.
 func (s *Sink) handleBlockUndoSignal(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *sink.Cursor) error {
-	// Save cursor to state file on undo
-	if s.stateFile != "" && cursor != nil {
-		if err := sink.WriteCursor(s.stateFile, cursor); err != nil {
-			s.logger.Warn("failed to save cursor to state file on undo",
-				zap.Error(err),
-				zap.String("file", s.stateFile))
+	if s.undoURL == "" {
+		if s.stateFile != "" && cursor != nil {
+			if err := sink.WriteCursor(s.stateFile, cursor); err != nil {
+				s.logger.Warn("failed to save cursor to state file on undo",
+					zap.Error(err),
+					zap.String("file", s.stateFile))
+			}
 		}
+		return nil
 	}
-	return nil
+
+	payload, err := NewUndoPayload(s.moduleName, undoSignal.LastValidBlock).ToJSON()
+	if err != nil {
+		return fmt.Errorf("failed to serialize undo payload: %w", err)
+	}
+
+	pending := &pendingDelivery{
+		Kind:           pendingKindUndo,
+		Payload:        payload,
+		FirstAttemptAt: time.Now(),
+		Fingerprint:    s.fingerprint,
+	}
+	if undoSignal.LastValidBlock != nil {
+		pending.BlockNumber = undoSignal.LastValidBlock.Number
+	}
+	if cursor != nil {
+		pending.Cursor = cursor.String()
+	}
+
+	return s.send(ctx, pending)
 }
 
 // PrintStats prints final statistics

--- a/sink/webhook/sink.go
+++ b/sink/webhook/sink.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	pbsubstreamsrpc "github.com/streamingfast/substreams/pb/sf/substreams/rpc/v2"
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
 )
 
 // OnFailure selects what the sink does once every attempt to deliver a block
@@ -86,10 +87,24 @@ type Sink struct {
 	onFailure      OnFailure
 	terminationLog string
 	fingerprint    string
+	batchMaxBlocks int
+	batchMaxWait   time.Duration
+	batch          *openBatch
 	client         *Client
 	sinker         *sink.Sinker
 	decoder        *protodecode.Decoder
 	logger         *zap.Logger
+}
+
+// openBatch is the batch being filled. It is flushed when it holds
+// batchMaxBlocks blocks, when batchMaxWait has passed since it was opened,
+// when a live block arrives, when an undo signal arrives, or when the stream
+// ends cleanly.
+type openBatch struct {
+	payload   *BatchPayload
+	cursor    string
+	lastBlock uint64
+	openedAt  time.Time
 }
 
 // SinkConfig holds configuration for the webhook sink
@@ -105,6 +120,13 @@ type SinkConfig struct {
 	OnFailure    OnFailure
 	SinkerConfig *sink.SinkerConfig
 	ClientConfig Config
+	// BatchMaxBlocks above zero switches every call to the BatchPayload shape
+	// and sends up to that many blocks per call. Zero sends one WebhookPayload
+	// per block.
+	BatchMaxBlocks int
+	// BatchMaxWait bounds how long a batch waits for more blocks. It is
+	// checked when the next block arrives. Defaults to one second.
+	BatchMaxWait time.Duration
 	// TerminationLogPath receives the reason for a delivery-failure exit. It
 	// is written only when the file already exists, which is the case under
 	// Kubernetes, so the default of /dev/termination-log is safe elsewhere.
@@ -133,7 +155,14 @@ func NewSink(config SinkConfig) (*Sink, error) {
 		onFailure = OnFailureSkip
 	}
 
+	batchMaxWait := config.BatchMaxWait
+	if batchMaxWait <= 0 {
+		batchMaxWait = time.Second
+	}
+
 	return &Sink{
+		batchMaxBlocks: max(config.BatchMaxBlocks, 0),
+		batchMaxWait:   batchMaxWait,
 		webhookURL:     config.WebhookURL,
 		undoURL:        config.UndoURL,
 		moduleName:     sinker.OutputModuleName(),
@@ -177,7 +206,16 @@ func (s *Sink) Run(ctx context.Context) error {
 	)
 
 	s.sinker.Run(ctx, startCursor, handlers)
-	return s.sinker.Err()
+	if err := s.sinker.Err(); err != nil {
+		return err
+	}
+
+	// A clean end, the stop block was reached. On a shutdown the batch is
+	// left alone: its cursor was not saved, so the stream re-sends it.
+	if s.batch != nil && ctx.Err() == nil {
+		return s.flushBatch(ctx)
+	}
+	return nil
 }
 
 // recoverPending delivers the pending block from a previous run and returns
@@ -189,6 +227,15 @@ func (s *Sink) recoverPending(ctx context.Context, startCursor *sink.Cursor) (*s
 	}
 	if pending == nil {
 		return startCursor, nil
+	}
+
+	if !pending.isUndo() && pending.Batched != s.batching() {
+		// The user switched batching on or off while the sink was down. The
+		// receiver expects the new shape, and the cursor was not advanced past
+		// these blocks, so the stream sends them again in that shape.
+		s.logger.Info("pending payload was written in the other batching mode, discarding it; the stream re-sends its blocks",
+			zap.Bool("pending_batched", pending.Batched), zap.Bool("batching", s.batching()), zap.Uint64("block", pending.BlockNumber))
+		return startCursor, removePending(s.pendingFile)
 	}
 
 	if pending.Fingerprint != s.fingerprint {
@@ -295,8 +342,20 @@ func writeTerminationMessage(path string, msg []byte) error {
 	return os.WriteFile(path, msg, 0o644)
 }
 
+func (s *Sink) batching() bool { return s.batchMaxBlocks > 0 }
+
 // handleBlockScopedData processes a block of data and sends it to the webhook
 func (s *Sink) handleBlockScopedData(ctx context.Context, data *pbsubstreamsrpc.BlockScopedData, isLive *bool, cursor *sink.Cursor) error {
+	now := time.Now()
+
+	// Blocks with no output do not join a batch, but they do move the clock
+	// for one that is waiting: a sparse module must not hold a batch forever.
+	if s.batch != nil && now.Sub(s.batch.openedAt) >= s.batchMaxWait {
+		if err := s.flushBatch(ctx); err != nil {
+			return err
+		}
+	}
+
 	if data.Output.MapOutput.Value == nil {
 		return nil
 	}
@@ -304,7 +363,16 @@ func (s *Sink) handleBlockScopedData(ctx context.Context, data *pbsubstreamsrpc.
 	msgDesc := s.decoder.GetMessageDescriptor(data.Output.Name)
 	dataContent := s.decoder.DecodeDynamicMessage(msgDesc, data.Output.MapOutput)
 
-	payload, err := NewWebhookPayload(data.Output.Name, data.Clock, data.Output.MapOutput.TypeUrl, dataContent)
+	live := isLive != nil && *isLive
+	if s.batching() {
+		return s.addToBatch(ctx, data.Output.Name, data.Output.MapOutput.TypeUrl, data.Clock, dataContent, cursor, live, now)
+	}
+	return s.sendBlock(ctx, data.Output.Name, data.Output.MapOutput.TypeUrl, data.Clock, dataContent, cursor, now)
+}
+
+// sendBlock delivers one block as a WebhookPayload.
+func (s *Sink) sendBlock(ctx context.Context, moduleName, typeURL string, clock *pbsubstreams.Clock, dataContent json.RawMessage, cursor *sink.Cursor, now time.Time) error {
+	payload, err := NewWebhookPayload(moduleName, clock, typeURL, dataContent)
 	if err != nil {
 		return fmt.Errorf("failed to create webhook payload: %w", err)
 	}
@@ -316,15 +384,62 @@ func (s *Sink) handleBlockScopedData(ctx context.Context, data *pbsubstreamsrpc.
 
 	pending := &pendingDelivery{
 		Kind:           pendingKindBlock,
-		BlockNumber:    data.Clock.Number,
+		BlockNumber:    clock.Number,
 		Payload:        wrappedOut,
-		FirstAttemptAt: time.Now(),
+		FirstAttemptAt: now,
 		Fingerprint:    s.fingerprint,
 	}
 	if cursor != nil {
 		pending.Cursor = cursor.String()
 	}
 
+	return s.send(ctx, pending)
+}
+
+// addToBatch appends the block to the open batch and flushes it when it is
+// full, when it waited long enough, or when the chain is live and holding the
+// block back would only add latency.
+func (s *Sink) addToBatch(ctx context.Context, moduleName, typeURL string, clock *pbsubstreams.Clock, dataContent json.RawMessage, cursor *sink.Cursor, live bool, now time.Time) error {
+	if s.batch == nil {
+		s.batch = &openBatch{payload: NewBatchPayload(moduleName, typeURL), openedAt: now}
+	}
+	s.batch.payload.Append(clock, dataContent)
+	s.batch.lastBlock = clock.Number
+	if cursor != nil {
+		s.batch.cursor = cursor.String()
+	}
+
+	full := len(s.batch.payload.Blocks) >= s.batchMaxBlocks
+	waited := now.Sub(s.batch.openedAt) >= s.batchMaxWait
+	if full || waited || live {
+		return s.flushBatch(ctx)
+	}
+	return nil
+}
+
+// flushBatch delivers the open batch as one call and closes it. The batch
+// is closed even when delivery fails: in exit mode it is on disk, in skip mode
+// it is dropped.
+func (s *Sink) flushBatch(ctx context.Context) error {
+	batch := s.batch
+	s.batch = nil
+
+	wrappedOut, err := batch.payload.ToJSON()
+	if err != nil {
+		return fmt.Errorf("failed to serialize batch payload: %w", err)
+	}
+
+	pending := &pendingDelivery{
+		Kind:           pendingKindBlock,
+		Batched:        true,
+		Cursor:         batch.cursor,
+		BlockNumber:    batch.lastBlock,
+		Payload:        wrappedOut,
+		FirstAttemptAt: time.Now(),
+		Fingerprint:    s.fingerprint,
+	}
+
+	s.logger.Debug("flushing batch", zap.Int("blocks", len(batch.payload.Blocks)), zap.Uint64("last_block", batch.lastBlock))
 	return s.send(ctx, pending)
 }
 
@@ -348,6 +463,14 @@ func (s *Sink) send(ctx context.Context, pending *pendingDelivery) error {
 // handleBlockUndoSignal moves the cursor back to the last valid block and, when
 // an undo URL is configured, tells the receiver which blocks are gone.
 func (s *Sink) handleBlockUndoSignal(ctx context.Context, undoSignal *pbsubstreamsrpc.BlockUndoSignal, cursor *sink.Cursor) error {
+	// The receiver must see the blocks before it is told some of them are
+	// gone, so an open batch goes out first.
+	if s.batch != nil {
+		if err := s.flushBatch(ctx); err != nil {
+			return err
+		}
+	}
+
 	if s.undoURL == "" {
 		if s.stateFile != "" && cursor != nil {
 			if err := sink.WriteCursor(s.stateFile, cursor); err != nil {


### PR DESCRIPTION
Five independent commits to `substreams sink webhook`, in review order:

1. **Auth header and HMAC signature.** `--webhook-auth-header-name` / `--webhook-auth-header-value-envvar` send a verbatim header; `--webhook-signing-secret-envvar` adds `X-Substreams-Signature: t=<unix>,v1=<hex>` over `<t>.<body>`. Secrets come from env vars so they never sit on the command line. `Client.Call` now returns a `*DeliveryError` with status and attempt count once retries run out.
2. **Resumable delivery.** `--webhook-on-failure=exit` writes the failed payload to `<state-file>.pending`, writes a JSON reason to `--webhook-termination-log` when that file exists, and exits with status 75. On the next start the pending payload is delivered before any Substreams stream is opened, so retrying against a dead endpoint costs no egress. The file is only written on failure: a kill mid-call leaves nothing behind, the cursor was not advanced, and the stream re-sends that block. A changed URL or secret resets `first_attempt_at`. Also exposes `substreams_sink_progress_block`.
3. **Sink library fix.** With `--undo-buffer-size`, an undo signal reaching below the buffer while nothing had been emitted yet was swallowed. That is what a restart from a cursor on a fork produces, so the previous run's forked blocks were never rolled back. The buffer now reports whether it absorbed the undo and the sinker forwards it to the handler otherwise. Affects every buffered sink, not just the webhook one.
4. **Reorg notifications.** `--webhook-undo-url` receives `{"lastValidBlock": {"number", "id"}, "manifest": {"moduleName"}}` per undo signal, with the same headers, retry, on-failure and pending-file rules as blocks. Opt-in; without it the cursor moves back and only replacement blocks are delivered, as before.
5. **Batching.** `--webhook-batch-max-blocks=N` switches every call to `{"manifest": {...}, "blocks": [{"clock", "data"}, ...]}` with up to N blocks. A batch is sent when full, when `--webhook-batch-max-wait` (1s) has passed and the next block arrives, when the chain is live, before an undo notification, and when the stream ends. A failed batch is kept and resumed as one payload. Toggling batching while the sink is stopped discards a pending payload of the other shape and lets the stream re-send its blocks. Off by default.

Not included: a receive-window cap on the Substreams client.

Design context: streamingfast/services-control-plane#61.