### PR TITLE
Have tier1 reconnect to the relayer from its LIB

### DIFF
--- a/app/tier1.go
+++ b/app/tier1.go
@@ -39,6 +39,20 @@ import (
 // any linkable block and only armed once ready; same value the relayer uses.
 const maxConsecutiveUnlinkableBlocks = 5
 
+// burstFromLIB is the burst the hub's live source asks the relayer for: every block from
+// the hub's LIB onward, forks included, so the gap left by a disconnect is filled from the
+// relayer's memory instead of from the one-block store. When the LIB is older than what
+// the relayer holds, the relayer starts at its lowest block and the hub fills the rest from
+// the one-block store. A hub without a head yet asks for the last 2 blocks.
+func burstFromLIB(h *hub.ForkableHub) int64 {
+	_, _, _, libNum, err := h.HeadInfo()
+	// a burst of -1 means "from the relayer's LIB", -N (N > 1) means "from block N"
+	if err != nil || libNum < 2 {
+		return 2
+	}
+	return -int64(libNum)
+}
+
 type Tier1Modules struct {
 	// Required dependencies
 	Authenticator         dauth.Authenticator
@@ -245,6 +259,7 @@ func (a *Tier1App) Run() error {
 				}),
 				blockstream.WithRequester("substreams-tier1"),
 				blockstream.WithPartialBlocks(),
+				blockstream.WithBurstFunc(func() int64 { return burstFromLIB(forkableHub) }),
 			)
 		})
 

--- a/app/tier1_burst_test.go
+++ b/app/tier1_burst_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/streamingfast/bstream"
+	"github.com/streamingfast/bstream/hub"
+	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
+	"github.com/streamingfast/dstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBurstFromLIB(t *testing.T) {
+	t.Run("hub without a head", func(t *testing.T) {
+		assert.Equal(t, int64(2), burstFromLIB(nil))
+	})
+
+	t.Run("ready hub", func(t *testing.T) {
+		store := dstore.NewMockStore(nil)
+		for _, blk := range []*pbbstream.Block{
+			bstream.TestBlockWithLIBNum("00000003", "00000002", 2),
+			bstream.TestBlockWithLIBNum("00000004", "00000003", 2),
+			bstream.TestBlockWithLIBNum("00000005", "00000004", 2),
+			bstream.TestBlockWithLIBNum("00000008", "00000005", 3),
+			bstream.TestBlockWithLIBNum("00000009", "00000008", 3),
+		} {
+			buffer := bytes.NewBuffer(nil)
+			writer, err := bstream.NewDBinBlockWriter(buffer)
+			require.NoError(t, err)
+			require.NoError(t, writer.Write(blk))
+			store.SetFile(bstream.BlockFileName(blk), buffer.Bytes())
+		}
+
+		forkableHub := hub.NewForkableHub(bstream.NewTestSourceFactory().NewSource, 0, store)
+		go forkableHub.Run()
+		defer forkableHub.Shutdown(nil)
+
+		select {
+		case <-forkableHub.Ready:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "hub never became ready")
+		}
+
+		_, _, _, libNum, err := forkableHub.HeadInfo()
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), libNum)
+
+		assert.Equal(t, int64(-3), burstFromLIB(forkableHub))
+	})
+}

--- a/docs/release-notes/change-log.md
+++ b/docs/release-notes/change-log.md
@@ -34,6 +34,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Server
 
+- `substreams-tier1` now asks the relayer for every block from its own LIB when it connects
+  or reconnects, instead of the last 2 blocks. A gap left by a disconnect is filled from the
+  relayer's memory, and only the part older than what the relayer holds is read from the
+  one-block store. On fast chains a tier1 that fell a few seconds behind used to fill the
+  whole gap from the one-block store, long enough for the relayer to drop it again.
 - Fix partial-blocks (flashblocks) streams on a tier1 that is shutting down. The stream now
   ends with `Unavailable` like a full-block stream does, so the client reconnects elsewhere.
   It used to stay open but silent, then sent an undo signal at each block boundary naming a

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jhump/protoreflect v1.14.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	github.com/streamingfast/bstream v0.0.2-0.20260817182204-a513e03b7ada
+	github.com/streamingfast/bstream v0.0.2-0.20260910212213-07a378ae0f74
 	github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b
 	github.com/streamingfast/dauth v0.0.0-20260304175046-02898e30442d
 	github.com/streamingfast/dbin v0.9.1-0.20231117225723-59790c798e2c

--- a/go.sum
+++ b/go.sum
@@ -653,6 +653,8 @@ github.com/stoewer/go-strcase v1.3.1 h1:iS0MdW+kVTxgMoE1LAZyMiYJFKlOzLooE4Mxjirt
 github.com/stoewer/go-strcase v1.3.1/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/streamingfast/bstream v0.0.2-0.20260817182204-a513e03b7ada h1:EzBAxetlI+6kEKKgZ7D75j0QlwIUP/2vI2KsQiDrkB8=
 github.com/streamingfast/bstream v0.0.2-0.20260817182204-a513e03b7ada/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
+github.com/streamingfast/bstream v0.0.2-0.20260910212213-07a378ae0f74 h1:0Dy392LW8ed46HJDbXjc+J8WI57w3MWGloaKlxzXYGg=
+github.com/streamingfast/bstream v0.0.2-0.20260910212213-07a378ae0f74/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b h1:ztYeX3/5rg2tV2EU7edcrcHzMz6wUbdJB+LqCrP5W8s=
 github.com/streamingfast/cli v0.0.4-0.20250815192146-d8a233ec3d0b/go.mod h1:o9R/tjNON01X2mgWL5qirl2MV6xQ4EZI5D504ST3K/M=
 github.com/streamingfast/dauth v0.0.0-20260304175046-02898e30442d h1:NYrpGcWWLNpIYbHwvNo/W8E+oXhsrn/0kUwun0Rwx8w=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1472,6 +1472,8 @@ github.com/streamingfast/bstream v0.0.2-0.20260219185151-b5ba3f4bc777/go.mod h1:
 github.com/streamingfast/bstream v0.0.2-0.20260219205021-a73f004bfdea h1:dshasnf6SEnOvhmbsMxw6SA+qm+eiuNp45IQX47Ivac=
 github.com/streamingfast/bstream v0.0.2-0.20260219205021-a73f004bfdea/go.mod h1:6IkpMw6g2z+E4gH2DJkm6vsQfZ8Y/WdYdYWjsLJIYr4=
 github.com/streamingfast/bstream v0.0.2-0.20260611155534-4edda1cff251/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
+github.com/streamingfast/bstream v0.0.2-0.20260910200824-037a10c6149b h1:adnWk6foHegfzOh0TJs0fRchNEmZNKSZXJr1Ymz3wuI=
+github.com/streamingfast/bstream v0.0.2-0.20260910200824-037a10c6149b/go.mod h1:Asuul2Rnxln0Vk6eY869AZ2UybIQcB7eYOQAIhfQHzE=
 github.com/streamingfast/derr v0.0.0-20210811180100-9138d738bcec/go.mod h1:ulVfui/yGXmPBbt9aAqCWdAjM7YxnZkYHzvQktLfw3M=
 github.com/streamingfast/dgrpc v0.0.0-20230616153353-6bbf5534a79a/go.mod h1:e0CV14wi/p11xLBcIZgPIyBxy7CcQTqX2498DuQQHTg=
 github.com/streamingfast/dgrpc v0.0.0-20250227145723-9bc2e4941b4e/go.mod h1:qdcskj9WmO+nDjgxyafc5oMCftTZolOk693p2ZFUdO8=
@@ -1484,6 +1486,7 @@ github.com/streamingfast/dgrpc v0.0.0-20260213162824-8daf6d0a5775/go.mod h1:S6lJ
 github.com/streamingfast/dgrpc v0.0.0-20260218164858-719a69f1b7b4 h1:C4WiIoGrI3QJzAe4Gcye5L0avOm0lB4yQtk28E0OvNc=
 github.com/streamingfast/dgrpc v0.0.0-20260218164858-719a69f1b7b4/go.mod h1:S6lJ9Dd6M3myzWbxspuhGggHtld9uYVN0xQ/7EGXmX8=
 github.com/streamingfast/dgrpc v0.0.0-20260224192836-e5cd6cffceff/go.mod h1:S6lJ9Dd6M3myzWbxspuhGggHtld9uYVN0xQ/7EGXmX8=
+github.com/streamingfast/dgrpc v0.0.0-20260420180129-8b81f2664993/go.mod h1:S6lJ9Dd6M3myzWbxspuhGggHtld9uYVN0xQ/7EGXmX8=
 github.com/streamingfast/dhammer v0.0.0-20230125192823-c34bbd561bd4/go.mod h1:ehPytv7E4rI65iLcrwTes4rNGGqPPiugnH+20nDQyp4=
 github.com/streamingfast/dmetrics v0.0.0-20210811180524-8494aeb34447/go.mod h1:VLdQY/FwczmC/flqWkcsBbqXO4BhU4zQDSK7GMrpcjY=
 github.com/streamingfast/dmetrics v0.0.0-20230516031116-28fcfeb4b9ed/go.mod h1:JbxEDbzWRG1dHdNIPrYfuPllEkktZMgm40AwVIBENcw=
@@ -1769,6 +1772,7 @@ golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtC
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
@@ -2380,6 +2384,7 @@ google.golang.org/grpc v1.79.1/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhH
 google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 h1:F29+wU6Ee6qgu9TddPgooOdaqsxTMunOoj8KA5yuS5A=


### PR DESCRIPTION
tier1 now asks the relayer for every block from its own LIB when it connects or reconnects, instead of the last 2 blocks. The gap left by a disconnect comes from the relayer's memory; only the part older than what the relayer holds is still read from the one-block store.

On fast chains, a tier1 that fell a few seconds behind used to fill the whole gap from the one-block store, which took long enough for the relayer to drop it again.

Uses `blockstream.WithBurstFunc` from streamingfast/bstream#67, so bstream is bumped to that merge.