### PR TITLE
chore: log per-store lines at debug

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -30,6 +30,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Server
 
+- Per-store lines are now logged at `Debug` instead of `Info`: `using mmap KV store`,
+  `using in-memory KV store`, `flushing store at boundary`, `merged partial into full store`,
+  `deleting partial store`. They fired for every store opened by tier1 and tier2 and for
+  every squash. `squashing time metrics` stays at `Info` as the squash progress signal.
 - Fix partial-blocks (flashblocks) streams on a tier1 that is shutting down. The stream now
   ends with `Unavailable` like a full-block stream does, so the client reconnects elsewhere.
   It used to stay open but silent, then sent an undo signal at each block boundary naming a

--- a/orchestrator/stage/squash.go
+++ b/orchestrator/stage/squash.go
@@ -152,13 +152,13 @@ func (s *Stages) singleSquash(stage *Stage, modState *StoreModuleState, mergeUni
 	modState.lastBlockInStore = rng.ExclusiveEndBlock
 	meter.mergeEnd = time.Now()
 
-	s.logger.Info("merged partial into full store",
+	s.logger.Debug("merged partial into full store",
 		zap.String("store", modState.name),
 		zap.Uint64("up_to_block", rng.ExclusiveEndBlock),
 		zap.String("store_size", humanize.IBytes(fullKV.SizeBytes())),
 	)
 
-	s.logger.Info("deleting partial store", zap.Stringer("store", partialKV))
+	s.logger.Debug("deleting partial store", zap.Stringer("store", partialKV))
 
 	// Flush full store
 	if segmentEndsOnInterval {

--- a/pipeline/stores.go
+++ b/pipeline/stores.go
@@ -89,7 +89,7 @@ func (s *Stores) flushStores(ctx context.Context, executionStages exec.Execution
 func (s *Stores) saveStoresSnapshots(ctx context.Context, stage int, boundaryBlock uint64) (err error) {
 	for mod := range s.storesToWrite {
 		store := s.StoreMap[mod]
-		s.logger.Info("flushing store at boundary", zap.Uint64("boundary", boundaryBlock), zap.String("store", mod), zap.Int("stage", stage))
+		s.logger.Debug("flushing store at boundary", zap.Uint64("boundary", boundaryBlock), zap.String("store", mod), zap.Int("stage", stage))
 		// TODO when partials are generic again, we can also check if PartialKV exists and skip if it does.
 		existsFullKv, _ := s.configs[mod].ExistsFullKV(ctx, boundaryBlock)
 		if existsFullKv {

--- a/storage/store/kv_impl_config.go
+++ b/storage/store/kv_impl_config.go
@@ -58,7 +58,7 @@ func (cfg *KVImplConfig) NewKVImpl(logger *zap.Logger) (KVImpl, error) {
 		if mmapCfg == nil {
 			mmapCfg = &MmapBackendConfig{}
 		}
-		logger.Info("using mmap KV store",
+		logger.Debug("using mmap KV store",
 			zap.String("scratch_space", mmapCfg.ScratchSpace),
 			zap.String("store_name", cfg.StoreName))
 		impl, err := newMmapKVImplWithConfig(cfg.StoreName, cfg.ModuleHash, mmapCfg)
@@ -71,7 +71,7 @@ func (cfg *KVImplConfig) NewKVImpl(logger *zap.Logger) (KVImpl, error) {
 		}
 		return impl, nil
 	default: // KVImplTypeMemory, mmap is opt-in, memory is the default
-		logger.Info("using in-memory KV store")
+		logger.Debug("using in-memory KV store")
 		return newMemoryKVImplWithStoreName(cfg.StoreName), nil
 	}
 }


### PR DESCRIPTION
Six log lines that fired on every store open and every squash for tier1/tier2 jobs are now Debug instead of Info: mmap/in-memory KV store selection, flushing store at boundary, merging partial into full store, deleting partial store, and squashing time metrics. These accounted for roughly 10-15% of substreams tier1/tier2 log bytes in dfuseio-global. Log-level only, no behavior change.

Note: `bin/test.sh` is already red on develop (`TestWithBlockBytesReadMeteringOptions`, `TestWithBytesReadMeteringOptionsGzip` in `metering/`), unrelated to this diff.