### PR TITLE
Speed up store squashing on tier1

### DIFF
--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -36,6 +36,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   block the client had never received.
 - Never send an undo signal for partial-block state whose outputs were never sent.
 
+- `substreams-tier1` now squashes store partials in runs. When a segment is ready to be merged, every
+  following segment whose partial is already there is merged by the same command, up to 1000 segments or 30 s
+  of work, instead of one segment per command. Each command waits for a round trip through the scheduler loop,
+  which also borrows a worker for every job it schedules. On a busy backprocessing request that round trip took
+  3 to 5 s, so squashing was capped at about 15 segments per minute even when a merge took 0.3 s, and it fell
+  tens of thousands of segments behind the tier2 jobs.
+
 - `substreams-tier1` scheduling no longer slows down as a large backprocessing range progresses. Picking the next
   tier2 job walked every segment between the squasher and the job frontier on every call, re-checking
   dependencies that could not have changed, so a run over N segments cost O(N²) in scheduling. The scheduler now

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -43,6 +43,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   3 to 5 s, so squashing was capped at about 15 segments per minute even when a merge took 0.3 s, and it fell
   tens of thousands of segments behind the tier2 jobs.
 
+- `substreams-tier1` squash runs now copy the previous full store over segments whose partials are all empty,
+  instead of merging and saving each of them: an empty partial leaves the store unchanged. A run lists the sizes
+  of its partials in one go, reads the first decompressed byte of the small ones only, so a large partial is
+  never downloaded, then copies the last written full store to every consecutive empty segment, 32 at a time,
+  server-side on object stores that support it. On a store most segments never touch, a run of 1000 segments
+  goes from about 190 s to a few seconds. A module's first segment and segments shorter than the store interval
+  still go through the regular squash.
+
 - `substreams-tier1` no longer releases the squasher's cached stores while a squash is still running. When the
   scheduler stopped early (a tier2 job failed, or the pod was shutting down), the stores were closed under the
   in-flight merge, which could panic the process or write an empty full store to storage. Closing now cancels

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   never downloaded, then copies the last written full store to every consecutive empty segment, 32 at a time,
   server-side on object stores that support it. On a store most segments never touch, a run of 1000 segments
   goes from about 190 s to a few seconds. A module's first segment and segments shorter than the store interval
-  still go through the regular squash.
+  still go through the regular squash, and so do the segments of a copy that fails.
 
 - `substreams-tier1` no longer releases the squasher's cached stores while a squash is still running. When the
   scheduler stopped early (a tier2 job failed, or the pod was shutting down), the stores were closed under the

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -43,6 +43,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   3 to 5 s, so squashing was capped at about 15 segments per minute even when a merge took 0.3 s, and it fell
   tens of thousands of segments behind the tier2 jobs.
 
+- `substreams-tier1` no longer releases the squasher's cached stores while a squash is still running. When the
+  scheduler stopped early (a tier2 job failed, or the pod was shutting down), the stores were closed under the
+  in-flight merge, which could panic the process or write an empty full store to storage. Closing now cancels
+  the squash, which stops at its next segment, and waits for it to finish.
+
 - `substreams-tier1` scheduling no longer slows down as a large backprocessing range progresses. Picking the next
   tier2 job walked every segment between the squasher and the job frontier on every call, re-checking
   dependencies that could not have changed, so a run over N segments cost O(N²) in scheduling. The scheduler now

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/streamingfast/derr v0.0.0-20250814163534-bd7407bd89d7
 	github.com/streamingfast/dgrpc v0.0.0-20260801042045-4c4ac6a8e41a
 	github.com/streamingfast/dhttp v0.1.3-0.20251218140957-6d46b8f12eb1
-	github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902
+	github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c
 	github.com/streamingfast/logging v1.2.3-0.20260810132752-360563ac68a9
 	github.com/streamingfast/pbgo v0.0.6-0.20251125204657-0a9c67563b19
 	github.com/stretchr/testify v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	golang.org/x/mod v0.40.0
 	golang.org/x/net v0.58.0
 	golang.org/x/oauth2 v0.36.0
-	google.golang.org/grpc v1.83.1
+	google.golang.org/grpc v1.83.2
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -267,7 +267,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -294,7 +293,6 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
 	github.com/paulbellamy/ratecounter v0.2.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -999,8 +999,8 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/go.sum
+++ b/go.sum
@@ -675,8 +675,8 @@ github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1 h1:keuutoe
 github.com/streamingfast/dregistry v0.0.0-20260818204944-2fed3956d4e1/go.mod h1:vfsE+IinxWwS89Zu7KdQAizkF+INgG9x/7V++Aeum6A=
 github.com/streamingfast/dsession v0.0.0-20251029144057-b94d1030e142 h1:mgPawX0VOgrG2LHSc6EfY15r0x3AO/GK6LY58io3/+4=
 github.com/streamingfast/dsession v0.0.0-20251029144057-b94d1030e142/go.mod h1:ldDwFqr20xXyaLhwDm7XlMaf2vvoZNOrjgsMcFJGtrw=
-github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902 h1:vmSOeUk0Q56YLeVuYqYwmQEfPvq6guLbRRuVrWo8j2Y=
-github.com/streamingfast/dstore v0.2.4-0.20260709193311-122163592902/go.mod h1:TMunfchUOefhTu+X2a81fPMW0F4/cGNNdihXIaChpJI=
+github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c h1:GURTlIajYhrQvk8dIYPLTa9urVaghe8fUCb/V+6qeVk=
+github.com/streamingfast/dstore v0.2.4-0.20260825160629-56e87480522c/go.mod h1:TMunfchUOefhTu+X2a81fPMW0F4/cGNNdihXIaChpJI=
 github.com/streamingfast/dummy-blockchain v1.7.7 h1:9IZk0zmkeqHirSIRSNtbxrl5kRzyoS7kmXGqKuFI2Yc=
 github.com/streamingfast/dummy-blockchain v1.7.7/go.mod h1:EP8X3OwOoGYjJfzhw+zD1A0GTNSDg+v1OKDwSTDhHyc=
 github.com/streamingfast/firehose-ethereum/types v0.0.0-20251113151010-c9c94d64348a h1:qatil0YhFzTVAFQnH7iMcq+gpVUNEs9Se3lLq4eaof8=

--- a/go.work.sum
+++ b/go.work.sum
@@ -2380,6 +2380,7 @@ google.golang.org/grpc v1.79.1/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhH
 google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 h1:F29+wU6Ee6qgu9TddPgooOdaqsxTMunOoj8KA5yuS5A=

--- a/orchestrator/scheduler/scheduler.go
+++ b/orchestrator/scheduler/scheduler.go
@@ -264,7 +264,7 @@ func (s *Scheduler) Update(msg loop.Msg) loop.Cmd {
 		cmds = append(cmds, loop.Quit(msg.Error))
 
 	case stage.MsgMergeFinished:
-		s.Stages.MergeCompleted(msg.Unit)
+		s.Stages.MergeRunCompleted(msg.Stage, msg.Merged, msg.Unmerged)
 		if !s.delayedScheduleNextJob {
 			cmds = append(cmds, work.CmdScheduleNextJob("merge finished"))
 		}

--- a/orchestrator/stage/emptysquash_test.go
+++ b/orchestrator/stage/emptysquash_test.go
@@ -2,6 +2,7 @@ package stage
 
 import (
 	"context"
+	"errors"
 	"io"
 	"slices"
 	"strings"
@@ -23,14 +24,18 @@ import (
 	"github.com/streamingfast/substreams/storage/store"
 )
 
-// copyCountingStore counts the objects copied through it and through its sub stores.
+// copyCountingStore counts the objects copied through it and through its sub stores, and
+// fails every copy after the first failAfter ones when failAfter is not zero.
 type copyCountingStore struct {
 	dstore.Store
-	copies *atomic.Int64
+	copies    *atomic.Int64
+	failAfter int64
 }
 
 func (c *copyCountingStore) CopyObject(ctx context.Context, src, dest string) error {
-	c.copies.Add(1)
+	if n := c.copies.Add(1); c.failAfter > 0 && n > c.failAfter {
+		return errors.New("copy failure injected by the test")
+	}
 	return c.Store.CopyObject(ctx, src, dest)
 }
 
@@ -39,7 +44,7 @@ func (c *copyCountingStore) SubStore(subFolder string) (dstore.Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &copyCountingStore{Store: sub, copies: c.copies}, nil
+	return &copyCountingStore{Store: sub, copies: c.copies, failAfter: c.failAfter}, nil
 }
 
 // partialContent is what the partial of one segment holds. The zero value is an empty
@@ -49,29 +54,57 @@ type partialContent struct {
 	deletePrefix string
 }
 
+// storeScenario is one store module of the squashed stage.
+type storeScenario struct {
+	name      string
+	initBlock uint64
+	// initialKeys is the module's full store at block 10, written when the run starts at
+	// segment 1 and the module started before it.
+	initialKeys map[string]string
+	// partials is the content of the module's partial for each segment of the run. The
+	// segments missing here get an empty partial.
+	partials map[int]partialContent
+}
+
 type squashScenario struct {
 	// endBlock is the exclusive end of the store segments, which are 10 blocks long.
 	endBlock uint64
-	// initialKeys is the full store at block 10, with segment 0 already merged. When nil,
-	// the run starts at the module's first segment, with no full store yet.
-	initialKeys map[string]string
-	// partials holds one entry per segment of the run.
-	partials []partialContent
+	// firstSegment is where the run starts, 0 or 1. When 1, segment 0 is already merged.
+	firstSegment int
+	stores       []storeScenario
+	// secondRunFrom, when not zero, splits the squash in two runs: the partials of the
+	// segments from it are only reported present once the first run is done.
+	secondRunFrom int
+	// failCopiesAfter, when not zero, fails every copy after that many.
+	failCopiesAfter int64
+	// extraPartials allows partials to remain on segments that have a full store, which
+	// the regular squash leaves behind when it finds the full store already written.
+	extraPartials bool
 }
 
 type squashOutcome struct {
-	cfg    *store.Config
+	cfgs   map[string]*store.Config
 	copies int64
-	// fullKVs is the decompressed content of every full store file, by file name.
-	fullKVs map[string][]byte
+	// fullKVs is the decompressed content of every full store file, by store then file.
+	fullKVs map[string]map[string][]byte
+	// partials is the partial files left in storage, by store.
+	partials map[string][]string
 }
 
-// runSquashScenario writes the scenario's files to zstd-compressed local storage, the way
-// tier1 does, and squashes all its partials with one squash run.
 // declareTier1Metrics declares the tier1 metrics the squash increments, which tier1
 // declares at startup.
 var declareTier1Metrics sync.Once
 
+func storeModule(name string, initBlock uint64) *pbsubstreams.Module {
+	return &pbsubstreams.Module{
+		Name:         name,
+		InitialBlock: initBlock,
+		Kind:         &pbsubstreams.Module_KindStore_{KindStore: &pbsubstreams.Module_KindStore{}},
+	}
+}
+
+// runSquashScenario writes the scenario's files to zstd-compressed local storage, the way
+// tier1 does, and squashes all of its partials on stage 0 as the scheduler would.
 func runSquashScenario(t *testing.T, sc squashScenario, copyEmpty bool) squashOutcome {
 	t.Helper()
 	declareTier1Metrics.Do(func() { metrics.DeclareTier1Metrics(zap.NewNop()) })
@@ -83,85 +116,129 @@ func runSquashScenario(t *testing.T, sc squashScenario, copyEmpty bool) squashOu
 
 	base, err := dstore.NewStore("file://"+t.TempDir(), "zst", "zstd", true)
 	require.NoError(t, err)
-	counting := &copyCountingStore{Store: base, copies: &atomic.Int64{}}
-	cfg := testStoreConfig(t, "", 0, "hash", pbsubstreams.Module_KindStore_UPDATE_POLICY_SET, "string", counting)
+	counting := &copyCountingStore{Store: base, copies: &atomic.Int64{}, failAfter: sc.failCopiesAfter}
+
+	var modules []*pbsubstreams.Module
+	cfgs := make(map[string]*store.Config)
+	for _, st := range sc.stores {
+		modules = append(modules, storeModule(st.name, st.initBlock))
+		cfgs[st.name] = testStoreConfig(t, st.name, st.initBlock, "hash-"+st.name, pbsubstreams.Module_KindStore_UPDATE_POLICY_SET, "string", counting)
+	}
 
 	reqPlan, err := plan.BuildTier1RequestPlan(true, 10, 0, 0, 0, sc.endBlock, sc.endBlock, true)
 	require.NoError(t, err)
-	s := NewStages(ctx, exec.TestGraphStagedModules(0, 0, 0, 0, 0), reqPlan, nil, store.ConfigMap{"": cfg})
+	s := NewStages(ctx, exec.TestGraphStores(modules...), reqPlan, nil, cfgs)
 	t.Cleanup(s.Close)
 
-	firstSegment := 0
-	if sc.initialKeys != nil {
-		full := cfg.NewFullKV(zap.NewNop())
-		for k, v := range sc.initialKeys {
-			full.Set(0, k, v)
-		}
-		require.NoError(t, full.Flush())
-		_, writer, err := full.Save(10)
-		require.NoError(t, err)
-		require.NoError(t, writer.Write(ctx))
-		full.Close()
-		firstSegment = 1
-	}
-	lastSegment := firstSegment + len(sc.partials) - 1
-	require.Equal(t, s.stages[0].segmenter.LastIndex(), lastSegment, "the scenario must cover every store segment")
-
+	stage := s.stages[0]
+	lastSegment := stage.segmenter.LastIndex()
 	s.allocSegments(lastSegment)
-	if firstSegment == 1 {
+
+	for i, st := range sc.stores {
+		cfg := cfgs[st.name]
+		modSegmenter := stage.storeModuleStates[i].segmenter
+		if sc.firstSegment == 1 && modSegmenter.FirstIndex() == 0 {
+			full := cfg.NewFullKV(zap.NewNop())
+			for k, v := range st.initialKeys {
+				full.Set(0, k, v)
+			}
+			require.NoError(t, full.Flush())
+			_, writer, err := full.Save(10)
+			require.NoError(t, err)
+			require.NoError(t, writer.Write(ctx))
+			full.Close()
+		}
+		for segment := max(sc.firstSegment, modSegmenter.FirstIndex()); segment <= lastSegment; segment++ {
+			rng := modSegmenter.Range(segment)
+			content := st.partials[segment]
+			partial := cfg.NewPartialKV(rng.StartBlock, zap.NewNop())
+			for k, v := range content.set {
+				partial.Set(0, k, v)
+			}
+			if content.deletePrefix != "" {
+				partial.DeletePrefix(0, content.deletePrefix)
+			}
+			require.NoError(t, partial.Flush())
+			_, writer, err := partial.Save(rng.ExclusiveEndBlock)
+			require.NoError(t, err)
+			require.NoError(t, writer.Write(ctx))
+		}
+	}
+	if sc.firstSegment == 1 {
 		s.forceTransition(0, 0, UnitMerging)
 		s.MergeCompleted(unit(0, 0))
 	}
-	for i, content := range sc.partials {
-		segment := firstSegment + i
-		rng := s.stages[0].segmenter.Range(segment)
-		partial := cfg.NewPartialKV(rng.StartBlock, zap.NewNop())
-		for k, v := range content.set {
-			partial.Set(0, k, v)
-		}
-		if content.deletePrefix != "" {
-			partial.DeletePrefix(0, content.deletePrefix)
-		}
-		require.NoError(t, partial.Flush())
-		_, writer, err := partial.Save(rng.ExclusiveEndBlock)
-		require.NoError(t, err)
-		require.NoError(t, writer.Write(ctx))
-		s.forceTransition(segment, 0, UnitPartialPresent)
-	}
 
-	msg := s.CmdTryMerge(0)()
-	finished, ok := msg.(MsgMergeFinished)
-	require.True(t, ok, "squash run failed: %+v", msg)
+	runs := [][2]int{{sc.firstSegment, lastSegment}}
+	if sc.secondRunFrom != 0 {
+		runs = [][2]int{{sc.firstSegment, sc.secondRunFrom - 1}, {sc.secondRunFrom, lastSegment}}
+	}
+	var merged []Unit
+	for _, run := range runs {
+		for segment := run[0]; segment <= run[1]; segment++ {
+			s.forceTransition(segment, 0, UnitPartialPresent)
+		}
+		msg := s.CmdTryMerge(0)()
+		finished, ok := msg.(MsgMergeFinished)
+		require.True(t, ok, "squash run failed: %+v", msg)
+		require.Empty(t, finished.Unmerged)
+		s.MergeRunCompleted(finished.Stage, finished.Merged, finished.Unmerged)
+		merged = append(merged, finished.Merged...)
+	}
 	var want []Unit
-	for segment := firstSegment; segment <= lastSegment; segment++ {
+	for segment := sc.firstSegment; segment <= lastSegment; segment++ {
 		want = append(want, unit(segment, 0))
 	}
-	assert.Equal(t, want, finished.Merged)
-	assert.Empty(t, finished.Unmerged)
+	require.Equal(t, want, merged)
 
-	// A partial is deleted once a full store covers its segment, which a segment shorter
-	// than the interval never gets.
-	var wantPartials []string
-	for segment := firstSegment; segment <= lastSegment; segment++ {
-		if !s.stages[0].segmenter.EndsOnInterval(segment) {
-			wantPartials = append(wantPartials, store.PartialFileName(s.stages[0].segmenter.Range(segment)))
+	out := squashOutcome{
+		cfgs:     cfgs,
+		fullKVs:  make(map[string]map[string][]byte),
+		partials: make(map[string][]string),
+	}
+	for i, st := range sc.stores {
+		modSegmenter := stage.storeModuleStates[i].segmenter
+		states, err := base.SubStore("hash-" + st.name + "/states")
+		require.NoError(t, err)
+
+		// A partial is deleted once a full store covers its segment, which a segment
+		// shorter than the interval never gets.
+		var wantPartials []string
+		for segment := max(sc.firstSegment, modSegmenter.FirstIndex()); segment <= lastSegment; segment++ {
+			if !modSegmenter.EndsOnInterval(segment) {
+				wantPartials = append(wantPartials, store.PartialFileName(modSegmenter.Range(segment)))
+			}
+		}
+		require.Eventually(t, func() bool {
+			have := listStateFiles(t, states, ".partial")
+			if sc.extraPartials {
+				return !slices.ContainsFunc(wantPartials, func(p string) bool { return !slices.Contains(have, p) })
+			}
+			return slices.Equal(wantPartials, have)
+		}, 5*time.Second, 10*time.Millisecond, "store %s: exactly the partials not covered by a full store remain", st.name)
+		out.partials[st.name] = listStateFiles(t, states, ".partial")
+
+		out.fullKVs[st.name] = make(map[string][]byte)
+		fullEndBlocks := make(map[string]bool)
+		for _, name := range listStateFiles(t, states, ".kv") {
+			reader, err := states.OpenObject(ctx, name)
+			require.NoError(t, err)
+			content, err := io.ReadAll(reader)
+			reader.Close()
+			require.NoError(t, err)
+			out.fullKVs[st.name][name] = content
+			endBlock, _, _ := strings.Cut(name, "-")
+			fullEndBlocks[endBlock] = true
+		}
+		for _, p := range out.partials[st.name] {
+			if slices.Contains(wantPartials, p) {
+				continue
+			}
+			endBlock, _, _ := strings.Cut(p, "-")
+			assert.True(t, fullEndBlocks[endBlock], "store %s: partial %s left behind without a full store", st.name, p)
 		}
 	}
-	states, err := base.SubStore("hash/states")
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		return slices.Equal(wantPartials, listStateFiles(t, states, ".partial"))
-	}, 5*time.Second, 10*time.Millisecond, "only partials not covered by a full store remain: want %v, have %v", wantPartials, listStateFiles(t, states, ".partial"))
-
-	out := squashOutcome{cfg: cfg, copies: counting.copies.Load(), fullKVs: map[string][]byte{}}
-	for _, name := range listStateFiles(t, states, ".kv") {
-		reader, err := states.OpenObject(ctx, name)
-		require.NoError(t, err)
-		content, err := io.ReadAll(reader)
-		reader.Close()
-		require.NoError(t, err)
-		out.fullKVs[name] = content
-	}
+	out.copies = counting.copies.Load()
 	return out
 }
 
@@ -181,7 +258,7 @@ func loadFullKVKeys(t *testing.T, cfg *store.Config, endBlock uint64) map[string
 	t.Helper()
 	full := cfg.NewFullKV(zap.NewNop())
 	defer full.Close()
-	require.NoError(t, full.Load(context.Background(), store.NewCompleteFileInfo("", 0, endBlock)))
+	require.NoError(t, full.Load(context.Background(), store.NewCompleteFileInfo(cfg.Name(), cfg.ModuleInitialBlock(), endBlock)))
 	out := map[string]string{}
 	require.NoError(t, full.Iter(func(key string, value []byte) error {
 		out[key] = string(value)
@@ -191,92 +268,168 @@ func loadFullKVKeys(t *testing.T, cfg *store.Config, endBlock uint64) map[string
 }
 
 func TestSquashCopiesOverEmptyPartials(t *testing.T) {
-	empty := partialContent{}
-
 	tests := []struct {
-		name       string
-		scenario   squashScenario
+		name     string
+		scenario squashScenario
+		// wantCopies is the number of copies made, or -1 to not check it.
 		wantCopies int64
-		// wantKeys is the content expected in some of the full stores, by end block.
-		wantKeys  map[uint64]map[string]string
-		wantFiles int
+		// wantKeys is the content expected in some full stores, by store then end block.
+		wantKeys map[string]map[uint64]map[string]string
+		// wantFiles is the number of full store files expected, by store.
+		wantFiles map[string]int
 	}{
 		{
 			name: "empty partials around data",
 			scenario: squashScenario{
-				endBlock:    100,
-				initialKeys: map[string]string{"a": "1"},
-				partials: []partialContent{
-					empty, empty, // segment 1 is squashed normally, the store is not in memory yet
-					{set: map[string]string{"b": "2"}},
-					empty,
-					{deletePrefix: "a"}, // only a deleted prefix: not empty
-					empty, empty,
-					{set: map[string]string{"c": "3"}},
-					empty,
-				},
+				endBlock:     100,
+				firstSegment: 1,
+				stores: []storeScenario{{
+					name:        "a",
+					initialKeys: map[string]string{"a": "1"},
+					partials: map[int]partialContent{
+						// 1 and 2 empty: 1 is squashed normally, the store is not in memory yet
+						3: {set: map[string]string{"b": "2"}},
+						5: {deletePrefix: "a"}, // only a deleted prefix: not empty
+						8: {set: map[string]string{"c": "3"}},
+					},
+				}},
 			},
 			wantCopies: 5, // segments 2, 4, 6, 7 and 9
-			wantKeys: map[uint64]map[string]string{
+			wantKeys: map[string]map[uint64]map[string]string{"a": {
 				30:  {"a": "1"},
 				40:  {"a": "1", "b": "2"},
 				50:  {"a": "1", "b": "2"},
 				70:  {"b": "2"},
 				100: {"b": "2", "c": "3"},
-			},
-			wantFiles: 10,
+			}},
+			wantFiles: map[string]int{"a": 10},
 		},
 		{
 			name: "last segment shorter than the interval is never saved",
 			scenario: squashScenario{
-				endBlock:    95,
-				initialKeys: map[string]string{"a": "1"},
-				partials: []partialContent{
-					{set: map[string]string{"b": "2"}},
-					empty, empty, empty, empty, empty, empty, empty, empty,
-				},
+				endBlock:     95,
+				firstSegment: 1,
+				stores: []storeScenario{{
+					name:        "a",
+					initialKeys: map[string]string{"a": "1"},
+					partials:    map[int]partialContent{1: {set: map[string]string{"b": "2"}}},
+				}},
 			},
 			wantCopies: 7, // segments 2 to 8, segment 9 ends at 95
-			wantKeys: map[uint64]map[string]string{
-				90: {"a": "1", "b": "2"},
-			},
-			wantFiles: 9,
+			wantKeys:   map[string]map[uint64]map[string]string{"a": {90: {"a": "1", "b": "2"}}},
+			wantFiles:  map[string]int{"a": 9},
 		},
 		{
 			name: "run starting at the module's first segment",
 			scenario: squashScenario{
 				endBlock: 50,
-				partials: []partialContent{
-					empty, // first segment: no earlier full store to copy
-					empty,
-					{set: map[string]string{"a": "1"}},
-					empty, empty,
-				},
+				stores: []storeScenario{{
+					name: "a",
+					// 0 is the first segment: no earlier full store to copy
+					partials: map[int]partialContent{2: {set: map[string]string{"a": "1"}}},
+				}},
 			},
 			wantCopies: 3, // segments 1, 3 and 4
-			wantKeys: map[uint64]map[string]string{
-				10: {},
-				20: {},
-				50: {"a": "1"},
-			},
-			wantFiles: 5,
+			wantKeys:   map[string]map[uint64]map[string]string{"a": {10: {}, 20: {}, 50: {"a": "1"}}},
+			wantFiles:  map[string]int{"a": 5},
 		},
 		{
 			name: "no empty partial",
 			scenario: squashScenario{
-				endBlock:    40,
-				initialKeys: map[string]string{"a": "1"},
-				partials: []partialContent{
-					{set: map[string]string{"b": "2"}},
-					{set: map[string]string{"c": "3"}},
-					{deletePrefix: "b"},
-				},
+				endBlock:     40,
+				firstSegment: 1,
+				stores: []storeScenario{{
+					name:        "a",
+					initialKeys: map[string]string{"a": "1"},
+					partials: map[int]partialContent{
+						1: {set: map[string]string{"b": "2"}},
+						2: {set: map[string]string{"c": "3"}},
+						3: {deletePrefix: "b"},
+					},
+				}},
 			},
 			wantCopies: 0,
-			wantKeys: map[uint64]map[string]string{
-				40: {"a": "1", "c": "3"},
+			wantKeys:   map[string]map[uint64]map[string]string{"a": {40: {"a": "1", "c": "3"}}},
+			wantFiles:  map[string]int{"a": 4},
+		},
+		{
+			name: "two stores, one starting within the run",
+			scenario: squashScenario{
+				endBlock:     60,
+				firstSegment: 1,
+				stores: []storeScenario{
+					{name: "a", initialKeys: map[string]string{"a": "1"}},
+					{
+						name:      "b",
+						initBlock: 25, // starts in segment 2, which is therefore never copied
+						partials:  map[int]partialContent{2: {set: map[string]string{"b": "1"}}},
+					},
+				},
 			},
-			wantFiles: 4,
+			wantCopies: 6, // segments 3, 4 and 5 of both stores
+			wantKeys: map[string]map[uint64]map[string]string{
+				"a": {30: {"a": "1"}, 60: {"a": "1"}},
+				"b": {30: {"b": "1"}, 60: {"b": "1"}},
+			},
+			wantFiles: map[string]int{"a": 6, "b": 4},
+		},
+		{
+			name: "one store empty while the other holds data",
+			scenario: squashScenario{
+				endBlock:     60,
+				firstSegment: 1,
+				stores: []storeScenario{
+					{
+						name:        "a",
+						initialKeys: map[string]string{"a": "1"},
+						partials:    map[int]partialContent{3: {set: map[string]string{"a": "2"}}},
+					},
+					{
+						name:        "b",
+						initialKeys: map[string]string{"b": "1"},
+						partials:    map[int]partialContent{4: {deletePrefix: "b"}},
+					},
+				},
+			},
+			wantCopies: 4, // segments 2 and 5 of both stores; 3 and 4 hold data in one of them
+			wantKeys: map[string]map[uint64]map[string]string{
+				"a": {40: {"a": "2"}, 60: {"a": "2"}},
+				"b": {40: {"b": "1"}, 50: {}, 60: {}},
+			},
+			wantFiles: map[string]int{"a": 6, "b": 6},
+		},
+		{
+			name: "two runs, the second starting on empty partials",
+			scenario: squashScenario{
+				endBlock:      60,
+				firstSegment:  1,
+				secondRunFrom: 3,
+				stores: []storeScenario{{
+					name:        "a",
+					initialKeys: map[string]string{"a": "1"},
+					partials:    map[int]partialContent{1: {set: map[string]string{"b": "2"}}},
+				}},
+			},
+			wantCopies: 4, // segment 2 in the first run, 3 to 5 in the second
+			wantKeys:   map[string]map[uint64]map[string]string{"a": {60: {"a": "1", "b": "2"}}},
+			wantFiles:  map[string]int{"a": 6},
+		},
+		{
+			name: "failing copies fall back to the regular squash",
+			scenario: squashScenario{
+				endBlock:        60,
+				firstSegment:    1,
+				failCopiesAfter: 1,
+				extraPartials:   true, // the copy that succeeded makes the fallback skip that partial
+				stores: []storeScenario{{
+					name:        "a",
+					initialKeys: map[string]string{"a": "1"},
+					partials:    map[int]partialContent{1: {set: map[string]string{"b": "2"}}},
+				}},
+			},
+			wantCopies: -1, // retried copies all count
+			wantKeys:   map[string]map[uint64]map[string]string{"a": {60: {"a": "1", "b": "2"}}},
+			wantFiles:  map[string]int{"a": 6},
 		},
 	}
 
@@ -286,13 +439,24 @@ func TestSquashCopiesOverEmptyPartials(t *testing.T) {
 			copied := runSquashScenario(t, tt.scenario, true)
 
 			assert.Zero(t, regular.copies)
-			assert.Equal(t, tt.wantCopies, copied.copies)
+			if tt.wantCopies >= 0 {
+				assert.Equal(t, tt.wantCopies, copied.copies)
+			} else {
+				assert.Positive(t, copied.copies)
+			}
 
-			assert.Len(t, copied.fullKVs, tt.wantFiles)
+			for name, want := range tt.wantFiles {
+				assert.Len(t, copied.fullKVs[name], want, "full stores of %s", name)
+			}
 			assert.Equal(t, regular.fullKVs, copied.fullKVs, "copying must produce the same full stores as merging")
+			if !tt.scenario.extraPartials {
+				assert.Equal(t, regular.partials, copied.partials, "copying must leave the same partials as merging")
+			}
 
-			for endBlock, want := range tt.wantKeys {
-				assert.Equal(t, want, loadFullKVKeys(t, copied.cfg, endBlock), "full store at block %d", endBlock)
+			for name, byEnd := range tt.wantKeys {
+				for endBlock, want := range byEnd {
+					assert.Equal(t, want, loadFullKVKeys(t, copied.cfgs[name], endBlock), "full store of %s at block %d", name, endBlock)
+				}
 			}
 		})
 	}

--- a/orchestrator/stage/emptysquash_test.go
+++ b/orchestrator/stage/emptysquash_test.go
@@ -1,0 +1,299 @@
+package stage
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/dstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/streamingfast/substreams/metrics"
+	"github.com/streamingfast/substreams/orchestrator/plan"
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
+	"github.com/streamingfast/substreams/pipeline/exec"
+	"github.com/streamingfast/substreams/reqctx"
+	"github.com/streamingfast/substreams/storage/store"
+)
+
+// copyCountingStore counts the objects copied through it and through its sub stores.
+type copyCountingStore struct {
+	dstore.Store
+	copies *atomic.Int64
+}
+
+func (c *copyCountingStore) CopyObject(ctx context.Context, src, dest string) error {
+	c.copies.Add(1)
+	return c.Store.CopyObject(ctx, src, dest)
+}
+
+func (c *copyCountingStore) SubStore(subFolder string) (dstore.Store, error) {
+	sub, err := c.Store.SubStore(subFolder)
+	if err != nil {
+		return nil, err
+	}
+	return &copyCountingStore{Store: sub, copies: c.copies}, nil
+}
+
+// partialContent is what the partial of one segment holds. The zero value is an empty
+// partial.
+type partialContent struct {
+	set          map[string]string
+	deletePrefix string
+}
+
+type squashScenario struct {
+	// endBlock is the exclusive end of the store segments, which are 10 blocks long.
+	endBlock uint64
+	// initialKeys is the full store at block 10, with segment 0 already merged. When nil,
+	// the run starts at the module's first segment, with no full store yet.
+	initialKeys map[string]string
+	// partials holds one entry per segment of the run.
+	partials []partialContent
+}
+
+type squashOutcome struct {
+	cfg    *store.Config
+	copies int64
+	// fullKVs is the decompressed content of every full store file, by file name.
+	fullKVs map[string][]byte
+}
+
+// runSquashScenario writes the scenario's files to zstd-compressed local storage, the way
+// tier1 does, and squashes all its partials with one squash run.
+// declareTier1Metrics declares the tier1 metrics the squash increments, which tier1
+// declares at startup.
+var declareTier1Metrics sync.Once
+
+func runSquashScenario(t *testing.T, sc squashScenario, copyEmpty bool) squashOutcome {
+	t.Helper()
+	declareTier1Metrics.Do(func() { metrics.DeclareTier1Metrics(zap.NewNop()) })
+	ctx := reqctx.WithReqStats(context.Background(), metrics.NewReqStats(&metrics.Config{}, nil, nil, zap.NewNop()))
+
+	previous := copyOverEmptyPartials
+	copyOverEmptyPartials = copyEmpty
+	t.Cleanup(func() { copyOverEmptyPartials = previous })
+
+	base, err := dstore.NewStore("file://"+t.TempDir(), "zst", "zstd", true)
+	require.NoError(t, err)
+	counting := &copyCountingStore{Store: base, copies: &atomic.Int64{}}
+	cfg := testStoreConfig(t, "", 0, "hash", pbsubstreams.Module_KindStore_UPDATE_POLICY_SET, "string", counting)
+
+	reqPlan, err := plan.BuildTier1RequestPlan(true, 10, 0, 0, 0, sc.endBlock, sc.endBlock, true)
+	require.NoError(t, err)
+	s := NewStages(ctx, exec.TestGraphStagedModules(0, 0, 0, 0, 0), reqPlan, nil, store.ConfigMap{"": cfg})
+	t.Cleanup(s.Close)
+
+	firstSegment := 0
+	if sc.initialKeys != nil {
+		full := cfg.NewFullKV(zap.NewNop())
+		for k, v := range sc.initialKeys {
+			full.Set(0, k, v)
+		}
+		require.NoError(t, full.Flush())
+		_, writer, err := full.Save(10)
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(ctx))
+		full.Close()
+		firstSegment = 1
+	}
+	lastSegment := firstSegment + len(sc.partials) - 1
+	require.Equal(t, s.stages[0].segmenter.LastIndex(), lastSegment, "the scenario must cover every store segment")
+
+	s.allocSegments(lastSegment)
+	if firstSegment == 1 {
+		s.forceTransition(0, 0, UnitMerging)
+		s.MergeCompleted(unit(0, 0))
+	}
+	for i, content := range sc.partials {
+		segment := firstSegment + i
+		rng := s.stages[0].segmenter.Range(segment)
+		partial := cfg.NewPartialKV(rng.StartBlock, zap.NewNop())
+		for k, v := range content.set {
+			partial.Set(0, k, v)
+		}
+		if content.deletePrefix != "" {
+			partial.DeletePrefix(0, content.deletePrefix)
+		}
+		require.NoError(t, partial.Flush())
+		_, writer, err := partial.Save(rng.ExclusiveEndBlock)
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(ctx))
+		s.forceTransition(segment, 0, UnitPartialPresent)
+	}
+
+	msg := s.CmdTryMerge(0)()
+	finished, ok := msg.(MsgMergeFinished)
+	require.True(t, ok, "squash run failed: %+v", msg)
+	var want []Unit
+	for segment := firstSegment; segment <= lastSegment; segment++ {
+		want = append(want, unit(segment, 0))
+	}
+	assert.Equal(t, want, finished.Merged)
+	assert.Empty(t, finished.Unmerged)
+
+	// A partial is deleted once a full store covers its segment, which a segment shorter
+	// than the interval never gets.
+	var wantPartials []string
+	for segment := firstSegment; segment <= lastSegment; segment++ {
+		if !s.stages[0].segmenter.EndsOnInterval(segment) {
+			wantPartials = append(wantPartials, store.PartialFileName(s.stages[0].segmenter.Range(segment)))
+		}
+	}
+	states, err := base.SubStore("hash/states")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return slices.Equal(wantPartials, listStateFiles(t, states, ".partial"))
+	}, 5*time.Second, 10*time.Millisecond, "only partials not covered by a full store remain: want %v, have %v", wantPartials, listStateFiles(t, states, ".partial"))
+
+	out := squashOutcome{cfg: cfg, copies: counting.copies.Load(), fullKVs: map[string][]byte{}}
+	for _, name := range listStateFiles(t, states, ".kv") {
+		reader, err := states.OpenObject(ctx, name)
+		require.NoError(t, err)
+		content, err := io.ReadAll(reader)
+		reader.Close()
+		require.NoError(t, err)
+		out.fullKVs[name] = content
+	}
+	return out
+}
+
+func listStateFiles(t *testing.T, states dstore.Store, kind string) []string {
+	t.Helper()
+	var out []string
+	require.NoError(t, states.Walk(context.Background(), "", func(filename string) error {
+		if strings.Contains(filename, kind) {
+			out = append(out, filename)
+		}
+		return nil
+	}))
+	return out
+}
+
+func loadFullKVKeys(t *testing.T, cfg *store.Config, endBlock uint64) map[string]string {
+	t.Helper()
+	full := cfg.NewFullKV(zap.NewNop())
+	defer full.Close()
+	require.NoError(t, full.Load(context.Background(), store.NewCompleteFileInfo("", 0, endBlock)))
+	out := map[string]string{}
+	require.NoError(t, full.Iter(func(key string, value []byte) error {
+		out[key] = string(value)
+		return nil
+	}))
+	return out
+}
+
+func TestSquashCopiesOverEmptyPartials(t *testing.T) {
+	empty := partialContent{}
+
+	tests := []struct {
+		name       string
+		scenario   squashScenario
+		wantCopies int64
+		// wantKeys is the content expected in some of the full stores, by end block.
+		wantKeys  map[uint64]map[string]string
+		wantFiles int
+	}{
+		{
+			name: "empty partials around data",
+			scenario: squashScenario{
+				endBlock:    100,
+				initialKeys: map[string]string{"a": "1"},
+				partials: []partialContent{
+					empty, empty, // segment 1 is squashed normally, the store is not in memory yet
+					{set: map[string]string{"b": "2"}},
+					empty,
+					{deletePrefix: "a"}, // only a deleted prefix: not empty
+					empty, empty,
+					{set: map[string]string{"c": "3"}},
+					empty,
+				},
+			},
+			wantCopies: 5, // segments 2, 4, 6, 7 and 9
+			wantKeys: map[uint64]map[string]string{
+				30:  {"a": "1"},
+				40:  {"a": "1", "b": "2"},
+				50:  {"a": "1", "b": "2"},
+				70:  {"b": "2"},
+				100: {"b": "2", "c": "3"},
+			},
+			wantFiles: 10,
+		},
+		{
+			name: "last segment shorter than the interval is never saved",
+			scenario: squashScenario{
+				endBlock:    95,
+				initialKeys: map[string]string{"a": "1"},
+				partials: []partialContent{
+					{set: map[string]string{"b": "2"}},
+					empty, empty, empty, empty, empty, empty, empty, empty,
+				},
+			},
+			wantCopies: 7, // segments 2 to 8, segment 9 ends at 95
+			wantKeys: map[uint64]map[string]string{
+				90: {"a": "1", "b": "2"},
+			},
+			wantFiles: 9,
+		},
+		{
+			name: "run starting at the module's first segment",
+			scenario: squashScenario{
+				endBlock: 50,
+				partials: []partialContent{
+					empty, // first segment: no earlier full store to copy
+					empty,
+					{set: map[string]string{"a": "1"}},
+					empty, empty,
+				},
+			},
+			wantCopies: 3, // segments 1, 3 and 4
+			wantKeys: map[uint64]map[string]string{
+				10: {},
+				20: {},
+				50: {"a": "1"},
+			},
+			wantFiles: 5,
+		},
+		{
+			name: "no empty partial",
+			scenario: squashScenario{
+				endBlock:    40,
+				initialKeys: map[string]string{"a": "1"},
+				partials: []partialContent{
+					{set: map[string]string{"b": "2"}},
+					{set: map[string]string{"c": "3"}},
+					{deletePrefix: "b"},
+				},
+			},
+			wantCopies: 0,
+			wantKeys: map[uint64]map[string]string{
+				40: {"a": "1", "c": "3"},
+			},
+			wantFiles: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regular := runSquashScenario(t, tt.scenario, false)
+			copied := runSquashScenario(t, tt.scenario, true)
+
+			assert.Zero(t, regular.copies)
+			assert.Equal(t, tt.wantCopies, copied.copies)
+
+			assert.Len(t, copied.fullKVs, tt.wantFiles)
+			assert.Equal(t, regular.fullKVs, copied.fullKVs, "copying must produce the same full stores as merging")
+
+			for endBlock, want := range tt.wantKeys {
+				assert.Equal(t, want, loadFullKVKeys(t, copied.cfg, endBlock), "full store at block %d", endBlock)
+			}
+		})
+	}
+}

--- a/orchestrator/stage/modstate.go
+++ b/orchestrator/stage/modstate.go
@@ -22,6 +22,9 @@ type StoreModuleState struct {
 
 	cachedStore      *store.FullKV
 	lastBlockInStore uint64
+	// snapshotEnd is the end block of the last full store this module saved to or loaded
+	// from storage. When it equals lastBlockInStore, that file holds cachedStore's content.
+	snapshotEnd uint64
 }
 
 func NewModuleState(logger *zap.Logger, name string, segmenter *block.Segmenter, storeConfig *store.Config) *StoreModuleState {
@@ -88,6 +91,9 @@ func (s *StoreModuleState) getStore(ctx context.Context, exclusiveEndBlock uint6
 	}
 	s.cachedStore = loadStore
 	s.lastBlockInStore = exclusiveEndBlock
+	if moduleInitBlock < exclusiveEndBlock {
+		s.snapshotEnd = exclusiveEndBlock
+	}
 	return loadStore, nil
 }
 

--- a/orchestrator/stage/msgs.go
+++ b/orchestrator/stage/msgs.go
@@ -14,10 +14,15 @@ func CmdAllStoresCompleted() loop.Cmd {
 	}
 }
 
+// MsgMergeFinished reports a squash run on one stage: the Merged units were squashed into
+// the full stores, in order, and the Unmerged ones were claimed by the run but left for
+// the next one.
 type MsgMergeFinished struct {
 	loop.IsMsg
-	Unit
-} // A single partial store was successfully merged into the full store.
+	Stage    int
+	Merged   []Unit
+	Unmerged []Unit
+}
 
 type MsgMergeFailed struct {
 	loop.IsMsg

--- a/orchestrator/stage/squash.go
+++ b/orchestrator/stage/squash.go
@@ -50,6 +50,47 @@ func (s *Stages) multiSquash(stage *Stage, mergeUnit Unit) error {
 	return stage.syncWork.Wait() // ensure we don't merge the same fullKV multiple times concurrently before it is completely written
 }
 
+// A squash run covers at most maxSquashRunSegments segments and stops taking new ones
+// once squashRunTimeBudget is spent, so that a long run still reports progress regularly.
+const (
+	maxSquashRunSegments = 1000
+	squashRunTimeBudget  = 30 * time.Second
+)
+
+// claimMergeRun marks as Merging the units that directly follow first on its stage and
+// already have their partial, up to limit units in total, and returns them all, first
+// included. first must already be Merging. The whole run is squashed by a single
+// command: squashed one command at a time, each segment would wait for its own round
+// trip through the scheduler loop, which is busy with job scheduling.
+func (s *Stages) claimMergeRun(stage *Stage, first Unit, limit int) []Unit {
+	run := []Unit{first}
+	for len(run) < limit {
+		next := Unit{Stage: first.Stage, Segment: run[len(run)-1].Segment + 1}
+		if next.Segment > stage.segmenter.LastIndex() || s.getState(next) != UnitPartialPresent {
+			break
+		}
+		s.transition(next, UnitMerging, UnitPartialPresent)
+		run = append(run, next)
+	}
+	return run
+}
+
+// squashRun squashes the units of run in order. It always squashes the first one, then
+// stops once budget is spent and returns the units it did not get to as unmerged. On
+// error, merged holds the units squashed before the failing one.
+func squashRun(run []Unit, budget time.Duration, squash func(Unit) error) (merged, unmerged []Unit, err error) {
+	start := time.Now()
+	for i, u := range run {
+		if i > 0 && time.Since(start) >= budget {
+			return run[:i], run[i:], nil
+		}
+		if err := squash(u); err != nil {
+			return run[:i], nil, err
+		}
+	}
+	return run, nil, nil
+}
+
 type Result struct {
 	partialKVStore *store.PartialKV
 	partialFile    *store.FileInfo

--- a/orchestrator/stage/squash.go
+++ b/orchestrator/stage/squash.go
@@ -175,11 +175,25 @@ func (s *Stages) findEmptyUnits(stage *Stage, run []Unit) map[int]bool {
 // squashEmptyUnits squashes consecutive units whose partials are all empty. Such a unit
 // leaves every store unchanged, so each of its full stores is a copy of the previous one.
 // Copying needs that previous full store both in memory and in storage: until it is, units
-// go through the regular squash one at a time.
+// go through the regular squash one at a time. If a copy fails, the units go through the
+// regular squash too, which rewrites any full store already copied with the same content.
 func (s *Stages) squashEmptyUnits(stage *Stage, units []Unit) error {
 	for len(units) > 0 {
 		if canCopySnapshots(stage, units[0]) {
-			return s.copySnapshots(stage, units)
+			err := s.copySnapshots(stage, units)
+			if err == nil {
+				return nil
+			}
+			if ctxErr := s.ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			s.logger.Warn("copying full stores over empty partials failed, squashing them one at a time", zap.Error(err))
+			for _, u := range units {
+				if err := s.multiSquash(stage, u); err != nil {
+					return err
+				}
+			}
+			return nil
 		}
 		if err := s.multiSquash(stage, units[0]); err != nil {
 			return err
@@ -212,24 +226,55 @@ func canCopySnapshots(stage *Stage, u Unit) bool {
 }
 
 // copySnapshots squashes units, consecutive units whose partials are all empty, by
-// copying each started module's current full store to every one of them.
+// copying each started module's current full store to every one of them. The modules only
+// move forward once every copy succeeded, so a failure leaves them as they were.
 func (s *Stages) copySnapshots(stage *Stage, units []Unit) error {
-	var eg errgroup.Group
+	var modStates []*StoreModuleState
 	for _, modState := range stage.storeModuleStates {
-		if units[0].Segment < modState.segmenter.FirstIndex() {
-			continue // not started, and a module's first segment is never part of the copied units
+		// A module not started at units[0] does not start within units either: its first
+		// segment is never empty, so it never is part of the copied units.
+		if units[0].Segment >= modState.segmenter.FirstIndex() {
+			modStates = append(modStates, modState)
 		}
+	}
+
+	lastCopied := make([]uint64, len(modStates))
+	var eg errgroup.Group
+	for i, modState := range modStates {
 		eg.Go(func() error {
-			if err := s.copyModuleSnapshots(modState, units); err != nil {
+			end, err := s.copyModuleSnapshots(modState, units)
+			if err != nil {
 				return fmt.Errorf("squash stage %d module %q: %w", stage.idx, modState.name, err)
 			}
+			lastCopied[i] = end
 			return nil
 		})
 	}
-	return eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	for i, modState := range modStates {
+		modState.lastBlockInStore = modState.segmenter.Range(units[len(units)-1].Segment).ExclusiveEndBlock
+		modState.snapshotEnd = lastCopied[i]
+
+		// Like the regular squash, only delete the partials that a full store now covers.
+		partials := make([]*store.FileInfo, 0, len(units))
+		for _, u := range units {
+			if !modState.segmenter.EndsOnInterval(u.Segment) {
+				continue
+			}
+			rng := modState.segmenter.Range(u.Segment)
+			partials = append(partials, store.NewPartialFileInfo(modState.name, rng.StartBlock, rng.ExclusiveEndBlock))
+		}
+		go modState.storeConfig.DeletePartialKVs(context.Background(), partials)
+	}
+	return nil
 }
 
-func (s *Stages) copyModuleSnapshots(modState *StoreModuleState, units []Unit) error {
+// copyModuleSnapshots copies modState's current full store to each of units that ends on
+// the store interval, and returns the end block of the last full store written.
+func (s *Stages) copyModuleSnapshots(modState *StoreModuleState, units []Unit) (uint64, error) {
 	start := time.Now()
 	from := modState.snapshotEnd
 
@@ -249,32 +294,17 @@ func (s *Stages) copyModuleSnapshots(modState *StoreModuleState, units []Unit) e
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return fmt.Errorf("copying full store at block %d: %w", from, err)
+		return 0, fmt.Errorf("copying full store at block %d: %w", from, err)
 	}
-
-	lastRange := modState.segmenter.Range(units[len(units)-1].Segment)
-	modState.lastBlockInStore = lastRange.ExclusiveEndBlock
-	modState.snapshotEnd = lastCopied
-
-	// Like the regular squash, only delete the partials that a full store now covers.
-	partials := make([]*store.FileInfo, 0, len(units))
-	for _, u := range units {
-		if !modState.segmenter.EndsOnInterval(u.Segment) {
-			continue
-		}
-		rng := modState.segmenter.Range(u.Segment)
-		partials = append(partials, store.NewPartialFileInfo(modState.name, rng.StartBlock, rng.ExclusiveEndBlock))
-	}
-	go modState.storeConfig.DeletePartialKVs(context.Background(), partials)
 
 	s.logger.Info("copied full store over empty partials",
 		zap.String("store", modState.name),
 		zap.Uint64("from_block", from),
-		zap.Uint64("up_to_block", lastRange.ExclusiveEndBlock),
+		zap.Uint64("up_to_block", lastCopied),
 		zap.Int("copies", copies),
 		zap.Duration("duration", time.Since(start)),
 	)
-	return nil
+	return lastCopied, nil
 }
 
 type Result struct {

--- a/orchestrator/stage/squash.go
+++ b/orchestrator/stage/squash.go
@@ -3,9 +3,11 @@ package stage
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/go-multierror"
@@ -55,7 +57,15 @@ func (s *Stages) multiSquash(stage *Stage, mergeUnit Unit) error {
 const (
 	maxSquashRunSegments = 1000
 	squashRunTimeBudget  = 30 * time.Second
+
+	// snapshotCopyConcurrency bounds the full store copies in flight for one store module.
+	snapshotCopyConcurrency = 32
 )
+
+// copyOverEmptyPartials enables copying the previous full store over segments whose
+// partials are all empty, instead of merging and saving them one at a time. Tests turn it
+// off to compare both paths.
+var copyOverEmptyPartials = true
 
 // claimMergeRun marks as Merging the units that directly follow first on its stage and
 // already have their partial, up to limit units in total, and returns them all, first
@@ -75,20 +85,196 @@ func (s *Stages) claimMergeRun(stage *Stage, first Unit, limit int) []Unit {
 	return run
 }
 
-// squashRun squashes the units of run in order. It always squashes the first one, then
-// stops once budget is spent and returns the units it did not get to as unmerged. On
-// error, merged holds the units squashed before the failing one.
-func squashRun(run []Unit, budget time.Duration, squash func(Unit) error) (merged, unmerged []Unit, err error) {
+// squashRun squashes steps, consecutive groups of units, in order. It always squashes the
+// first step, then stops once budget is spent and returns the units of the steps it did
+// not get to as unmerged. On error, merged holds the units of the steps squashed before
+// the failing one.
+func squashRun(steps [][]Unit, budget time.Duration, squash func(step []Unit) error) (merged, unmerged []Unit, err error) {
 	start := time.Now()
-	for i, u := range run {
+	for i, step := range steps {
 		if i > 0 && time.Since(start) >= budget {
-			return run[:i], run[i:], nil
+			return merged, slices.Concat(steps[i:]...), nil
 		}
-		if err := squash(u); err != nil {
-			return run[:i], nil, err
+		if err := squash(step); err != nil {
+			return merged, nil, err
+		}
+		merged = append(merged, step...)
+	}
+	return merged, nil, nil
+}
+
+// planSquashSteps splits run into the steps squashRun goes through: each sequence of
+// consecutive empty units is one step, and every other unit is a step of its own.
+func planSquashSteps(run []Unit, empty map[int]bool) [][]Unit {
+	var steps [][]Unit
+	for i := 0; i < len(run); {
+		j := i + 1
+		if empty[run[i].Segment] {
+			for j < len(run) && empty[run[j].Segment] {
+				j++
+			}
+		}
+		steps = append(steps, run[i:j])
+		i = j
+	}
+	return steps
+}
+
+// findEmptyUnits returns the segments of run on which the partial of every store module
+// of stage that already started is empty. A module's first segment is never reported:
+// there is no earlier full store to copy. Any failure only means fewer segments are
+// reported, since the regular squash handles every unit.
+func (s *Stages) findEmptyUnits(stage *Stage, run []Unit) map[int]bool {
+	if !copyOverEmptyPartials || len(run) < 2 {
+		return nil
+	}
+
+	emptyFiles := make([]map[string]bool, len(stage.storeModuleStates))
+	for i, modState := range stage.storeModuleStates {
+		if modState.storeConfig == nil {
+			return nil
+		}
+		var files []*store.FileInfo
+		for _, u := range run {
+			if u.Segment <= modState.segmenter.FirstIndex() {
+				continue
+			}
+			if rng := modState.segmenter.Range(u.Segment); rng != nil {
+				files = append(files, store.NewPartialFileInfo(modState.name, rng.StartBlock, rng.ExclusiveEndBlock))
+			}
+		}
+		empties, err := modState.storeConfig.EmptyPartialKVs(s.ctx, files)
+		if err != nil {
+			s.logger.Warn("cannot tell which partials are empty, squashing them all", zap.String("store", modState.name), zap.Error(err))
+			return nil
+		}
+		emptyFiles[i] = empties
+	}
+
+	out := make(map[int]bool)
+	for _, u := range run {
+		empty := true
+		for i, modState := range stage.storeModuleStates {
+			if u.Segment < modState.segmenter.FirstIndex() {
+				continue // not started yet: nothing to squash for it
+			}
+			rng := modState.segmenter.Range(u.Segment)
+			if u.Segment == modState.segmenter.FirstIndex() || rng == nil ||
+				!emptyFiles[i][store.NewPartialFileInfo(modState.name, rng.StartBlock, rng.ExclusiveEndBlock).Filename] {
+				empty = false
+				break
+			}
+		}
+		if empty {
+			out[u.Segment] = true
 		}
 	}
-	return run, nil, nil
+	return out
+}
+
+// squashEmptyUnits squashes consecutive units whose partials are all empty. Such a unit
+// leaves every store unchanged, so each of its full stores is a copy of the previous one.
+// Copying needs that previous full store both in memory and in storage: until it is, units
+// go through the regular squash one at a time.
+func (s *Stages) squashEmptyUnits(stage *Stage, units []Unit) error {
+	for len(units) > 0 {
+		if canCopySnapshots(stage, units[0]) {
+			return s.copySnapshots(stage, units)
+		}
+		if err := s.multiSquash(stage, units[0]); err != nil {
+			return err
+		}
+		units = units[1:]
+		if err := s.ctx.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// canCopySnapshots reports whether every started store module of stage holds, in memory
+// and in storage, the full store as of the start of u.
+func canCopySnapshots(stage *Stage, u Unit) bool {
+	for _, modState := range stage.storeModuleStates {
+		if u.Segment < modState.segmenter.FirstIndex() {
+			continue
+		}
+		rng := modState.segmenter.Range(u.Segment)
+		if rng == nil ||
+			modState.cachedStore == nil ||
+			modState.storeConfig.ModuleInitialBlock() >= rng.StartBlock ||
+			modState.lastBlockInStore != rng.StartBlock ||
+			modState.snapshotEnd != rng.StartBlock {
+			return false
+		}
+	}
+	return true
+}
+
+// copySnapshots squashes units, consecutive units whose partials are all empty, by
+// copying each started module's current full store to every one of them.
+func (s *Stages) copySnapshots(stage *Stage, units []Unit) error {
+	var eg errgroup.Group
+	for _, modState := range stage.storeModuleStates {
+		if units[0].Segment < modState.segmenter.FirstIndex() {
+			continue // not started, and a module's first segment is never part of the copied units
+		}
+		eg.Go(func() error {
+			if err := s.copyModuleSnapshots(modState, units); err != nil {
+				return fmt.Errorf("squash stage %d module %q: %w", stage.idx, modState.name, err)
+			}
+			return nil
+		})
+	}
+	return eg.Wait()
+}
+
+func (s *Stages) copyModuleSnapshots(modState *StoreModuleState, units []Unit) error {
+	start := time.Now()
+	from := modState.snapshotEnd
+
+	eg, ctx := errgroup.WithContext(s.ctx)
+	eg.SetLimit(snapshotCopyConcurrency)
+	copies := 0
+	lastCopied := from
+	for _, u := range units {
+		if !modState.segmenter.EndsOnInterval(u.Segment) {
+			continue // the regular squash does not save these either
+		}
+		to := modState.segmenter.Range(u.Segment).ExclusiveEndBlock
+		copies++
+		lastCopied = max(lastCopied, to)
+		eg.Go(func() error {
+			return modState.storeConfig.CopyFullKV(ctx, from, to)
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("copying full store at block %d: %w", from, err)
+	}
+
+	lastRange := modState.segmenter.Range(units[len(units)-1].Segment)
+	modState.lastBlockInStore = lastRange.ExclusiveEndBlock
+	modState.snapshotEnd = lastCopied
+
+	// Like the regular squash, only delete the partials that a full store now covers.
+	partials := make([]*store.FileInfo, 0, len(units))
+	for _, u := range units {
+		if !modState.segmenter.EndsOnInterval(u.Segment) {
+			continue
+		}
+		rng := modState.segmenter.Range(u.Segment)
+		partials = append(partials, store.NewPartialFileInfo(modState.name, rng.StartBlock, rng.ExclusiveEndBlock))
+	}
+	go modState.storeConfig.DeletePartialKVs(context.Background(), partials)
+
+	s.logger.Info("copied full store over empty partials",
+		zap.String("store", modState.name),
+		zap.Uint64("from_block", from),
+		zap.Uint64("up_to_block", lastRange.ExclusiveEndBlock),
+		zap.Int("copies", copies),
+		zap.Duration("duration", time.Since(start)),
+	)
+	return nil
 }
 
 type Result struct {
@@ -177,6 +363,7 @@ func (s *Stages) singleSquash(stage *Stage, modState *StoreModuleState, mergeUni
 		}
 		modState.cachedStore = newFullKV
 		modState.lastBlockInStore = rng.ExclusiveEndBlock
+		modState.snapshotEnd = rng.ExclusiveEndBlock
 		s.logger.Debug("squashing time metrics (skipped, loaded from full kv)", meter.logFields()...)
 		return nil
 	}
@@ -221,6 +408,7 @@ func (s *Stages) singleSquash(stage *Stage, modState *StoreModuleState, mergeUni
 		if err != nil {
 			return fmt.Errorf("flushing full store: %w", err)
 		}
+		modState.snapshotEnd = rng.ExclusiveEndBlock
 	}
 
 	s.logger.Info("squashing time metrics", meter.logFields()...)

--- a/orchestrator/stage/squashrun_test.go
+++ b/orchestrator/stage/squashrun_test.go
@@ -101,13 +101,19 @@ func TestMergeRunCompleted(t *testing.T) {
 	assert.Equal(t, unit(2, 0), s.stages[0].nextUnit(), "the next run starts at the first unmerged unit")
 }
 
+// oneUnitSteps makes each unit of run a step of its own, the way planSquashSteps does
+// when no partial is empty.
+func oneUnitSteps(run []Unit) [][]Unit {
+	return planSquashSteps(run, nil)
+}
+
 func TestSquashRun(t *testing.T) {
 	run := []Unit{unit(1, 0), unit(2, 0), unit(3, 0)}
 
 	t.Run("squashes every unit in order", func(t *testing.T) {
 		var squashed []Unit
-		merged, unmerged, err := squashRun(run, time.Hour, func(u Unit) error {
-			squashed = append(squashed, u)
+		merged, unmerged, err := squashRun(oneUnitSteps(run), time.Hour, func(step []Unit) error {
+			squashed = append(squashed, step...)
 			return nil
 		})
 
@@ -118,7 +124,7 @@ func TestSquashRun(t *testing.T) {
 	})
 
 	t.Run("squashes the first unit even with no budget left", func(t *testing.T) {
-		merged, unmerged, err := squashRun(run, 0, func(Unit) error { return nil })
+		merged, unmerged, err := squashRun(oneUnitSteps(run), 0, func([]Unit) error { return nil })
 
 		require.NoError(t, err)
 		assert.Equal(t, run[:1], merged)
@@ -127,8 +133,8 @@ func TestSquashRun(t *testing.T) {
 
 	t.Run("stops at the first error", func(t *testing.T) {
 		boom := errors.New("boom")
-		merged, _, err := squashRun(run, time.Hour, func(u Unit) error {
-			if u == unit(2, 0) {
+		merged, _, err := squashRun(oneUnitSteps(run), time.Hour, func(step []Unit) error {
+			if step[0] == unit(2, 0) {
 				return boom
 			}
 			return nil
@@ -137,6 +143,38 @@ func TestSquashRun(t *testing.T) {
 		assert.ErrorIs(t, err, boom)
 		assert.Equal(t, run[:1], merged)
 	})
+
+	t.Run("budget is only checked between steps", func(t *testing.T) {
+		steps := [][]Unit{{unit(1, 0), unit(2, 0)}, {unit(3, 0)}}
+		merged, unmerged, err := squashRun(steps, 0, func([]Unit) error { return nil })
+
+		require.NoError(t, err)
+		assert.Equal(t, run[:2], merged, "a step is never split")
+		assert.Equal(t, run[2:], unmerged)
+	})
+}
+
+func TestPlanSquashSteps(t *testing.T) {
+	run := []Unit{unit(1, 0), unit(2, 0), unit(3, 0), unit(4, 0), unit(5, 0), unit(6, 0)}
+
+	tests := []struct {
+		name  string
+		empty map[int]bool
+		want  [][]Unit
+	}{
+		{"no empty unit", nil, [][]Unit{{unit(1, 0)}, {unit(2, 0)}, {unit(3, 0)}, {unit(4, 0)}, {unit(5, 0)}, {unit(6, 0)}}},
+		{"all empty", map[int]bool{1: true, 2: true, 3: true, 4: true, 5: true, 6: true}, [][]Unit{run}},
+		{
+			"empty units grouped, others alone",
+			map[int]bool{1: true, 2: true, 4: true, 6: true},
+			[][]Unit{{unit(1, 0), unit(2, 0)}, {unit(3, 0)}, {unit(4, 0)}, {unit(5, 0)}, {unit(6, 0)}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, planSquashSteps(run, tt.empty))
+		})
+	}
 }
 
 func TestCloseWaitsForSquashRun(t *testing.T) {
@@ -199,11 +237,11 @@ func TestSquashRunStopsOnceContextCancelled(t *testing.T) {
 	run := s.claimMergeRun(s.stages[0], unit(1, 0), 10)
 
 	var squashed []Unit
-	merged, _, err := squashRun(run, time.Hour, func(u Unit) error {
+	merged, _, err := squashRun(oneUnitSteps(run), time.Hour, func(step []Unit) error {
 		if err := s.ctx.Err(); err != nil {
 			return err
 		}
-		squashed = append(squashed, u)
+		squashed = append(squashed, step...)
 		s.cancel()
 		return nil
 	})

--- a/orchestrator/stage/squashrun_test.go
+++ b/orchestrator/stage/squashrun_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/streamingfast/substreams/orchestrator/loop"
 	"github.com/streamingfast/substreams/orchestrator/plan"
 	"github.com/streamingfast/substreams/pipeline/exec"
 )
@@ -136,4 +137,78 @@ func TestSquashRun(t *testing.T) {
 		assert.ErrorIs(t, err, boom)
 		assert.Equal(t, run[:1], merged)
 	})
+}
+
+func TestCloseWaitsForSquashRun(t *testing.T) {
+	s := newMergeTestStages(t)
+
+	squashing := make(chan struct{})
+	release := make(chan struct{})
+	squashDone := make(chan loop.Msg, 1)
+	go func() {
+		squashDone <- s.guardSquash(func() loop.Msg {
+			close(squashing)
+			<-release
+			return MsgMergeFinished{}
+		})
+	}()
+	<-squashing
+
+	closeDone := make(chan struct{})
+	go func() {
+		s.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned while a squash run was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Error(t, s.ctx.Err(), "Close cancels the stages context before waiting")
+
+	close(release)
+	assert.IsType(t, MsgMergeFinished{}, <-squashDone)
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not return once the squash run finished")
+	}
+}
+
+func TestSquashSkippedAfterClose(t *testing.T) {
+	s := newMergeTestStages(t)
+	s.Close()
+
+	ran := false
+	msg := s.guardSquash(func() loop.Msg {
+		ran = true
+		return MsgMergeFinished{}
+	})
+
+	assert.False(t, ran)
+	assert.IsType(t, MsgMergeFailed{}, msg)
+}
+
+func TestSquashRunStopsOnceContextCancelled(t *testing.T) {
+	s := newMergeTestStages(t)
+	for seg := 1; seg <= 3; seg++ {
+		s.forceTransition(seg, 0, UnitPartialPresent)
+	}
+	s.MarkSegmentMerging(unit(1, 0))
+	run := s.claimMergeRun(s.stages[0], unit(1, 0), 10)
+
+	var squashed []Unit
+	merged, _, err := squashRun(run, time.Hour, func(u Unit) error {
+		if err := s.ctx.Err(); err != nil {
+			return err
+		}
+		squashed = append(squashed, u)
+		s.cancel()
+		return nil
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, run[:1], squashed, "the unit in progress finishes, the next one is not started")
+	assert.Equal(t, run[:1], merged)
 }

--- a/orchestrator/stage/squashrun_test.go
+++ b/orchestrator/stage/squashrun_test.go
@@ -1,0 +1,139 @@
+package stage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/streamingfast/substreams/orchestrator/plan"
+	"github.com/streamingfast/substreams/pipeline/exec"
+)
+
+// newMergeTestStages returns stages with store segments 0 to 4 on stages 0 and 1, and
+// segment 0 of stage 0 already merged.
+func newMergeTestStages(t *testing.T) *Stages {
+	t.Helper()
+	reqPlan, err := plan.BuildTier1RequestPlan(true, 10, 5, 5, 5, 50, 50, true)
+	require.NoError(t, err)
+	s := NewStages(context.Background(), exec.TestGraphStagedModules(5, 5, 5, 5, 5), reqPlan, nil, nil)
+	s.allocSegments(4)
+
+	s.forceTransition(0, 0, UnitMerging)
+	s.MergeCompleted(unit(0, 0))
+	return s
+}
+
+func TestClaimMergeRun(t *testing.T) {
+	t.Run("stops at the first segment without a partial", func(t *testing.T) {
+		s := newMergeTestStages(t)
+		s.forceTransition(1, 0, UnitPartialPresent)
+		s.forceTransition(2, 0, UnitPartialPresent)
+		s.forceTransition(4, 0, UnitPartialPresent)
+
+		s.MarkSegmentMerging(unit(1, 0))
+		run := s.claimMergeRun(s.stages[0], unit(1, 0), 10)
+
+		assert.Equal(t, []Unit{unit(1, 0), unit(2, 0)}, run)
+		assert.Equal(t, UnitMerging, s.getState(unit(2, 0)))
+		assert.Equal(t, UnitPending, s.getState(unit(3, 0)))
+		assert.Equal(t, UnitPartialPresent, s.getState(unit(4, 0)))
+	})
+
+	t.Run("stops at the limit", func(t *testing.T) {
+		s := newMergeTestStages(t)
+		for seg := 1; seg <= 4; seg++ {
+			s.forceTransition(seg, 0, UnitPartialPresent)
+		}
+
+		s.MarkSegmentMerging(unit(1, 0))
+		run := s.claimMergeRun(s.stages[0], unit(1, 0), 2)
+
+		assert.Equal(t, []Unit{unit(1, 0), unit(2, 0)}, run)
+		assert.Equal(t, UnitPartialPresent, s.getState(unit(3, 0)))
+	})
+
+	t.Run("stops at the last segment of the stage", func(t *testing.T) {
+		s := newMergeTestStages(t)
+		for seg := 1; seg <= 4; seg++ {
+			s.forceTransition(seg, 0, UnitPartialPresent)
+		}
+
+		s.MarkSegmentMerging(unit(1, 0))
+		run := s.claimMergeRun(s.stages[0], unit(1, 0), 100)
+
+		assert.Equal(t, []Unit{unit(1, 0), unit(2, 0), unit(3, 0), unit(4, 0)}, run)
+	})
+}
+
+func TestCmdTryMergeClaimsRun(t *testing.T) {
+	s := newMergeTestStages(t)
+	s.forceTransition(1, 0, UnitPartialPresent)
+	s.forceTransition(2, 0, UnitPartialPresent)
+
+	require.NotNil(t, s.CmdTryMerge(0))
+	assert.Equal(t, UnitMerging, s.getState(unit(1, 0)))
+	assert.Equal(t, UnitMerging, s.getState(unit(2, 0)))
+
+	// the run is in flight: nothing more to merge on that stage until it reports back
+	msg := s.CmdTryMerge(0)()
+	assert.IsType(t, MsgMergeNotReady{}, msg)
+}
+
+func TestMergeRunCompleted(t *testing.T) {
+	s := newMergeTestStages(t)
+	for seg := 1; seg <= 3; seg++ {
+		s.forceTransition(seg, 0, UnitPartialPresent)
+	}
+	s.MarkSegmentMerging(unit(1, 0))
+	run := s.claimMergeRun(s.stages[0], unit(1, 0), 10)
+	require.Len(t, run, 3)
+
+	s.MergeRunCompleted(0, run[:1], run[1:])
+
+	assert.Equal(t, UnitCompleted, s.getState(unit(1, 0)))
+	assert.Equal(t, UnitPartialPresent, s.getState(unit(2, 0)))
+	assert.Equal(t, UnitPartialPresent, s.getState(unit(3, 0)))
+	assert.Equal(t, unit(2, 0), s.stages[0].nextUnit(), "the next run starts at the first unmerged unit")
+}
+
+func TestSquashRun(t *testing.T) {
+	run := []Unit{unit(1, 0), unit(2, 0), unit(3, 0)}
+
+	t.Run("squashes every unit in order", func(t *testing.T) {
+		var squashed []Unit
+		merged, unmerged, err := squashRun(run, time.Hour, func(u Unit) error {
+			squashed = append(squashed, u)
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, run, squashed)
+		assert.Equal(t, run, merged)
+		assert.Empty(t, unmerged)
+	})
+
+	t.Run("squashes the first unit even with no budget left", func(t *testing.T) {
+		merged, unmerged, err := squashRun(run, 0, func(Unit) error { return nil })
+
+		require.NoError(t, err)
+		assert.Equal(t, run[:1], merged)
+		assert.Equal(t, run[1:], unmerged)
+	})
+
+	t.Run("stops at the first error", func(t *testing.T) {
+		boom := errors.New("boom")
+		merged, _, err := squashRun(run, time.Hour, func(u Unit) error {
+			if u == unit(2, 0) {
+				return boom
+			}
+			return nil
+		})
+
+		assert.ErrorIs(t, err, boom)
+		assert.Equal(t, run[:1], merged)
+	})
+}

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -38,7 +39,14 @@ import (
 
 type Stages struct {
 	ctx    context.Context
+	cancel context.CancelFunc
 	logger *zap.Logger
+
+	// A squash run holds squashMu shared for its whole duration and Close takes it
+	// exclusively, so a store is never closed under a merge or a save. closed tells a
+	// run that gets the lock after Close to do nothing.
+	squashMu sync.RWMutex
+	closed   bool
 
 	globalSegmenter   *block.Segmenter // This segmenter covers both the stores and the mapper
 	storeSegmenter    *block.Segmenter // This segmenter covers only jobs needed to build up stores according to the RequestPlan.
@@ -96,9 +104,11 @@ func NewStages(
 ) (out *Stages) {
 
 	logger := reqctx.Logger(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	out = &Stages{
 		ctx:                 ctx,
-		logger:              reqctx.Logger(ctx),
+		cancel:              cancel,
+		logger:              logger,
 		globalSegmenter:     reqPlan.BackprocessSegmenter(),
 		outputModuleIsIndex: execGraph.OutputModule().GetKindBlockIndex() != nil,
 		execoutConfigs:      execoutConfigs,
@@ -171,7 +181,15 @@ func NewStages(
 	return out
 }
 
+// Close releases the cached stores. It first cancels the stages context, so the
+// in-flight squash run stops at its next unit, then waits for that run to finish:
+// closing a store under a merge would panic, and under a save would write an empty
+// full store to storage.
 func (s *Stages) Close() {
+	s.cancel()
+	s.squashMu.Lock()
+	defer s.squashMu.Unlock()
+	s.closed = true
 	for _, stage := range s.stages {
 		for _, modState := range stage.storeModuleStates {
 			modState.Close()
@@ -477,14 +495,31 @@ func (s *Stages) CmdTryMerge(stageIdx int) loop.Cmd {
 	run := s.claimMergeRun(stage, mergeUnit, maxSquashRunSegments)
 
 	return func() loop.Msg {
-		merged, unmerged, err := squashRun(run, squashRunTimeBudget, func(u Unit) error {
-			return s.multiSquash(stage, u)
+		return s.guardSquash(func() loop.Msg {
+			merged, unmerged, err := squashRun(run, squashRunTimeBudget, func(u Unit) error {
+				if err := s.ctx.Err(); err != nil {
+					return err
+				}
+				return s.multiSquash(stage, u)
+			})
+			if err != nil {
+				return MsgMergeFailed{Unit: run[len(merged)], Error: err}
+			}
+			return MsgMergeFinished{Stage: stageIdx, Merged: merged, Unmerged: unmerged}
 		})
-		if err != nil {
-			return MsgMergeFailed{Unit: run[len(merged)], Error: err}
-		}
-		return MsgMergeFinished{Stage: stageIdx, Merged: merged, Unmerged: unmerged}
 	}
+}
+
+// guardSquash runs squash while holding squashMu shared, which keeps Close from
+// releasing the stores underneath it. Once Close has run, the stores are gone and
+// the scheduler loop that would receive the message is too, so squash is skipped.
+func (s *Stages) guardSquash(squash func() loop.Msg) loop.Msg {
+	s.squashMu.RLock()
+	defer s.squashMu.RUnlock()
+	if s.closed {
+		return MsgMergeFailed{Error: context.Canceled}
+	}
+	return squash()
 }
 
 func (s *Stages) MergeCompleted(mergeUnit Unit) {

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -496,11 +496,15 @@ func (s *Stages) CmdTryMerge(stageIdx int) loop.Cmd {
 
 	return func() loop.Msg {
 		return s.guardSquash(func() loop.Msg {
-			merged, unmerged, err := squashRun(run, squashRunTimeBudget, func(u Unit) error {
+			empty := s.findEmptyUnits(stage, run)
+			merged, unmerged, err := squashRun(planSquashSteps(run, empty), squashRunTimeBudget, func(step []Unit) error {
 				if err := s.ctx.Err(); err != nil {
 					return err
 				}
-				return s.multiSquash(stage, u)
+				if empty[step[0].Segment] {
+					return s.squashEmptyUnits(stage, step)
+				}
+				return s.multiSquash(stage, step[0])
 			})
 			if err != nil {
 				return MsgMergeFailed{Unit: run[len(merged)], Error: err}

--- a/orchestrator/stage/stages.go
+++ b/orchestrator/stage/stages.go
@@ -474,18 +474,35 @@ func (s *Stages) CmdTryMerge(stageIdx int) loop.Cmd {
 	}
 
 	s.MarkSegmentMerging(mergeUnit)
+	run := s.claimMergeRun(stage, mergeUnit, maxSquashRunSegments)
 
 	return func() loop.Msg {
-		if err := s.multiSquash(stage, mergeUnit); err != nil {
-			return MsgMergeFailed{Unit: mergeUnit, Error: err}
+		merged, unmerged, err := squashRun(run, squashRunTimeBudget, func(u Unit) error {
+			return s.multiSquash(stage, u)
+		})
+		if err != nil {
+			return MsgMergeFailed{Unit: run[len(merged)], Error: err}
 		}
-		return MsgMergeFinished{Unit: mergeUnit}
+		return MsgMergeFinished{Stage: stageIdx, Merged: merged, Unmerged: unmerged}
 	}
 }
 
 func (s *Stages) MergeCompleted(mergeUnit Unit) {
 	s.markSegmentCompleted(mergeUnit)
 	s.MoveSegmentCompletedForward(mergeUnit.Stage)
+}
+
+// MergeRunCompleted records the outcome of a squash run on a stage: the merged units are
+// complete, and the unmerged ones go back to having only their partial, for the next run
+// to pick up.
+func (s *Stages) MergeRunCompleted(stageIdx int, merged, unmerged []Unit) {
+	for _, u := range merged {
+		s.markSegmentCompleted(u)
+	}
+	for _, u := range unmerged {
+		s.transition(u, UnitPartialPresent, UnitMerging)
+	}
+	s.MoveSegmentCompletedForward(stageIdx)
 }
 
 func (s *Stages) MoveSegmentCompletedForward(stageIdx int) {

--- a/pipeline/exec/testing.go
+++ b/pipeline/exec/testing.go
@@ -12,6 +12,33 @@ func TestNew() *Graph {
 	}
 }
 
+// TestGraphStores returns a graph of two stages: the stores, all in one layer, then an
+// output mapper starting at the lowest initial block of the stores.
+func TestGraphStores(stores ...*pbsubstreams.Module) *Graph {
+	lowest := stores[0].InitialBlock
+	initBlocks := make(map[string]uint64, len(stores)+1)
+	for _, st := range stores {
+		lowest = min(lowest, st.InitialBlock)
+		initBlocks[st.Name] = st.InitialBlock
+	}
+	output := &pbsubstreams.Module{
+		Name:         "output",
+		Kind:         &pbsubstreams.Module_KindMap_{KindMap: &pbsubstreams.Module_KindMap{}},
+		InitialBlock: lowest,
+	}
+	initBlocks[output.Name] = lowest
+
+	return &Graph{
+		lowestInitBlock:   lowest,
+		modulesInitBlocks: initBlocks,
+		outputModule:      output,
+		stagedUsedModules: ExecutionStages{
+			{LayerModules(stores)},
+			{{output}},
+		},
+	}
+}
+
 func TestGraphStagedModules(initialBlock1, ib2, ib3, ib4, ib5 uint64) *Graph {
 	lowest := initialBlock1
 	lowest = min(lowest, ib2)

--- a/storage/store/emptypartial.go
+++ b/storage/store/emptypartial.go
@@ -1,0 +1,181 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/streamingfast/derr"
+	"github.com/streamingfast/dstore"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// maxEmptyPartialSize is the size above which a partial file is never read to check
+	// whether it is empty. An empty partial holds no bytes once decompressed, which zstd
+	// stores in 13 bytes.
+	maxEmptyPartialSize = 64
+
+	emptyPartialProbeConcurrency = 32
+	deletePartialConcurrency     = 16
+)
+
+// EmptyPartialKVs reports which of files, partial files of this store, are empty: no keys
+// and no deleted prefixes. It lists the sizes of the files, then reads the first
+// decompressed byte of the small ones only, so a large partial is never downloaded. A
+// file that is missing, too large or unreadable is reported as not empty.
+func (c *Config) EmptyPartialKVs(ctx context.Context, files []*FileInfo) (map[string]bool, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	sizes, err := c.partialFileSizes(ctx, files)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]bool, len(files))
+	var mu sync.Mutex
+	var eg errgroup.Group
+	eg.SetLimit(emptyPartialProbeConcurrency)
+	for _, file := range files {
+		size, found := sizes[file.Filename]
+		if !found || size > maxEmptyPartialSize {
+			continue
+		}
+		eg.Go(func() error {
+			empty, err := c.isEmptyFile(ctx, file.Filename)
+			if err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				zlog.Debug("cannot tell whether partial file is empty", zap.String("file_name", file.Filename), zap.Error(err))
+				return nil
+			}
+			if empty {
+				mu.Lock()
+				out[file.Filename] = true
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// isEmptyFile reads at most one decompressed byte of filename.
+func (c *Config) isEmptyFile(ctx context.Context, filename string) (bool, error) {
+	reader, err := loadStoreStream(ctx, c.objStore, filename)
+	if err != nil {
+		return false, err
+	}
+	defer reader.Close()
+
+	var b [1]byte
+	_, err = io.ReadFull(reader, b[:])
+	if errors.Is(err, io.EOF) {
+		return true, nil
+	}
+	return false, err
+}
+
+// partialFileSizes returns the size of each of files found in storage, keyed by file name.
+// It lists the store rather than asking for each file: state files are named after their
+// zero-padded end block, so the files of a range of segments sit next to each other in the
+// listing.
+func (c *Config) partialFileSizes(ctx context.Context, files []*FileInfo) (map[string]int64, error) {
+	wanted := make(map[string]bool, len(files))
+	var first, last string
+	for _, file := range files {
+		wanted[file.Filename] = true
+		endBlock, _, _ := strings.Cut(file.Filename, "-")
+		if first == "" || endBlock < first {
+			first = endBlock
+		}
+		if endBlock > last {
+			last = endBlock
+		}
+	}
+
+	sizes := make(map[string]int64, len(files))
+	for _, prefix := range listingPrefixes(first, last) {
+		err := c.objStore.WalkAttributes(ctx, prefix, func(entry dstore.ObjectEntry) error {
+			endBlock, _, _ := strings.Cut(entry.Name, "-")
+			if len(endBlock) == len(last) && endBlock > last {
+				return dstore.StopIteration
+			}
+			if name, ok := partialFileName(entry.Name); ok && wanted[name] {
+				sizes[name] = entry.Size
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing partial files with prefix %q: %w", prefix, err)
+		}
+	}
+	return sizes, nil
+}
+
+// listingPrefixes returns the name prefixes to list to see every file whose end block
+// prefix lies between first and last, both the same length: their common prefix followed
+// by each digit in between. It lists at most one decade of files outside the range.
+func listingPrefixes(first, last string) []string {
+	if len(first) != len(last) {
+		return []string{""}
+	}
+	n := 0
+	for n < len(first) && first[n] == last[n] {
+		n++
+	}
+	if n == len(first) {
+		return []string{first}
+	}
+	out := make([]string, 0, last[n]-first[n]+1)
+	for d := first[n]; d <= last[n]; d++ {
+		out = append(out, first[:n]+string(d))
+	}
+	return out
+}
+
+// partialFileName trims what a listing may add after a partial file name, like the store's
+// extension, and reports whether name is a partial file at all.
+func partialFileName(name string) (string, bool) {
+	i := strings.Index(name, ".partial")
+	if i < 0 {
+		return "", false
+	}
+	return name[:i+len(".partial")], true
+}
+
+// CopyFullKV copies the full KV file ending at fromEnd to the one ending at toEnd, as is.
+// Object stores that support it copy server-side, without the content leaving storage.
+func (c *Config) CopyFullKV(ctx context.Context, fromEnd, toEnd uint64) error {
+	from := NewCompleteFileInfo(c.name, c.moduleInitialBlock, fromEnd).Filename
+	to := NewCompleteFileInfo(c.name, c.moduleInitialBlock, toEnd).Filename
+	return derr.RetryContext(ctx, 3, func(ctx context.Context) error {
+		return c.objStore.CopyObject(ctx, from, to)
+	})
+}
+
+// DeletePartialKVs deletes files, partial files of this store, and logs the ones it could
+// not delete.
+func (c *Config) DeletePartialKVs(ctx context.Context, files []*FileInfo) {
+	var eg errgroup.Group
+	eg.SetLimit(deletePartialConcurrency)
+	for _, file := range files {
+		eg.Go(func() error {
+			if err := c.objStore.DeleteObject(ctx, file.Filename); err != nil {
+				zlog.Warn("deleting partial file", zap.String("file_name", file.Filename), zap.Error(err))
+			}
+			return nil
+		})
+	}
+	_ = eg.Wait()
+}

--- a/storage/store/emptypartial_test.go
+++ b/storage/store/emptypartial_test.go
@@ -1,0 +1,193 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/streamingfast/dstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	pbsubstreams "github.com/streamingfast/substreams/pb/sf/substreams/v1"
+)
+
+// openRecordingStore records the objects opened through it and through its sub stores.
+type openRecordingStore struct {
+	dstore.Store
+	opened *sync.Map
+}
+
+func (s *openRecordingStore) OpenObject(ctx context.Context, name string) (io.ReadCloser, error) {
+	s.opened.Store(name, true)
+	return s.Store.OpenObject(ctx, name)
+}
+
+func (s *openRecordingStore) SubStore(subFolder string) (dstore.Store, error) {
+	sub, err := s.Store.SubStore(subFolder)
+	if err != nil {
+		return nil, err
+	}
+	return &openRecordingStore{Store: sub, opened: s.opened}, nil
+}
+
+// newLocalTestConfig returns a store config over zstd-compressed files on local disk, the
+// way tier1 writes states, and the record of the objects opened through it.
+func newLocalTestConfig(t *testing.T) (*Config, *sync.Map) {
+	t.Helper()
+	base, err := dstore.NewStore("file://"+t.TempDir(), "zst", "zstd", true)
+	require.NoError(t, err)
+	opened := &sync.Map{}
+	cfg, err := NewConfig("test", 0, "hash", pbsubstreams.Module_KindStore_UPDATE_POLICY_SET, "string", &openRecordingStore{Store: base, opened: opened}, nil, 0, "", "")
+	require.NoError(t, err)
+	return cfg, opened
+}
+
+func writePartial(t *testing.T, cfg *Config, start, end uint64, fill func(p *PartialKV)) *FileInfo {
+	t.Helper()
+	p := cfg.NewPartialKV(start, zap.NewNop())
+	if fill != nil {
+		fill(p)
+		require.NoError(t, p.Flush())
+	}
+	file, writer, err := p.Save(end)
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(context.Background()))
+	return file
+}
+
+func TestEmptyPartialKVs(t *testing.T) {
+	ctx := context.Background()
+	cfg, opened := newLocalTestConfig(t)
+
+	empty := writePartial(t, cfg, 0, 10, nil)
+	withKey := writePartial(t, cfg, 10, 20, func(p *PartialKV) { p.Set(0, "k", "v") })
+	withDeletedPrefix := writePartial(t, cfg, 20, 30, func(p *PartialKV) { p.DeletePrefix(0, "k") })
+	large := writePartial(t, cfg, 30, 40, func(p *PartialKV) {
+		for i := range 20 {
+			sum := sha256.Sum256([]byte(fmt.Sprint(i)))
+			p.Set(0, hex.EncodeToString(sum[:]), hex.EncodeToString(sum[:]))
+		}
+	})
+	missing := NewPartialFileInfo("test", 40, 50)
+
+	emptySize, err := cfg.FileSize(ctx, empty)
+	require.NoError(t, err)
+	require.LessOrEqual(t, emptySize, int64(maxEmptyPartialSize), "an empty partial must be small enough to be checked")
+	largeSize, err := cfg.FileSize(ctx, large)
+	require.NoError(t, err)
+	require.Greater(t, largeSize, int64(maxEmptyPartialSize))
+
+	got, err := cfg.EmptyPartialKVs(ctx, []*FileInfo{empty, withKey, withDeletedPrefix, large, missing})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]bool{empty.Filename: true}, got)
+	_, largeOpened := opened.Load(large.Filename)
+	assert.False(t, largeOpened, "a partial above the size limit is never read")
+}
+
+func TestEmptyPartialKVsAcrossListingPrefixes(t *testing.T) {
+	ctx := context.Background()
+	cfg, _ := newLocalTestConfig(t)
+
+	// end blocks 990 to 1020 are listed under two prefixes, 0000000 and 0000001
+	var files []*FileInfo
+	for start := uint64(980); start < 1020; start += 10 {
+		files = append(files, writePartial(t, cfg, start, start+10, nil))
+	}
+	notAsked := writePartial(t, cfg, 1020, 1030, nil)
+
+	got, err := cfg.EmptyPartialKVs(ctx, files)
+	require.NoError(t, err)
+
+	want := make(map[string]bool)
+	for _, f := range files {
+		want[f.Filename] = true
+	}
+	assert.Equal(t, want, got)
+	assert.NotContains(t, got, notAsked.Filename)
+}
+
+func TestEmptyPartialKVsNoFiles(t *testing.T) {
+	cfg, _ := newLocalTestConfig(t)
+	got, err := cfg.EmptyPartialKVs(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestListingPrefixes(t *testing.T) {
+	tests := []struct {
+		first, last string
+		want        []string
+	}{
+		{"0000000010", "0000000010", []string{"0000000010"}},
+		{"0000000010", "0000000090", []string{"000000001", "000000002", "000000003", "000000004", "000000005", "000000006", "000000007", "000000008", "000000009"}},
+		{"0000000990", "0000001020", []string{"0000000", "0000001"}},
+		{"0003051000", "0004050000", []string{"0003", "0004"}},
+		{"999", "1000", []string{""}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.first+"-"+tt.last, func(t *testing.T) {
+			assert.Equal(t, tt.want, listingPrefixes(tt.first, tt.last))
+		})
+	}
+}
+
+func TestPartialFileName(t *testing.T) {
+	name, ok := partialFileName("0000000010-0000000000.partial")
+	assert.True(t, ok)
+	assert.Equal(t, "0000000010-0000000000.partial", name)
+
+	name, ok = partialFileName("0000000010-0000000000.partial.zst")
+	assert.True(t, ok)
+	assert.Equal(t, "0000000010-0000000000.partial", name, "a listing may keep the store extension")
+
+	_, ok = partialFileName("0000000010-0000000000.kv")
+	assert.False(t, ok)
+}
+
+func TestCopyFullKV(t *testing.T) {
+	ctx := context.Background()
+	cfg, _ := newLocalTestConfig(t)
+
+	full := cfg.NewFullKV(zap.NewNop())
+	full.Set(0, "a", "1")
+	full.Set(0, "b", "2")
+	require.NoError(t, full.Flush())
+	_, writer, err := full.Save(10)
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(ctx))
+	full.Close()
+
+	require.NoError(t, cfg.CopyFullKV(ctx, 10, 20))
+
+	copied := cfg.NewFullKV(zap.NewNop())
+	defer copied.Close()
+	require.NoError(t, copied.Load(ctx, NewCompleteFileInfo("test", 0, 20)))
+	got := map[string]string{}
+	require.NoError(t, copied.Iter(func(key string, value []byte) error {
+		got[key] = string(value)
+		return nil
+	}))
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+}
+
+func TestDeletePartialKVs(t *testing.T) {
+	ctx := context.Background()
+	cfg, _ := newLocalTestConfig(t)
+	first := writePartial(t, cfg, 0, 10, nil)
+	second := writePartial(t, cfg, 10, 20, nil)
+
+	cfg.DeletePartialKVs(ctx, []*FileInfo{first, second, NewPartialFileInfo("test", 20, 30)})
+
+	for _, f := range []*FileInfo{first, second} {
+		exists, err := cfg.ExistsPartialKV(ctx, f.Range.StartBlock, f.Range.ExclusiveEndBlock)
+		require.NoError(t, err)
+		assert.False(t, exists, f.Filename)
+	}
+}


### PR DESCRIPTION
Squashing on `substreams-tier1` merged one segment per scheduler round trip. On a busy backprocessing request that round trip took 3–5 s, so squashing ran at ~15 segments/min and fell tens of thousands of segments behind the tier2 jobs.

- **Squash in runs**: when a segment is ready to merge, every following segment whose partial is already there is merged by the same command (up to 1000 segments or 30 s of work). Measured on a production request: ~15 → ~310 segments/min.
- **Close safety**: the cached stores are no longer closed while a squash run is still using them.
- **Copy over empty partials**: an empty partial leaves the store unchanged, so its full store is a copy of the previous one. A run lists its partials' sizes in one go (`dstore.WalkAttributes`, hence the dstore bump), reads at most one decompressed byte of the small ones (large partials are never downloaded), then copies the last written full store to each consecutive empty segment, 32 at a time, server-side where the object store supports it. A module's first segment and segments shorter than the store interval still go through the regular squash, and only partials covered by a full store are deleted. If a copy fails, its segments go through the regular squash too: a store's state only moves forward once all its copies succeeded.

Tests run squash scenarios over real zstd files and compare the copy path against the regular merge byte-for-byte, checking copy counts, leftover partials and store contents. They cover stages with several stores (including one starting within a run), consecutive runs, and injected copy failures.

`TestTier2Call` in `test/` reports a data race under `-race` in `manifest.ApplyPackageTransformations`; it fails the same way on the branch before these changes.